### PR TITLE
Port DATE and TIME parse tests from Kotlin implementation

### DIFF
--- a/partiql-lang-kotlin-omitted-tests.md
+++ b/partiql-lang-kotlin-omitted-tests.md
@@ -30,6 +30,9 @@ https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf
 - semicolon semantic tests
   - https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf65c60b2a3b79/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt#L1860-L1886
   - https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf65c60b2a3b79/lang/test/org/partiql/lang/syntax/SqlParserTest.kt#L4025-L4064
+- TIME constructor with additional arguments
+  - AM/PM: https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf65c60b2a3b79/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt#L420-L437
+  - specifying timezone abbreviations (e.g. PST): https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf65c60b2a3b79/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt#L685-L693
 
 Unsure if should be included:
 - `expectedCastAsIntArity`, `expectedCastAsRealArity` -- type supplied with parameter; not sure is parse error
@@ -66,6 +69,4 @@ https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf
 https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf65c60b2a3b79/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt#L1627-L1639
 
 To be included:
-- DATE and TIME tests from [SqlParserDateTimeTests.kt](https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf65c60b2a3b79/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt)
-and [ParserErrorsTest.kt](https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf65c60b2a3b79/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt#L2848-L3099)
 - Operator precedence tests from [SqlParserPrecedenceTest.kt](https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf65c60b2a3b79/lang/test/org/partiql/lang/syntax/SqlParserPrecedenceTest.kt)

--- a/partiql-test-data/fail/parser/primitives/date-constructor.ion
+++ b/partiql-test-data/fail/parser/primitives/date-constructor.ion
@@ -1,0 +1,183 @@
+parse::{
+    name: "missing DATE string",
+    statement: "DATE",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid type INT for DATE string",
+    statement: "DATE 2012",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string without single quotes",
+    statement: "DATE 2012-08-28",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string using Ion literal",
+    statement: "DATE `2012-08-28`",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE STRING literal",
+    statement: "DATE 'date_string'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string format missing dashes",
+    statement: "DATE '20210310'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string format unexpected colons",
+    statement: "DATE '2021:03:10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string no starting single quotation",
+    statement: "DATE 2021-03-10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string no ending single quotation",
+    statement: "DATE '2021-03-10",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string format MMDDYYYY",
+    statement: "DATE '03-25-2021'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string format DDMMYYYY",
+    statement: "DATE '25-03-2021'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string minus before year",
+    statement: "DATE '-9999-03-10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string plus before year",
+    statement: "DATE '+9999-03-10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string extra minus between year and month",
+    statement: "DATE '2021--03-10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string plus between year and month",
+    statement: "DATE '2021-+03-10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string extra minus between month and day",
+    statement: "DATE '2021-03--10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string plus between month and day",
+    statement: "DATE '2021-03-+10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string month out of range",
+    statement: "DATE '2021-12345-10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string day out of range",
+    statement: "DATE '2021-03-12345'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string year missing padded zero",
+    statement: "DATE '123-03-10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string month missing padded zero",
+    statement: "DATE '2021-3-10'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string day missing padded zero",
+    statement: "DATE '2021-03-1'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid DATE string year beyond 9999",
+    statement: "DATE '12345-03-10'",
+    assert: {
+        result: ParseError
+    },
+}

--- a/partiql-test-data/fail/parser/primitives/time-constructor.ion
+++ b/partiql-test-data/fail/parser/primitives/time-constructor.ion
@@ -1,0 +1,263 @@
+parse::{
+    name: "TIME missing time string",
+    statement: "TIME",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME with INT",
+    statement: "TIME 123",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME with STRING literal",
+    statement: "TIME 'time_string'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME with DECIMAL",
+    statement: "TIME 123.23",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME with Ion literal",
+    statement: "TIME `2012-12-12`",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME with DATE string",
+    statement: "TIME '2012-12-12'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME with just the hour",
+    statement: "TIME '12'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME with just the hour and minute",
+    statement: "TIME '12:30'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME with nano missing a component",
+    statement: "TIME '59.12345'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME without padding of hour",
+    statement: "TIME '1:30:38'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME too many properties",
+    statement: "TIME '12.123:45.123:54.123'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME minus before hours",
+    statement: "TIME '-19:45:13'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME missing plus or minus before offset",
+    statement: "TIME '23:59:59.99999 05:30'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME offset with DECIMAL",
+    statement: "TIME '23:59:59+05:30.00'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME with unmatched left paren",
+    statement: "TIME ( '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME with no precision value",
+    statement: "TIME () '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME precision in square brackets",
+    statement: "TIME [4] '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME precision in curly braces",
+    statement: "TIME {4} '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME precision not in parens",
+    statement: "TIME 4 '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME precision as string",
+    statement: "TIME ('4') '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME precision as string literal",
+    statement: "TIME ('four') '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE missing time string",
+    statement: "TIME WITH TIME ZONE",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE without seconds specified",
+    statement: "TIME WITH TIME ZONE '12:20'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE with nano missing a component",
+    statement: "TIME WITH TIME ZONE '59.12345'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE no space",
+    statement: "TIME WITH TIMEZONE '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE using underscores",
+    statement: "TIME WITH_TIME_ZONE '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE all one word",
+    statement: "TIME WITHTIMEZONE '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE mispelled ZONE",
+    statement: "TIME WITH TIME PHONE '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE precision after WITH",
+    statement: "TIME WITH (4) TIME ZONE '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE precision after WITH TIME",
+    statement: "TIME WITH TIME (4) ZONE '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE precision after WITH TIME TIME ZONE",
+    statement: "TIME WITH TIME ZONE (4) '23:59:59.99999'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE with STRING literal",
+    statement: "TIME WITH TIME ZONE 'time_string'",
+    assert: {
+        result: ParseError
+    },
+}
+
+parse::{
+    name: "invalid TIME WITH TIME ZONE mistyped offset",
+    statement: "TIME WITH TIME ZONE '23:59:59-18-01'",
+    assert: {
+        result: ParseError
+    },
+}

--- a/partiql-test-data/fail/semantic/primitives/date-constructor.ion
+++ b/partiql-test-data/fail/semantic/primitives/date-constructor.ion
@@ -1,0 +1,127 @@
+semantic::{
+    name: "invalid DATE day out of range for January",
+    statement: "DATE '2021-01-32'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for February leap year",
+    statement: "DATE '2012-02-30'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for February non leap year",
+    statement: "DATE '2021-02-29'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for March",
+    statement: "DATE '2021-03-32'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for April",
+    statement: "DATE '2021-04-31'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for May",
+    statement: "DATE '2021-05-32'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for June",
+    statement: "DATE '2021-06-31'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for July",
+    statement: "DATE '2021-07-32'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for August",
+    statement: "DATE '2021-08-32'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for September",
+    statement: "DATE '2021-09-31'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for October",
+    statement: "DATE '2021-10-32'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for November",
+    statement: "DATE '2021-11-31'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day out of range for December",
+    statement: "DATE '2021-12-32'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE month above upper bound",
+    statement: "DATE '2021-13-01'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE month of zero",
+    statement: "DATE '2021-00-01'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid DATE day of zero",
+    statement: "DATE '2021-01-00'",
+    assert: {
+        result: SemanticError
+    },
+}

--- a/partiql-test-data/fail/semantic/primitives/time-constructor.ion
+++ b/partiql-test-data/fail/semantic/primitives/time-constructor.ion
@@ -1,0 +1,55 @@
+semantic::{
+    name: "invalid TIME second above upper bound",
+    statement: "TIME '12:59:61.0000'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid TIME hour field above upper bound",
+    statement: "TIME '24:00:00'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid TIME offset above upper bound",
+    statement: "TIME '23:59:59+24:00'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid TIME offset below lower bound",
+    statement: "TIME '23:59:59-24:00'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid TIME negative precision",
+    statement: "TIME (-1) '23:59:59.99999'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid TIME WITH TIME ZONE offset above upper bound",
+    statement: "TIME WITH TIME ZONE '23:59:59+18:00.00'",
+    assert: {
+        result: SemanticError
+    },
+}
+
+semantic::{
+    name: "invalid TIME WITH TIME ZONE offset below lower bound",
+    statement: "TIME WITH TIME ZONE '23:59:59-18:00.00'",
+    assert: {
+        result: SemanticError
+    },
+}

--- a/partiql-test-data/pass/parser/primitives/date-constructor.ion
+++ b/partiql-test-data/pass/parser/primitives/date-constructor.ion
@@ -1,0 +1,59 @@
+parse::{
+    name: "DATE constructor",
+    statement: "DATE '2012-01-01'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "DATE leap date",
+    statement: "DATE '2012-02-29'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "DATE first date",
+    statement: "DATE '0000-01-01'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "DATE last date",
+    statement: "DATE '9999-12-31'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "DATE no space between keyword and quote",
+    statement: "DATE'1992-11-30'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "DATE in SELECT",
+    statement: "SELECT DATE '2021-03-10' FROM foo",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}

--- a/partiql-test-data/pass/parser/primitives/time-constructor.ion
+++ b/partiql-test-data/pass/parser/primitives/time-constructor.ion
@@ -1,0 +1,239 @@
+parse::{
+    name: "TIME constructor",
+    statement: "TIME '02:30:59'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME no space between keyword and quote",
+    statement: "TIME'02:30:59",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME constructor with precision argument",
+    statement: "TIME (3) '12:59:31'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME constructor with precision argument no spaces between keyword and time string",
+    statement: "TIME(3)'12:59:31'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME nano precision",
+    statement: "TIME '23:59:59.9999'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME nano precision with precision argument",
+    statement: "TIME (7) '23:59:59.123456789'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME nano precision with zero precision argument",
+    statement: "TIME (0) '23:59:59.123456789'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME with negative offset",
+    statement: "TIME '02:30:59-05:30'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME with positive offset",
+    statement: "TIME '02:30:59+05:30'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME with positive zero offset",
+    statement: "TIME '02:30:59+00:00'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME with negative zero offset",
+    statement: "TIME '02:30:59-00:00'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME with offset and precision",
+    statement: "TIME (3) '12:59:31+10:30'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME with offset, precision, and nano seconds",
+    statement: "TIME (7) '23:59:59.123456789+01:00'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME WITH TIME ZONE",
+    statement: "TIME WITH TIME ZONE '02:30:59'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME WITH TIME ZONE no space between keyword and quote",
+    statement: "TIME WITH TIME ZONE'02:30:59'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME WITH TIME ZONE with precision",
+    statement: "TIME (3) WITH TIME ZONE '12:59:31'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME WITH TIME ZONE with precision and no spaces between precision and keyword",
+    statement: "TIME(3)WITH TIME ZONE '12:59:31'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME WITH TIME ZONE with nano seconds",
+    statement: "TIME WITH TIME ZONE '23:59:59.9999'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME WITH TIME ZONE with nano seconds and precision",
+    statement: "TIME (7) WITH TIME ZONE '23:59:59.123456789'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME WITH TIME ZONE with nano seconds, precision, and offset",
+    statement: "TIME (5) WITH TIME ZONE '23:59:59.9999-11:59'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME with nano precision greater than 10",
+    statement: "TIME '23:59:59.1234567890'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME with nano precision greater than 10 and offset",
+    statement: "TIME '23:59:59.1234567890+18:00'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME WITH TIME ZONE with nano precision greater than 10 and offset",
+    statement: "TIME WITH TIME ZONE '23:59:59.1234567890+18:00'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}
+
+parse::{
+    name: "TIME WITHOUT TIME ZONE",
+    statement: "TIME WITHOUT TIME ZONE '23:59:59.99999'",
+    assert: [
+        {
+            result: ParseOk
+        },
+    ]
+}


### PR DESCRIPTION
Finishes off the Kotlin parsing test issue https://github.com/partiql/partiql-tests/issues/5.

Ports tests from `DATE` and `TIME` constructors tests from [SqlParserDateTimeTests.kt](https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf65c60b2a3b79/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt) and [ParserErrorsTest.kt](https://github.com/partiql/partiql-lang-kotlin/blob/34625c68dbcbaf7b8ae60df7a4cf65c60b2a3b79/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt#L2848-L3099).

Verified these could be properly parsed by the Rust conformance test runner. As of https://github.com/partiql/partiql-lang-rust/commit/f57ee41e49c6d00027114bffe6f349dbe699dff3, the conformance test output is:

```
333 passed; 50 failed; 56 ignored; 0 measured; 0 filtered out;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
