### PR TITLE
Update `assert` schema and associated tests, fix typos

### DIFF
--- a/partiql-test-data/fail/parser/select/select-from-where.ion
+++ b/partiql-test-data/fail/parser/select/select-from-where.ion
@@ -1,7 +1,9 @@
 parse::{
     name: "SFW without WHERE expression",
     statement: "SELECT * FROM foo WHERE",
-    assert: {
-        result: ParserError
-    }
+    assert: [
+        {
+            result: ParserError
+        },
+    ]
 }

--- a/partiql-test-data/fail/parser/select/select-from-where.ion
+++ b/partiql-test-data/fail/parser/select/select-from-where.ion
@@ -1,9 +1,7 @@
 parse::{
     name: "SFW without WHERE expression",
     statement: "SELECT * FROM foo WHERE",
-    assert: [
-        {
-            result: ParserError
-        },
-    ]
+    assert: {
+        result: ParserError
+    },
 }

--- a/partiql-test-data/pass/parser/primitives/literal.ion
+++ b/partiql-test-data/pass/parser/primitives/literal.ion
@@ -2,92 +2,118 @@
     parse::{
         name: "int",
         statement: "5",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "null",
         statement: "null",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "missing",
         statement: "missing",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "list",
         statement: "[a, 5]",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "list with binary operation",
         statement: "[a, 5, (b + 6)]",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "list function",
         statement: "LIST(a, 5)",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "sexp function",
         statement: "SEXP(a, 5)",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "sexp function with binary operation",
         statement: "SEXP(a, 5, (b + 6))",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "struct",
         statement: "{'x':a, 'y':5 }",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "struct with binary operation",
         statement: "{'x':a, 'y':5, 'z':(b + 6)}",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "nested empty list",
         statement: "[[]]",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "nested empty bag",
         statement: "<<<<>>>>",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
     parse::{
         name: "nested empty struct",
         statement: "{'a':{}}",
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            },
+        ]
     },
 ]

--- a/partiql-test-data/pass/parser/select/select-from-where.ion
+++ b/partiql-test-data/pass/parser/select/select-from-where.ion
@@ -1,7 +1,9 @@
 parse::{
     name: "SELECT with single FROM",
     statement: "SELECT a FROM table1",
-    assert: {
-        result: Ok
-    }
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
 }

--- a/partiql-test-data/pass/parser/select/select-from-where.ion
+++ b/partiql-test-data/pass/parser/select/select-from-where.ion
@@ -1,9 +1,7 @@
 parse::{
     name: "SELECT with single FROM",
     statement: "SELECT a FROM table1",
-    assert: [
-        {
-            result: ParseOk
-        },
-    ]
+    assert: {
+        result: ParseOk
+    },
 }

--- a/partiql-tests-schema-proposal.md
+++ b/partiql-tests-schema-proposal.md
@@ -23,11 +23,12 @@ The following is an abstraction to describe current and future tests we will hav
     name: <string>,
     statement: <string>,
     <other fields relevant for corresponding test_category>
-    assert: <list<struct>>
+    assert: <struct | <list<struct>>>
 }
 ```
 
-The `assert` list provides flexibility for future tests to check for additional expected behaviors when running a test.
+The `assert` field can be a struct or a list of structs and provides flexibility for tests to check for additional 
+expected behavior(s).
 
 ---
 
@@ -40,27 +41,55 @@ Tests whether a given PartiQL statement successfully parses (no syntax error). F
 
 
 ```
-// parse 'pass' test
+// parse 'pass' test with one assertion
 parse::{
     name: <string>,
     statement: <string>,
+    assert: {
+       result: ParseOk
+    },
+}
+
+// parse 'fail' test with one assertion
+parse::{
+    name: <string>,
+    statement: <string>,
+    assert: {
+        result: ParseError
+    },
+}
+```
+
+The `assert` field could also be a list of structs if more test assertions are added in the future.
+
+```
+// parse 'pass' test with multiple assertions
+parse::{
+    ...
     assert: [
         {
-           result: ParseOk
+            result: ParseOk
         },
-        // in the future, could add an assertion checking the statement parses to the expected ast
+        {   // in the future, could add an assertion checking the statement parses to the expected ast
+            ast: ...
+        }
     ]
 }
 
-// parse 'fail' test
+// parse 'fail' test with multiple assertions
 parse::{
-    name: <string>,
-    statement: <string>,
+    ...
     assert: [
         {
             result: ParseError
         },
-        // in the future, can also add an assertion checking for `error_code` or other error details
+        {   // in the future, could check the error code
+            error_code: ...
+        },
+        {   // in the future, could check line and column of error
+            line_of_err: ...,
+            col_of_err: ...
+        }
     ]
 }
 ```
@@ -101,11 +130,9 @@ eval::{
     statement: <string>,
     env: <symbol | struct>,
     options: <list<symbol>>,
-    assert: [
-        {
-            result: <ion>
-        },
-    ]
+    assert: {
+        result: <ion>
+    },
 }
 
 // eval 'fail' test
@@ -114,12 +141,9 @@ eval::{
     statement: <string>,
     env: <symbol | struct>,
     options: <list<symbol>>,
-    assert: [
-        {
-            result: EvaluationError
-        },
-        // in the future, can also add an assertion checking for `error_code` or other error details
-    ]
+    assert: {
+        result: EvaluationError
+    }
 }
 ```
 
@@ -136,11 +160,9 @@ be used by the test runner to prepend additional text to a test name. E.g. names
     parse::{
         name: <string>,
         statement: <string>,
-        assert: [
-            {
-                result: ParseOk
-            }
-        ]
+        assert: {
+            result: ParseOk
+        }
     },
     ...
 ]

--- a/partiql-tests-schema-proposal.md
+++ b/partiql-tests-schema-proposal.md
@@ -1,4 +1,4 @@
-##`partiql-tests` Schema Proposal
+## `partiql-tests` Schema Proposal
 
 TODO:
 - add ISL definitions for this schema proposal
@@ -23,11 +23,15 @@ The following is an abstraction to describe current and future tests we will hav
     name: <string>,
     statement: <string>,
     <other fields relevant for corresponding test_category>
-    assert: <struct>
+    assert: <list<struct>>
 }
 ```
 
+The `assert` list provides flexibility for future tests to check for additional expected behaviors when running a test.
+
 ---
+
+### Parser Tests
 
 Tests whether a given PartiQL statement successfully parses (no syntax error). For now, composed of these properties:
 
@@ -40,20 +44,24 @@ Tests whether a given PartiQL statement successfully parses (no syntax error). F
 parse::{
     name: <string>,
     statement: <string>,
-    assert: {
-        result: Ok
-        // in the future, could add an `ast` field to check the statement parses to the expected ast
-    }
+    assert: [
+        {
+           result: ParseOk
+        },
+        // in the future, could add an assertion checking the statement parses to the expected ast
+    ]
 }
 
 // parse 'fail' test
 parse::{
     name: <string>,
     statement: <string>,
-    assert: {
-        result: ParseError
-        // in the future, can also add a field for `error_code` or other error details
-    }
+    assert: [
+        {
+            result: ParseError
+        },
+        // in the future, can also add an assertion checking for `error_code` or other error details
+    ]
 }
 ```
 
@@ -61,7 +69,7 @@ parse::{
 
 ### Evaluation Tests
 
-Tests whether a given PartiQL statement evaluates to the expected result. For now composed of these properties:
+Tests whether a given PartiQL statement evaluates to the expected result. For now, composed of these properties:
 
 - test name (string)
 - PartiQL statement (string)
@@ -92,10 +100,12 @@ eval::{
     name: <string>,
     statement: <string>,
     env: <symbol | struct>,
-    options: <list<symbol>>
-    asssertion: {
-        result: <ion>
-    }
+    options: <list<symbol>>,
+    assert: [
+        {
+            result: <ion>
+        },
+    ]
 }
 
 // eval 'fail' test
@@ -104,16 +114,18 @@ eval::{
     statement: <string>,
     env: <symbol | struct>,
     options: <list<symbol>>,
-    assert: {
-        result: EvaluationError
-        // in the future, can also add a field for `error_code` or other error details
-    }
+    assert: [
+        {
+            result: EvaluationError
+        },
+        // in the future, can also add an assertion checking for `error_code` or other error details
+    ]
 }
 ```
 
 ---
 
-###Additional inclusions
+### Additional inclusions
 The concept of namespacing tests can help categorize groups of tests and can reduce duplication in test names. This can 
 be used by the test runner to prepend additional text to a test name. E.g. namespace of "literals" can be prepended to test names of "int" and "null" to get "literals - int" and 
 "literals - null"
@@ -124,9 +136,11 @@ be used by the test runner to prepend additional text to a test name. E.g. names
     parse::{
         name: <string>,
         statement: <string>,
-        assert: {
-            result: Ok
-        }
+        assert: [
+            {
+                result: ParseOk
+            }
+        ]
     },
     ...
 ]

--- a/partiql-tests-schema-proposal.md
+++ b/partiql-tests-schema-proposal.md
@@ -23,7 +23,7 @@ The following is an abstraction to describe current and future tests we will hav
     name: <string>,
     statement: <string>,
     <other fields relevant for corresponding test_category>
-    assert: <struct | <list<struct>>>
+    assert: <struct> | <list<struct>>
 }
 ```
 
@@ -128,7 +128,7 @@ env: { 'table1': [{a:1}, {a:2}, {a:3}] }
 eval::{
     name: <string>,
     statement: <string>,
-    env: <symbol | struct>,
+    env: <symbol> | <struct>,
     options: <list<symbol>>,
     assert: {
         result: <ion>
@@ -139,7 +139,7 @@ eval::{
 eval::{
     name: <string>,
     statement: <string>,
-    env: <symbol | struct>,
+    env: <symbol> | <struct>,
     options: <list<symbol>>,
     assert: {
         result: EvaluationError


### PR DESCRIPTION
Resolves #4.

Remodels the `assert` field of the test to be either a struct or list of structs. This provides additional functionality for future tests and tested properties. I included some example test files that have `assert` as a struct and some as a list of structs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
