### PR TITLE
Remove empty inline comments

### DIFF
--- a/partiql-tests-data/eval/primitives/operators/like.ion
+++ b/partiql-tests-data/eval/primitives/operators/like.ion
@@ -1655,18 +1655,12 @@ like::[
 // (http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt):
 //         1) If an <escape character> is specified and M, P, or E is the null
 //            value, then
-//
 //              M LIKE P ESCAPE E
-//
 //            is unknown.
-//
 //         2) If an <escape character> is not specified and M or P is the null
 //            value, then
-//
 //              M LIKE P
-//
 //            is unknown.
-//
 // NULL/MISSING and mistyped arguments follow section 7 of the PartiQL spec
 // (https://partiql.org/assets/PartiQL-Specification.pdf#section.7)
 'null-missing-mistyped-for-like'::[


### PR DESCRIPTION
Some empty, inline comments were added in https://github.com/partiql/partiql-tests/pull/49, which caused some parsing errors with `ion-rs` ([example failing build](https://github.com/partiql/partiql-lang-rust/actions/runs/4048525189/jobs/6963874842)). I believe it's a bug in `ion-rs` (still confirming) as it parses fine with IonJava and isn't forbidden in the Ion spec. In the meantime, just removing those empty, inline comments to let `partiql-lang-rust` use the latest version of `partiql-tests`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.