### PR TITLE
Update case op tests

### DIFF
--- a/partiql-tests-data/eval/primitives/operators/case-operator.ion
+++ b/partiql-tests-data/eval/primitives/operators/case-operator.ion
@@ -7,7 +7,7 @@ envs::{
 case::[
   {
     name:"simpleCase",
-    statement:"SELECT VALUE CASE x + 1 WHEN NULL THEN 'shouldnt be null' WHEN NULL THEN 'shouldnt be missing' WHEN i THEN 'ONE' WHEN f THEN 'TWO' WHEN d THEN 'THREE' ELSE '?' END FROM << i, f, d, null, missing >> AS x",
+    statement:"SELECT VALUE CASE x + 1 WHEN NULL THEN 'shouldnt be null' WHEN MISSING THEN 'shouldnt be missing' WHEN i THEN 'ONE' WHEN f THEN 'TWO' WHEN d THEN 'THREE' ELSE '?' END FROM << i, f, d, null, missing >> AS x",
     assert:{
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
@@ -22,7 +22,7 @@ case::[
   },
   {
     name:"simpleCaseNoElse",
-    statement:"SELECT VALUE CASE x + 1 WHEN NULL THEN 'shouldnt be null' WHEN NULL THEN 'shouldnt be missing' WHEN i THEN 'ONE' WHEN f THEN 'TWO' WHEN d THEN 'THREE' END FROM << i, f, d, null, missing >> AS x",
+    statement:"SELECT VALUE CASE x + 1 WHEN NULL THEN 'shouldnt be null' WHEN MISSING THEN 'shouldnt be missing' WHEN i THEN 'ONE' WHEN f THEN 'TWO' WHEN d THEN 'THREE' END FROM << i, f, d, null, missing >> AS x",
     assert:{
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,


### PR DESCRIPTION
Original ported tests from [EvaluatorTestSuite.kt](https://github.com/partiql/partiql-lang-kotlin/blob/main/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTestSuite.kt#L753-L787) had a redundant `WHEN` branch that repeated `WHEN NULL THEN`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.