### PR TITLE
Add `EvalMode` to evaluation test assertion

### DIFF
--- a/docs/partiql-tests-schema-proposal.md
+++ b/docs/partiql-tests-schema-proposal.md
@@ -215,7 +215,8 @@ without schema). As defined in the PartiQL specification, these modes are:
 The naming of these modes can be somewhat confusing especially "type checking mode", which is sometimes referred to as
 `STRICT` mode in the specification and Kotlin reference implementation. For the purposes of this document and the
 conformance tests, we will refer to permissive mode as `EvalModeCoerce` and type checking mode as `EvalModeError`. 
-These names can be changed in the future once we improve the terminology in the specification.
+These names can be changed in the future once we improve the terminology in the specification (see 
+[partiql-docs#24](https://github.com/partiql/partiql-docs/issues/24)).
 
 ```ion
 // Test case using `EvalModeCoerce`

--- a/partiql-tests-data/fail/eval/query/select/select.ion
+++ b/partiql-tests-data/fail/eval/query/select/select.ion
@@ -2,6 +2,7 @@
     name: "select star from non existent binding",
     statement: "SELECT * FROM non_existent_binding",
     assert: {
-        result: EvaluationFail  // example fails in type-checking mode TBD on default evaluation mode (https://github.com/partiql/partiql-tests/issues/25)
+        evalMode: EvalModeError,
+        result: EvaluationFail
     }
 }

--- a/partiql-tests-data/partiql-tests-schema.isl
+++ b/partiql-tests-data/partiql-tests-schema.isl
@@ -48,7 +48,6 @@ type::{
             occurs: required
         },
         env: { type: struct, occurs: optional },
-        options: { type: struct, occurs: optional },
         assert: {
             type: {
                 one_of: [
@@ -71,6 +70,22 @@ type::{
             StaticAnalysisFailAssertion,
             EvaluationSuccessAssertion,
             EvaluationFailAssertion
+        ]
+    }
+}
+
+type::{
+    name: EvaluationMode,
+    type: symbol,
+    valid_values: [EvalModeError, EvalModeCoerce]
+}
+
+type::{
+    name: EvaluationModeSymbolOrList,
+    type: {
+        one_of: [
+            EvaluationMode,
+            { type: list, element: EvaluationMode }
         ]
     }
 }
@@ -107,7 +122,8 @@ type::{
     type: struct,
     fields: {
         result: { type: symbol, valid_values: [EvaluationSuccess], occurs: required },
-        output: { occurs: required }
+        output: { occurs: required },
+        evalMode: { type: EvaluationModeSymbolOrList, occurs: required }
     },
     content: closed
 }
@@ -116,7 +132,8 @@ type::{
     name: EvaluationFailAssertion,
     type: struct,
     fields: {
-        result: { type: symbol, valid_values: [EvaluationFail], occurs: required }
+        result: { type: symbol, valid_values: [EvaluationFail], occurs: required },
+        evalMode: { type: EvaluationModeSymbolOrList, occurs: required }
     },
     content: closed
 }

--- a/partiql-tests-data/success/eval-equiv/path.ion
+++ b/partiql-tests-data/success/eval-equiv/path.ion
@@ -26,6 +26,7 @@ equiv_class::{
     name: "equiv wildcard steps collection",
     statement: wildcard_steps_collection,
     assert: {
+        evalMode: [EvalModeCoerce, EvalModeError],
         result: EvaluationSuccess,
         output: $bag::[1, 2, 3]
     }
@@ -35,6 +36,7 @@ equiv_class::{
     name: "equiv wildcard steps struct",
     statement: wildcard_steps_struct,
     assert: {
+        evalMode: [EvalModeCoerce, EvalModeError],
         result: EvaluationSuccess,
         output: $bag::[1, 2]
     }

--- a/partiql-tests-data/success/eval/query/select/select.ion
+++ b/partiql-tests-data/success/eval/query/select/select.ion
@@ -9,6 +9,7 @@ envs::{
     name: "SELECT path",
     statement: "SELECT r.v FROM sensors AS s, s.readings AS r",
     assert: {
+        evalMode: [EvalModeCoerce, EvalModeError],
         result: EvaluationSuccess,
         output: $bag::[
             {
@@ -39,6 +40,7 @@ envs::{
         ]
     },
     assert: {
+        evalMode: [EvalModeCoerce, EvalModeError],
         result: EvaluationSuccess,
         output: $bag::[
             {

--- a/partiql-tests-validator/src/test/kotlin/org/partiql/tests/validator/PartiQLTestDataValidator.kt
+++ b/partiql-tests-validator/src/test/kotlin/org/partiql/tests/validator/PartiQLTestDataValidator.kt
@@ -306,6 +306,7 @@ class PartiQLTestDataValidator {
                 name: "some name",
                 statement: "some statement",
                 assert: {
+                    evalMode: EvalModeCoerce,
                     result: EvaluationSuccess,
                     output: some_output
                 }
@@ -323,6 +324,7 @@ class PartiQLTestDataValidator {
                 name: "some name",
                 statement: "some statement",
                 assert: {
+                    evalMode: EvalModeError,
                     result: EvaluationFail
                 }
             }
@@ -356,6 +358,7 @@ class PartiQLTestDataValidator {
                 name: "some name",
                 statement: some_equivalence_class,
                 assert: {
+                    evalMode: [EvalModeCoerce, EvalModeError],
                     result: EvaluationSuccess,
                     output: some_output,
                 }
@@ -373,8 +376,8 @@ class PartiQLTestDataValidator {
                 name: "some name",
                 statement: "some statement",
                 env: { some_key: some_value },
-                options: { some_option_key: some_option_value },
                 assert: {
+                    evalMode: [EvalModeCoerce, EvalModeError],
                     result: EvaluationSuccess,
                     output: some_output
                 }
@@ -589,7 +592,41 @@ class PartiQLTestDataValidator {
                 name: "some name",
                 statement: "some statement",
                 assert: {
+                    evalMode: [EvalModeCoerce, EvalModeError],
                     result: EvaluationSuccess
+                }
+            }
+            """
+        val dataInIon = ion.loader.load(testData)
+        assertViolationsOccurred(dataInIon)
+    }
+
+    @Test
+    fun testNoEvalModeInEvaluationSuccessSchema() {
+        val testData =
+            """
+            {
+                name: "some name",
+                statement: "some statement",
+                assert: {
+                    result: EvaluationSuccess,
+                    output: 'some_output'
+                }
+            }
+            """
+        val dataInIon = ion.loader.load(testData)
+        assertViolationsOccurred(dataInIon)
+    }
+
+    @Test
+    fun testNoEvalModeInEvaluationFailSchema() {
+        val testData =
+            """
+            {
+                name: "some name",
+                statement: "some statement",
+                assert: {
+                    result: EvaluationFail,
                 }
             }
             """


### PR DESCRIPTION
Issue #, if available: #25

Adds the `EvalMode` option to the evaluation test schema to represent the different dynamic type mismatch behaviors specified in the PartiQL specification (see [section 4.1](https://partiql.org/assets/PartiQL-Specification.pdf#subsection.4.1)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.