### PR TITLE
Fix `NULLLIF(MISSING, MISSING)` test case

### DIFF
--- a/partiql-tests-data/eval/primitives/functions/nullif.ion
+++ b/partiql-tests-data/eval/primitives/functions/nullif.ion
@@ -145,7 +145,7 @@ nullif::[
     }
   },
   {
-    name:"nullif valid cases{first:\"missing\",second:\"missing\",result:null}",
+    name:"nullif valid cases{first:\"missing\",second:\"missing\",result:missing}",
     statement:"nullif(missing, missing)",
     assert:{
       result:EvaluationSuccess,
@@ -153,7 +153,7 @@ nullif::[
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output:$missing::null
     }
   },
 ]


### PR DESCRIPTION
Existing test case result was wrong. `NULLIF(MISSING, MISSING)` should result in `MISSING` and not `NULL`. 

If we reduce `NULLIF` to a `CASE WHEN` expression as specified in the [SQL-92 spec section 6.9 page 141](http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt), `NULLIF(MISSING, MISSING)` is equivalent to:

```
CASE WHEN MISSING = MISSING THEN NULL ELSE MISSING END
```

Since `MISSING = MISSING` is not true, the result is the else branch, `MISSING`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.