### PR TITLE
Add evaluation and equivalence conformance test schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## PartiQL Test Data
 
-The `partiql-test-data` folder contains language-neutral test data used to check conformance to the [PartiQL 
+The `partiql-tests-data` folder contains language-neutral test data used to check conformance to the [PartiQL 
 specification](https://partiql.org/assets/PartiQL-Specification.pdf).
 
 Consumers of this repository must assume additional nested subfolders may be added, and should therefore recurse down 
@@ -25,4 +25,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This project is licensed under the Apache-2.0 License.
-

--- a/docs/partiql-tests-schema-proposal.md
+++ b/docs/partiql-tests-schema-proposal.md
@@ -1,9 +1,5 @@
 ## `partiql-tests` Schema Proposal
 
-TODO:
-- add ISL definitions for this schema proposal
-- move the doc to `partiql-docs`
-
 `partiql-tests`' data format should have the following goals in mind:
 1. ease of writing -- it should be easy to understand the test schema and create new tests.
 2. ease of integrating to test runner implementations -- it should be easy to parse the created test data.
@@ -13,6 +9,7 @@ As of this proposal, we want to test these categories:
 - syntax
 - static analysis and type-checking
 - end-to-end evaluation
+- equivalence
 
 ---
 
@@ -119,13 +116,43 @@ For now, composed of the same properties as the `syntax` `fail` tests. The only 
 
 Tests whether a given PartiQL statement evaluates to the expected result. For now, composed of these properties:
 
-- test name (string)
-- PartiQL statement (string)
-- [optional] input evaluation environment (symbol or struct) — defaults to empty environment
-- expected evaluation result (Ion) — only for success tests
-- [optional] evaluation options (list of symbols) other than the defaults -- could also be represented using a struct
-    - e.g. `TYPING_MODE_PERMISSIVE`
-- assert (struct or list of structs) with an evaluation assertion
+- test `name` - string
+- PartiQL `statement` - string
+- [optional] input evaluation environment, `env` - struct
+  - defaults to using environments specified in file (i.e. `envs`). If `envs` is unspecified, defaults to an empty
+  environment with no bindings
+- [optional] evaluation `options` other than the defaults - struct
+    - e.g. typing mode - strict vs permissive (permissive may be most useful)
+- `assert` - struct or list of structs
+  - `result` key maps to symbol
+    - `EvaluatorSuccess` if evluation succeeds for statement
+    - `EvaluatorFail` if evaluation fails for statement
+  - expected `output` of evaluation (only for `EvaluatorSuccess` `result`s)
+
+```
+// eval 'success' test
+{
+    name: <string>,
+    statement: <string>,
+    env: <struct>,        // optional
+    options: <struct>,    // optional
+    assert: {
+        result: EvaluationSuccess,
+        output: <ion>
+    },
+}
+
+// eval 'fail' test
+{
+    name: <string>,
+    statement: <string>,
+    env: <struct>,        // optional
+    options: <struct>,    // optional
+    assert: {
+        result: EvaluationFail
+    }
+}
+```
 
 For ease of writing evaluation tests, it’s necessary to provide a way to specify environments that can be referred to 
 outside a given test.
@@ -137,35 +164,83 @@ envs::{
   'table2': ...
 }
 
-// environment for test can be specified using one of `envs` in the file:
-env: table1
-// or specified explicitly with a struct
-env: { 'table1': [{a:1}, {a:2}, {a:3}] }
-```
-
-```
-// eval 'success' test
+// environment for test can be specified using one of the `envs` in the namespace/file
 {
-    name: <string>,
-    statement: <string>,
-    env: <symbol> | <struct>,
-    options: <list<symbol>>,
-    assert: {
-        result: <ion>
-    },
+   name: "test using environment symbol",
+   statement: "SELECT * FROM table1",
+   ...
 }
+// or specified explicitly using the inlined `env`
+{
+   name: "test using explicit environement",
+   statement: "SELECT * FROM table1",
+   env: { table1: [{a:1}, {a:2}, {a:3}] }
+   ...
+}
+```
 
-// eval 'fail' test
+#### Modeling PartiQL Types in Ion
+There are a few approaches we could take when modeling PartiQL data. PartiQL's type system encompasses Ion's types with
+a few additional types. These include
+- Annotations (using Ion)
+- S-expressions (using Ion)
+- PartiQL object notation
+
+Of the above options, we've decided to go with the annotation approach. Values of these additional types will be denoted
+using a `$<partiql_type>` annotation. This will be used for the output result and environments.
+
+```
+// bag -- list annotated with $bag
+$bag::[1, 2, 3]
+
+// missing -- null value annotated with $missing
+$missing::null
+
+// date -- string annotated with $date
+$date::'2022-02-22'
+
+// time -- string annotated with $time
+$time::'02:30:59'
+```
+
+---
+
+### Equivalence Tests
+The PartiQL specification mentions some PartiQL statements that could be rewritten using a different PartiQL syntax 
+(e.g. wildcard expressions). Rather than having to rewrite an evaluation test to assert on the same result, test writers
+can provide a list of PartiQL statements within an `EvaluationSuccess` assertion that evaluate to the same result.
+
+```
+// evaluation equivalence test
 {
     name: <string>,
     statement: <string>,
-    env: <symbol> | <struct>,
-    options: <list<symbol>>,
+    env: <struct>,        // optional
+    options: <struct>,    // optional
     assert: {
-        result: EvaluationFail
+        result: EvaluationSuccess,
+        output: <ion>,
+        equiv: <list<string>>   // list of equivalent PartiQL statements as strings
     }
 }
 ```
+
+As a simple example, the following would be how to write an evaluation equivalence test:
+```
+{
+    name: "equiv test sample",
+    statement: "10",
+    assert: {
+        result: EvaluationSuccess,
+        output: 10,
+        equiv: [
+            "5 * 2",
+            "20 / 2"
+        ]
+    }
+}
+```
+
 
 ---
 

--- a/docs/partiql-tests-schema-proposal.md
+++ b/docs/partiql-tests-schema-proposal.md
@@ -212,23 +212,23 @@ result or have the same plan. Users can specify an equivalence class as follows.
 
 ```
 equiv_class::{
-    id: <symbol>,               // identifier that can be referred to in equivalence assertions
+    id: <symbol>,               // identifier that can be referred to in tests (e.g. evaluation)
     statements: <list<string>>  // list of equivalent PartiQL statements as strings
 }
 ```
 
-Evaluation tests can refer to the equivalence classes specified in the file/namespace and make assertions that the
-statements evaluate to the same result.
+Evaluation tests can check that an equivalence class defined in the file/namespace have statements that evaluate to the
+same result by referencing the equivalence class' symbol identifier in the `statement` field.
 
 ```
 // evaluation equivalence test
 {
-    // same fields for evaluation success test
-    ...
+    name: <string>,
+    statement: <symbol>     // identifier to equivalence class
+    ...                     // same other evaluation test fields    
     assert: {
         result: EvaluationSuccess,
-        output: <ion>,
-        equiv_class: symbol     // identifier to equivalence class
+        output: <ion>
     }
 }
 ```
@@ -248,11 +248,10 @@ equiv_class::{
 // evaluation test with equivalence class assertion
 {
     name: "equivalence class test sample",
-    statement: "10",
+    statement: ten,
     assert: {
         result: EvaluationSuccess,
-        output: 10,
-        equiv_class: ten
+        output: 10
     }
 }
 ```

--- a/docs/partiql-tests-schema-proposal.md
+++ b/docs/partiql-tests-schema-proposal.md
@@ -125,7 +125,7 @@ Tests whether a given PartiQL statement evaluates to the expected result. For no
     - e.g. typing mode - strict vs permissive (permissive may be most useful)
 - `assert` - struct or list of structs
   - `result` key maps to symbol
-    - `EvaluatorSuccess` if evluation succeeds for statement
+    - `EvaluatorSuccess` if evaluation succeeds for statement
     - `EvaluatorFail` if evaluation fails for statement
   - expected `output` of evaluation (only for `EvaluatorSuccess` `result`s)
 
@@ -180,8 +180,8 @@ envs::{
 ```
 
 #### Modeling PartiQL Types in Ion
-There are a few approaches we could take when modeling PartiQL data. PartiQL's type system encompasses Ion's types with
-a few additional types. These include
+PartiQL's type system encompasses Ion's types with a few additional types (e.g. missing, bag, date, time). There are a 
+few approaches we could take to model PartiQL data:
 - Annotations (using Ion)
 - S-expressions (using Ion)
 - PartiQL object notation
@@ -205,42 +205,57 @@ $time::'02:30:59'
 
 ---
 
-### Equivalence Tests
+### Equivalence
 The PartiQL specification mentions some PartiQL statements that could be rewritten using a different PartiQL syntax 
-(e.g. wildcard expressions). Rather than having to rewrite an evaluation test to assert on the same result, test writers
-can provide a list of PartiQL statements within an `EvaluationSuccess` assertion that evaluate to the same result.
+(e.g. wildcard expressions). A common use case could be to assert that such PartiQL statements evaluate to the same 
+result or have the same plan. Users can specify an equivalence class as follows.
+
+```
+equiv_class::{
+    id: <symbol>,               // identifier that can be referred to in equivalence assertions
+    statements: <list<string>>  // list of equivalent PartiQL statements as strings
+}
+```
+
+Evaluation tests can refer to the equivalence classes specified in the file/namespace and make assertions that the
+statements evaluate to the same result.
 
 ```
 // evaluation equivalence test
 {
-    name: <string>,
-    statement: <string>,
-    env: <struct>,        // optional
-    options: <struct>,    // optional
+    // same fields for evaluation success test
+    ...
     assert: {
         result: EvaluationSuccess,
         output: <ion>,
-        equiv: <list<string>>   // list of equivalent PartiQL statements as strings
+        equiv_class: symbol     // identifier to equivalence class
     }
 }
 ```
 
 As a simple example, the following would be how to write an evaluation equivalence test:
 ```
+// equivalence class definition
+equiv_class::{
+    id: ten,
+    statements: [
+        "5 * 2",
+        "20 / 2",
+        "1 + 2 + 3 + 4",
+    ]
+}
+
+// evaluation test with equivalence class assertion
 {
-    name: "equiv test sample",
+    name: "equivalence class test sample",
     statement: "10",
     assert: {
         result: EvaluationSuccess,
         output: 10,
-        equiv: [
-            "5 * 2",
-            "20 / 2"
-        ]
+        equiv_class: ten
     }
 }
 ```
-
 
 ---
 

--- a/partiql-tests-data/fail/eval/query/select/select.ion
+++ b/partiql-tests-data/fail/eval/query/select/select.ion
@@ -1,0 +1,7 @@
+{
+    name: "select star from non existent binding",
+    statement: "SELECT * FROM non_existent_binding",
+    assert: {
+        result: EvaluationFail  // example fails in type-checking mode TBD on default evaluation mode (https://github.com/partiql/partiql-tests/issues/25)
+    }
+}

--- a/partiql-tests-data/partiql-tests-schema.isl
+++ b/partiql-tests-data/partiql-tests-schema.isl
@@ -38,7 +38,15 @@ type::{
     type: struct,
     fields: {
         name: { type: string, occurs: required },
-        statement: { type: string, occurs: required },
+        statement: {
+            type: {
+                one_of: [
+                    string,
+                    symbol      // to reference an equiv_class identifier
+                ]
+            },
+            occurs: required
+        },
         env: { type: struct, occurs: optional },
         options: { type: struct, occurs: optional },
         assert: {
@@ -99,8 +107,7 @@ type::{
     type: struct,
     fields: {
         result: { type: symbol, valid_values: [EvaluationSuccess], occurs: required },
-        output: { occurs: required },
-        equiv_class: { type: symbol, occurs: optional }
+        output: { occurs: required }
     },
     content: closed
 }

--- a/partiql-tests-data/partiql-tests-schema.isl
+++ b/partiql-tests-data/partiql-tests-schema.isl
@@ -4,7 +4,7 @@ schema_header::{
 type::{
     name: PartiQLTestDocument,
     type: document,
-    element: { one_of: [TestCase, Namespace, Environments] },
+    element: { one_of: [TestCase, Namespace, Environments, EquivalenceClass] },
     content: closed
 }
 
@@ -20,6 +20,17 @@ type::{
     type: struct,
     annotations: required::[envs],
     content: closed
+}
+
+type::{
+    name: EquivalenceClass,
+    type: struct,
+    annotations: required::[equiv_class],
+    content: closed,
+    fields: {
+        id: symbol,
+        statements: { type: list, element: string }
+    }
 }
 
 type::{
@@ -89,7 +100,7 @@ type::{
     fields: {
         result: { type: symbol, valid_values: [EvaluationSuccess], occurs: required },
         output: { occurs: required },
-        equiv: { type: list, element: string, occurs: optional }
+        equiv_class: { type: symbol, occurs: optional }
     },
     content: closed
 }

--- a/partiql-tests-data/partiql-tests-schema.isl
+++ b/partiql-tests-data/partiql-tests-schema.isl
@@ -4,13 +4,22 @@ schema_header::{
 type::{
     name: PartiQLTestDocument,
     type: document,
-    element: { one_of: [TestCase, Namespace] }
+    element: { one_of: [TestCase, Namespace, Environments] },
+    content: closed
 }
 
 type::{
     name: Namespace,
     type: list,
-    element: { one_of: [TestCase, Namespace] }
+    element: { one_of: [TestCase, Namespace] },
+    content: closed
+}
+
+type::{
+    name: Environments,
+    type: struct,
+    annotations: required::[envs],
+    content: closed
 }
 
 type::{
@@ -18,7 +27,9 @@ type::{
     type: struct,
     fields: {
         name: { type: string, occurs: required },
-        statement: { type: string, occurs: required }, // partiql-tests#17 may change this definition to a list
+        statement: { type: string, occurs: required },
+        env: { type: struct, occurs: optional },
+        options: { type: struct, occurs: optional },
         assert: {
             type: {
                 one_of: [
@@ -27,8 +38,9 @@ type::{
                 ]
             },
             occurs: required
-        }
-    }
+        },
+    },
+    content: closed
 }
 
 type::{
@@ -37,7 +49,9 @@ type::{
         one_of: [
             SyntaxSuccessAssertion,
             SyntaxFailAssertion,
-            StaticAnalysisFailAssertion
+            StaticAnalysisFailAssertion,
+            EvaluationSuccessAssertion,
+            EvaluationFailAssertion
         ]
     }
 }
@@ -47,7 +61,8 @@ type::{
     type: struct,
     fields: {
         result: { type: symbol, valid_values: [SyntaxSuccess], occurs: required }
-    }
+    },
+    content: closed
 }
 
 type::{
@@ -55,7 +70,8 @@ type::{
     type: struct,
     fields: {
         result: { type: symbol, valid_values: [SyntaxFail], occurs: required }
-    }
+    },
+    content: closed
 }
 
 type::{
@@ -63,7 +79,28 @@ type::{
     type: struct,
     fields: {
         result: { type: symbol, valid_values: [StaticAnalysisFail], occurs: required }
-    }
+    },
+    content: closed
+}
+
+type::{
+    name: EvaluationSuccessAssertion,
+    type: struct,
+    fields: {
+        result: { type: symbol, valid_values: [EvaluationSuccess], occurs: required },
+        output: { occurs: required },
+        equiv: { type: list, element: string, occurs: optional }
+    },
+    content: closed
+}
+
+type::{
+    name: EvaluationFailAssertion,
+    type: struct,
+    fields: {
+        result: { type: symbol, valid_values: [EvaluationFail], occurs: required }
+    },
+    content: closed
 }
 
 schema_footer::{

--- a/partiql-tests-data/success/eval-equiv/README.md
+++ b/partiql-tests-data/success/eval-equiv/README.md
@@ -1,0 +1,3 @@
+Tests in this directory should have statements that can be evaluated successfully and return the same result as the 
+expected result. Additionally, the tests in this directory assert the additional PartiQL statements evaluate to the
+same expected result.

--- a/partiql-tests-data/success/eval-equiv/path.ion
+++ b/partiql-tests-data/success/eval-equiv/path.ion
@@ -1,0 +1,31 @@
+envs::{
+    ints: [1, 2, 3],
+    simple_struct: {
+        'a': 1,
+        'b': 2
+    }
+}
+
+{
+    name: "equiv wildcard steps collection",
+    statement: "ints[*]",
+    assert: {
+        result: EvaluationSuccess,
+        output: $bag::[1, 2, 3],
+        equiv: [
+            "SELECT VALUE v FROM ints AS v"
+        ]
+    }
+}
+
+{
+    name: "equiv wildcard steps struct",
+    statement: "simple_struct.*",
+    assert: {
+        result: EvaluationSuccess,
+        output: $bag::[1, 2],
+        equiv: [
+            "SELECT VALUE v FROM UNPIVOT simple_struct AS v"
+        ]
+    }
+}

--- a/partiql-tests-data/success/eval-equiv/path.ion
+++ b/partiql-tests-data/success/eval-equiv/path.ion
@@ -24,20 +24,18 @@ equiv_class::{
 
 {
     name: "equiv wildcard steps collection",
-    statement: "ints[*]",
+    statement: wildcard_steps_collection,
     assert: {
         result: EvaluationSuccess,
-        output: $bag::[1, 2, 3],
-        equiv_class: wildcard_steps_collection
+        output: $bag::[1, 2, 3]
     }
 }
 
 {
     name: "equiv wildcard steps struct",
-    statement: "simple_struct.*",
+    statement: wildcard_steps_struct,
     assert: {
         result: EvaluationSuccess,
-        output: $bag::[1, 2],
-        equiv_class: wildcard_steps_struct
+        output: $bag::[1, 2]
     }
 }

--- a/partiql-tests-data/success/eval-equiv/path.ion
+++ b/partiql-tests-data/success/eval-equiv/path.ion
@@ -6,15 +6,29 @@ envs::{
     }
 }
 
+equiv_class::{
+    id: wildcard_steps_collection,
+    statements: [
+        "ints[*]",
+        "SELECT VALUE v FROM ints AS v"
+    ]
+}
+
+equiv_class::{
+    id: wildcard_steps_struct,
+    statements: [
+        "simple_struct.*",
+        "SELECT VALUE v FROM UNPIVOT simple_struct AS v"
+    ]
+}
+
 {
     name: "equiv wildcard steps collection",
     statement: "ints[*]",
     assert: {
         result: EvaluationSuccess,
         output: $bag::[1, 2, 3],
-        equiv: [
-            "SELECT VALUE v FROM ints AS v"
-        ]
+        equiv_class: wildcard_steps_collection
     }
 }
 
@@ -24,8 +38,6 @@ envs::{
     assert: {
         result: EvaluationSuccess,
         output: $bag::[1, 2],
-        equiv: [
-            "SELECT VALUE v FROM UNPIVOT simple_struct AS v"
-        ]
+        equiv_class: wildcard_steps_struct
     }
 }

--- a/partiql-tests-data/success/eval/query/select/select.ion
+++ b/partiql-tests-data/success/eval/query/select/select.ion
@@ -35,27 +35,17 @@ envs::{
     statement: "SELECT r.v FROM sensors AS s, s.readings AS r",
     env: {
         sensors: [
-            {readings: [{v: 1.3}, {v: 2}]},
-            {readings: [{v: 0.7}, {v: 0.8}, {v: 0.9}]}
+            {readings: [{v: 5.0}, {v: 78.2}]}
         ]
     },
     assert: {
         result: EvaluationSuccess,
         output: $bag::[
             {
-                v: 1.3
+                v: 5.0
             },
             {
-                v: 2
-            },
-            {
-                v: 0.7
-            },
-            {
-                v: 0.8
-            },
-            {
-                v: 0.9
+                v: 78.2
             }
         ]
     }

--- a/partiql-tests-data/success/eval/query/select/select.ion
+++ b/partiql-tests-data/success/eval/query/select/select.ion
@@ -1,0 +1,62 @@
+envs::{
+    sensors: [
+        {readings: [{v: 1.3}, {v: 2}]},
+        {readings: [{v: 0.7}, {v: 0.8}, {v: 0.9}]}
+    ]
+}
+
+{
+    name: "SELECT path",
+    statement: "SELECT r.v FROM sensors AS s, s.readings AS r",
+    assert: {
+        result: EvaluationSuccess,
+        output: $bag::[
+            {
+                v: 1.3
+            },
+            {
+                v: 2
+            },
+            {
+                v: 0.7
+            },
+            {
+                v: 0.8
+            },
+            {
+                v: 0.9
+            }
+        ]
+    }
+}
+
+{
+    name: "SELECT path with inline environment",
+    statement: "SELECT r.v FROM sensors AS s, s.readings AS r",
+    env: {
+        sensors: [
+            {readings: [{v: 1.3}, {v: 2}]},
+            {readings: [{v: 0.7}, {v: 0.8}, {v: 0.9}]}
+        ]
+    },
+    assert: {
+        result: EvaluationSuccess,
+        output: $bag::[
+            {
+                v: 1.3
+            },
+            {
+                v: 2
+            },
+            {
+                v: 0.7
+            },
+            {
+                v: 0.8
+            },
+            {
+                v: 0.9
+            }
+        ]
+    }
+}

--- a/partiql-tests-validator/src/test/kotlin/org/partiql/tests/validator/PartiQLTestDataValidator.kt
+++ b/partiql-tests-validator/src/test/kotlin/org/partiql/tests/validator/PartiQLTestDataValidator.kt
@@ -332,6 +332,23 @@ class PartiQLTestDataValidator {
     }
 
     @Test
+    fun testEquivalenceTestSchema() {
+        val testData =
+            """
+            equiv_class::{
+                id: some_identifier,
+                statements: [
+                    "some statement",
+                    "some equivalent statement 1",
+                    "some equivalent statement 2"
+                ]
+            }
+            """
+        val dataInIon = ion.loader.load(testData)
+        assertNoViolations(dataInIon)
+    }
+
+    @Test
     fun testEvaluationSuccessSchemaWithEquivalence() {
         val testData =
             """
@@ -341,11 +358,7 @@ class PartiQLTestDataValidator {
                 assert: {
                     result: EvaluationSuccess,
                     output: some_output,
-                    equiv: [
-                        "some equivalent statement 1",
-                        "some equivalent statement 2",
-                        "some equivalent statement 3"
-                    ]
+                    equiv_class: some_equiv_class
                 }
             }
             """
@@ -586,7 +599,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testNoOutputInEvaluationSuccessSchemaWithEquivalentStatement() {
+    fun testNoOutputInEvaluationSuccessSchemaWithEquivalenceClass() {
         val testData =
             """
             {
@@ -594,9 +607,7 @@ class PartiQLTestDataValidator {
                 statement: "some statement",
                 assert: {
                     result: EvaluationSuccess,
-                    equiv: [
-                        "some equivalent statement"
-                    ]
+                    equiv_class: some_equivalence_class
                 }
             }
             """
@@ -631,6 +642,22 @@ class PartiQLTestDataValidator {
                     'a': 1,
                     'b': 2
                 }
+            }
+            """
+        val dataInIon = ion.loader.load(testData)
+        assertViolationsOccurred(dataInIon)
+    }
+
+    @Test
+    fun testIncorrectEquivalenceClassAnnotationInSchema() {
+        val testData =
+            """
+            equiv_clas::{
+                id: some_id,
+                statements: [
+                    "some statement",
+                    "some equivalent statement"
+                ]
             }
             """
         val dataInIon = ion.loader.load(testData)

--- a/partiql-tests-validator/src/test/kotlin/org/partiql/tests/validator/PartiQLTestDataValidator.kt
+++ b/partiql-tests-validator/src/test/kotlin/org/partiql/tests/validator/PartiQLTestDataValidator.kt
@@ -354,11 +354,10 @@ class PartiQLTestDataValidator {
             """
             {
                 name: "some name",
-                statement: "some statement",
+                statement: some_equivalence_class,
                 assert: {
                     result: EvaluationSuccess,
                     output: some_output,
-                    equiv_class: some_equiv_class
                 }
             }
             """
@@ -479,7 +478,7 @@ class PartiQLTestDataValidator {
             """
             {
                 name: "some string",
-                statement: not_a_string,
+                statement: 123.4567,
                 assert: {
                     result: SyntaxSuccess
                 }

--- a/partiql-tests-validator/src/test/kotlin/org/partiql/tests/validator/PartiQLTestDataValidator.kt
+++ b/partiql-tests-validator/src/test/kotlin/org/partiql/tests/validator/PartiQLTestDataValidator.kt
@@ -73,7 +73,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testSyntaxSuccess() {
+    fun testSyntaxSuccessSchema() {
         val testData =
             """
             {
@@ -89,7 +89,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testSyntaxFail() {
+    fun testSyntaxFailSchema() {
         val testData =
             """
             {
@@ -105,7 +105,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testStaticAnalysisFail() {
+    fun testStaticAnalysisFailSchema() {
         val testData =
             """
             {
@@ -121,7 +121,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testSyntaxSuccessAssertList() {
+    fun testSyntaxSuccessAssertListSchema() {
         val testData =
             """
             {
@@ -139,7 +139,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testSyntaxFailAssertList() {
+    fun testSyntaxFailAssertListSchema() {
         val testData =
             """
             {
@@ -157,7 +157,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testStaticAnalysisFailAssertList() {
+    fun testStaticAnalysisFailAssertListSchema() {
         val testData =
             """
             {
@@ -175,7 +175,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testMultipleSyntaxTests() {
+    fun testMultipleSyntaxSuccessSchemas() {
         val testData =
             """
             'some-namespace'::[
@@ -213,7 +213,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testNestedNamespaces() {
+    fun testNestedNamespacesSchema() {
         val testData =
             """
             'ns-1'::[
@@ -265,7 +265,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testMultipleAssertions() {
+    fun testMultipleAssertionsSchema() {
         val testData =
             """
             {
@@ -286,7 +286,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testGlobalEnvs() {
+    fun testGlobalEnvsSchema() {
         val testData =
             """
             envs::{
@@ -299,7 +299,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testEvaluationSuccess() {
+    fun testEvaluationSuccessSchema() {
         val testData =
             """
             {
@@ -316,7 +316,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testEvaluationFail() {
+    fun testEvaluationFailSchema() {
         val testData =
             """
             {
@@ -332,7 +332,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testEvaluationSuccessWithEquivalence() {
+    fun testEvaluationSuccessSchemaWithEquivalence() {
         val testData =
             """
             {
@@ -354,7 +354,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testEvaluationWithOptionalFields() {
+    fun testEvaluationSuccessSchemaWithOptionalFields() {
         val testData =
             """
             {
@@ -374,7 +374,7 @@ class PartiQLTestDataValidator {
 
     // Negative tests
     @Test
-    fun testNonSpecifiedFieldInStruct() {
+    fun testNonSpecifiedFieldInStructSchema() {
         val testData =
             """
             {
@@ -391,7 +391,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testOtherNonSpecifiedFieldInAssertStruct() {
+    fun testOtherNonSpecifiedFieldInAssertStructSchema() {
         val testData =
             """
             {
@@ -408,7 +408,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testDisallowUndefinedAssertions() {
+    fun testDisallowUndefinedAssertionsInSchema() {
         val testData =
             """
             {
@@ -429,7 +429,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testWrongAssertResultSyntaxSuccess() {
+    fun testWrongAssertResultSyntaxSuccessSchema() {
         val testData =
             """
             {
@@ -445,7 +445,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testWrongNameType() {
+    fun testWrongNameTypeInSchema() {
         val testData =
             """
             {
@@ -461,7 +461,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testWrongStatementType() {
+    fun testWrongStatementTypeInSchema() {
         val testData =
             """
             {
@@ -477,7 +477,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testWrongAssertType() {
+    fun testWrongAssertTypeInSchema() {
         val testData =
             """
             {
@@ -497,7 +497,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testNoNameField() {
+    fun testNoNameFieldInSchema() {
         val testData =
             """
             {
@@ -512,7 +512,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testNoStatementField() {
+    fun testNoStatementFieldInSchema() {
         val testData =
             """
             {
@@ -527,7 +527,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testNoAssertField() {
+    fun testNoAssertFieldInSchema() {
         val testData =
             """
             {
@@ -540,7 +540,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testNoResultInAssertField() {
+    fun testNoResultInAssertFieldSchema() {
         val testData =
             """
             {
@@ -570,7 +570,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testNoOutputInEvaluationSuccess() {
+    fun testNoOutputInEvaluationSuccessSchema() {
         val testData =
             """
             {
@@ -586,7 +586,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testNoOutputInEvaluationSuccessWithEquivalentStatement() {
+    fun testNoOutputInEvaluationSuccessSchemaWithEquivalentStatement() {
         val testData =
             """
             {
@@ -605,7 +605,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testEvaluationFailWithUnexpectedOutput() {
+    fun testEvaluationFailSchemaWithUnexpectedOutput() {
         val testData =
             """
             {
@@ -622,7 +622,7 @@ class PartiQLTestDataValidator {
     }
 
     @Test
-    fun testIncorrectEnvAnnotation() {
+    fun testIncorrectEnvAnnotationInSchema() {
         val testData =
             """
             envssss::{


### PR DESCRIPTION
Issue #, if available: #17 and #20

Adds evaluation and equivalence schema proposal and ISL definitions. Additionally, makes some other changes:
- adds some example `EvaluationSuccess`, `EvaluationFail`, and equivalence tests
- changes structs to be closed content, which can help prevent using the wrong assertion fields (e.g. including an `output` for an `EvaluationFail` `result`)
- ISL validation tests related to evaluation + equivalence

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.