### PR TITLE
Add outer join type to `OUTER JOIN`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
 
         - name: Setup Gradle
           uses: gradle/gradle-build-action@v2
+          with:
+            gradle-version: 7.2
+
 
         - name: Validate Tests
           working-directory: ./partiql-tests-validator

--- a/partiql-tests-data/success/syntax/query/select/joins.ion
+++ b/partiql-tests-data/success/syntax/query/select/joins.ion
@@ -102,6 +102,22 @@
     },
 }
 
+{
+    name: "SELECT with multiple JOINS and implicit CROSS JOIN",
+    statement: "SELECT x FROM a, b CROSS JOIN c LEFT JOIN d ON e RIGHT OUTER CROSS JOIN f FULL OUTER JOIN g ON h",
+    assert: {
+        result: SyntaxSuccess
+    },
+}
+
+{
+    name: "SELECT with multiple JOINS and explicit CROSS JOIN",
+    statement: "SELECT x FROM a INNER CROSS JOIN b CROSS JOIN c LEFT JOIN d ON e RIGHT OUTER CROSS JOIN f FULL OUTER JOIN g ON h",
+    assert: {
+        result: SyntaxSuccess
+    },
+}
+
 'correlated-joins'::[
     {
         name: "SELECT correlated JOIN",

--- a/partiql-tests-data/success/syntax/query/select/joins.ion
+++ b/partiql-tests-data/success/syntax/query/select/joins.ion
@@ -102,22 +102,6 @@
     },
 }
 
-{
-    name: "SELECT with multiple JOINS and implicit CROSS JOIN",
-    statement: "SELECT x FROM a, b CROSS JOIN c LEFT JOIN d ON e RIGHT OUTER CROSS JOIN f OUTER JOIN g ON h",
-    assert: {
-        result: SyntaxSuccess
-    },
-}
-
-{
-    name: "SELECT with multiple JOINS and explicit CROSS JOIN",
-    statement: "SELECT x FROM a INNER CROSS JOIN b CROSS JOIN c LEFT JOIN d ON e RIGHT OUTER CROSS JOIN f OUTER JOIN g ON h",
-    assert: {
-        result: SyntaxSuccess
-    },
-}
-
 'correlated-joins'::[
     {
         name: "SELECT correlated JOIN",


### PR DESCRIPTION
Removes some `OUTER JOIN` tests that don't include an outer join type (i.e. `LEFT`, `RIGHT`, `FULL`). From [Josh's comment](https://github.com/partiql/partiql-lang-rust/pull/306#issuecomment-1435244301) in a recent Rust PR:

```
Tests are here: 
https://github.com/partiql/partiql-tests/blob/main/partiql-tests-data/success/syntax/query/select/joins.ion#L105-L118

- 
   SELECT x FROM a, b CROSS JOIN c LEFT JOIN d ON e RIGHT OUTER CROSS JOIN f OUTER JOIN g ON h
   
- 
   SELECT x FROM a INNER CROSS JOIN b CROSS JOIN c LEFT JOIN d ON e RIGHT OUTER CROSS JOIN f OUTER JOIN g ON h
   

They both presume that `<x> OUTER JOIN <y>` is equivalent to `<x> FULL OUTER JOIN <y>`, but I have found:
-  no SQL database that supports this,
- the [SQL syntax](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#join-type) spec requires a join type before `OUTER`,
- this is not mentioned in the PartiQL Spec
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.