### PR TITLE
Port more `GROUP BY` tests from partiql-lang-kotlin

### DIFF
--- a/partiql-tests-data/eval/query/group-by/group-by.ion
+++ b/partiql-tests-data/eval/query/group-by/group-by.ion
@@ -1090,3 +1090,8494 @@
     ]
   }
 ]
+
+// GROUP BY without aggregates
+'group-by-test'::[
+  envs::{
+    simple_1_col_1_group: [
+      {
+        col1: 1
+      },
+      {
+        col1: 1
+      }
+    ],
+    simple_2_col_1_group: [
+      {
+        col1: 1,
+        col2: 10
+      },
+      {
+        col1: 1,
+        col2: 10
+      }
+    ],
+    simple_1_col_2_groups: [
+      {
+        col1: 1
+      },
+      {
+        col1: 2
+      },
+      {
+        col1: 1
+      },
+      {
+        col1: 2
+      }
+    ],
+    simple_2_col_2_groups: [
+      {
+        col1: 1,
+        col2: 10},
+      {
+        col1: 11,
+        col2: 110},
+      {
+        col1: 1,
+        col2: 10
+      },
+      {
+        col1: 11,
+        col2: 110
+      }
+    ],
+    string_groups: [
+      {
+        col1: 'a'
+      },
+      {
+        col1: 'a'
+      }
+    ],
+    string_numbers: [
+      {
+        num: '1'
+      },
+      {
+        num: '2'
+      }
+    ],
+    products_sparse: [
+      { productId: 1,  categoryId: 20, regionId: 100, supplierId_nulls: 10,   supplierId_missings: 10, supplierId_mixed: 10,   price_nulls: 1.0,  price_missings: 1.0, price_mixed: 1.0  },
+      { productId: 2,  categoryId: 20, regionId: 100, supplierId_nulls: 10,   supplierId_missings: 10, supplierId_mixed: 10,   price_nulls: 2.0,  price_missings: 2.0, price_mixed: 2.0  },
+      { productId: 3,  categoryId: 20, regionId: 200, supplierId_nulls: 10,   supplierId_missings: 10, supplierId_mixed: 10,   price_nulls: 3.0,  price_missings: 3.0, price_mixed: 3.0  },
+      { productId: 5,  categoryId: 21, regionId: 100, supplierId_nulls: null,                                                  price_nulls: null                                         },
+      { productId: 4,  categoryId: 20, regionId: 100, supplierId_nulls: null,                          supplierId_mixed: null, price_nulls: null,                      price_mixed: null },
+      { productId: 6,  categoryId: 21, regionId: 100, supplierId_nulls: 11,   supplierId_missings: 11, supplierId_mixed: 11,   price_nulls: 4.0,  price_missings: 4.0, price_mixed: 4.0  },
+      { productId: 7,  categoryId: 21, regionId: 200, supplierId_nulls: 11,   supplierId_missings: 11, supplierId_mixed: 11,   price_nulls: 5.0,  price_missings: 5.0, price_mixed: 5.0  },
+      { productId: 8,  categoryId: 21, regionId: 200, supplierId_nulls: null,                          supplierId_mixed: null, price_nulls: null,                      price_mixed: null },
+      { productId: 9,  categoryId: 21, regionId: 200, supplierId_nulls: null,                                                  price_nulls: null,                                        },
+      { productId: 10, categoryId: 21, regionId: 200, supplierId_nulls: null,                          supplierId_mixed: null, price_nulls: null,                                        }
+    ]
+  },
+  {
+    name:"SELECT * FROM [] GROUP BY doesntMatterWontBeEvaluated",
+    statement:"SELECT * FROM [] GROUP BY doesntMatterWontBeEvaluated",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { } FROM [] GROUP BY doesntMatterWontBeEvaluated",
+    statement:"SELECT VALUE { } FROM [] GROUP BY doesntMatterWontBeEvaluated",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col1 FROM simple_1_col_1_group GROUP BY col1",
+    statement:"SELECT col1 FROM simple_1_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col1': 1 } FROM simple_1_col_1_group GROUP BY col1",
+    statement:"SELECT VALUE { 'col1': 1 } FROM simple_1_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col1 FROM simple_2_col_1_group GROUP BY col1",
+    statement:"SELECT col1 FROM simple_2_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col1': 1 } FROM simple_2_col_1_group GROUP BY col1",
+    statement:"SELECT VALUE { 'col1': 1 } FROM simple_2_col_1_group GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col2 FROM simple_2_col_1_group GROUP BY col2",
+    statement:"SELECT col2 FROM simple_2_col_1_group GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col2': col2 } FROM simple_2_col_1_group GROUP BY col2",
+    statement:"SELECT VALUE { 'col2': col2 } FROM simple_2_col_1_group GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_1_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:11
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:11
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:11
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:11
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:11
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:11
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        },
+        {
+          col2:110
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        },
+        {
+          col2:110
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        },
+        {
+          col2:110
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        },
+        {
+          col2:110
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        },
+        {
+          col2:110
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        },
+        {
+          col2:110
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col1 FROM simple_1_col_2_groups GROUP BY col1",
+    statement:"SELECT col1 FROM simple_1_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col1': col1 } FROM simple_1_col_2_groups GROUP BY col1",
+    statement:"SELECT VALUE { 'col1': col1 } FROM simple_1_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col1 FROM simple_2_col_2_groups GROUP BY col1",
+    statement:"SELECT col1 FROM simple_2_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:11
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col1': col1 } FROM simple_2_col_2_groups GROUP BY col1",
+    statement:"SELECT VALUE { 'col1': col1 } FROM simple_2_col_2_groups GROUP BY col1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1
+        },
+        {
+          col1:11
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col2 FROM simple_2_col_2_groups GROUP BY col2",
+    statement:"SELECT col2 FROM simple_2_col_2_groups GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        },
+        {
+          col2:110
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col2': col2 } FROM simple_2_col_2_groups GROUP BY col2",
+    statement:"SELECT VALUE { 'col2': col2 } FROM simple_2_col_2_groups GROUP BY col2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10
+        },
+        {
+          col2:110
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY col1 + 1",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY col1 + 1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT _1 FROM simple_1_col_1_group GROUP BY col1 + 1",
+    statement:"SELECT _1 FROM simple_1_col_1_group GROUP BY col1 + 1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { '_1': _1 } FROM simple_1_col_1_group GROUP BY col1 + 1",
+    statement:"SELECT VALUE { '_1': _1 } FROM simple_1_col_1_group GROUP BY col1 + 1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM string_groups GROUP BY col1 || 'a'",
+    statement:"SELECT * FROM string_groups GROUP BY col1 || 'a'",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:"aa"
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT _1 FROM string_groups GROUP BY col1 || 'a'",
+    statement:"SELECT _1 FROM string_groups GROUP BY col1 || 'a'",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:"aa"
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { '_1': _1 } FROM string_groups GROUP BY col1 || 'a'",
+    statement:"SELECT VALUE { '_1': _1 } FROM string_groups GROUP BY col1 || 'a'",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:"aa"
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM string_numbers GROUP BY CAST(num AS INT)",
+    statement:"SELECT * FROM string_numbers GROUP BY CAST(num AS INT)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          num:1
+        },
+        {
+          num:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT num FROM string_numbers GROUP BY CAST(num AS INT)",
+    statement:"SELECT num FROM string_numbers GROUP BY CAST(num AS INT)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          num:1
+        },
+        {
+          num:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'num': num } FROM string_numbers GROUP BY CAST(num AS INT)",
+    statement:"SELECT VALUE { 'num': num } FROM string_numbers GROUP BY CAST(num AS INT)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          num:1
+        },
+        {
+          num:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY col1 + 1 AS someGBE",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY col1 + 1 AS someGBE",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someGBE:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT someGBE FROM simple_1_col_1_group GROUP BY col1 + 1 AS someGBE",
+    statement:"SELECT someGBE FROM simple_1_col_1_group GROUP BY col1 + 1 AS someGBE",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someGBE:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'someGBE': someGBE } FROM simple_1_col_1_group GROUP BY col1 + 1 AS someGBE",
+    statement:"SELECT VALUE { 'someGBE': someGBE } FROM simple_1_col_1_group GROUP BY col1 + 1 AS someGBE",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someGBE:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM string_groups GROUP BY col1 || 'a' AS someGBE",
+    statement:"SELECT * FROM string_groups GROUP BY col1 || 'a' AS someGBE",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someGBE:"aa"
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT someGBE FROM string_groups GROUP BY col1 || 'a' AS someGBE",
+    statement:"SELECT someGBE FROM string_groups GROUP BY col1 || 'a' AS someGBE",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someGBE:"aa"
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'someGBE': someGBE } FROM string_groups GROUP BY col1 || 'a' AS someGBE",
+    statement:"SELECT VALUE { 'someGBE': someGBE } FROM string_groups GROUP BY col1 || 'a' AS someGBE",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someGBE:"aa"
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM string_numbers GROUP BY CAST(num AS INT) AS someGBE",
+    statement:"SELECT * FROM string_numbers GROUP BY CAST(num AS INT) AS someGBE",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someGBE:1
+        },
+        {
+          someGBE:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT someGBE FROM string_numbers GROUP BY CAST(num AS INT) AS someGBE",
+    statement:"SELECT someGBE FROM string_numbers GROUP BY CAST(num AS INT) AS someGBE",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someGBE:1
+        },
+        {
+          someGBE:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'someGBE': someGBE } FROM string_numbers GROUP BY CAST(num AS INT) AS someGBE",
+    statement:"SELECT VALUE { 'someGBE': someGBE } FROM string_numbers GROUP BY CAST(num AS INT) AS someGBE",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someGBE:1
+        },
+        {
+          someGBE:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY NULL AS someNull",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY NULL AS someNull",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someNull:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT someNull FROM simple_1_col_1_group GROUP BY NULL AS someNull",
+    statement:"SELECT someNull FROM simple_1_col_1_group GROUP BY NULL AS someNull",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someNull:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'someNull': someNull } FROM simple_1_col_1_group GROUP BY NULL AS someNull",
+    statement:"SELECT VALUE { 'someNull': someNull } FROM simple_1_col_1_group GROUP BY NULL AS someNull",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          someNull:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY MISSING AS someMissing",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY MISSING AS someMissing",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT someMissing FROM simple_1_col_1_group GROUP BY MISSING AS someMissing",
+    statement:"SELECT someMissing FROM simple_1_col_1_group GROUP BY MISSING AS someMissing",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'someMissing': someMissing } FROM simple_1_col_1_group GROUP BY MISSING AS someMissing",
+    statement:"SELECT VALUE { 'someMissing': someMissing } FROM simple_1_col_1_group GROUP BY MISSING AS someMissing",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY NULL AS groupExp",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY NULL AS groupExp",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          groupExp:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT groupExp FROM simple_1_col_1_group GROUP BY NULL AS groupExp",
+    statement:"SELECT groupExp FROM simple_1_col_1_group GROUP BY NULL AS groupExp",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          groupExp:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'groupExp': groupExp } FROM simple_1_col_1_group GROUP BY NULL AS groupExp",
+    statement:"SELECT VALUE { 'groupExp': groupExp } FROM simple_1_col_1_group GROUP BY NULL AS groupExp",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          groupExp:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY MISSING AS groupExp",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY MISSING AS groupExp",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT groupExp FROM simple_1_col_1_group GROUP BY MISSING AS groupExp",
+    statement:"SELECT groupExp FROM simple_1_col_1_group GROUP BY MISSING AS groupExp",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'groupExp': groupExp } FROM simple_1_col_1_group GROUP BY MISSING AS groupExp",
+    statement:"SELECT VALUE { 'groupExp': groupExp } FROM simple_1_col_1_group GROUP BY MISSING AS groupExp",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM products_sparse p GROUP BY p.supplierId_nulls",
+    statement:"SELECT * FROM products_sparse p GROUP BY p.supplierId_nulls",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId_nulls:10
+        },
+        {
+          supplierId_nulls:11
+        },
+        {
+          supplierId_nulls:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId_nulls FROM products_sparse p GROUP BY p.supplierId_nulls",
+    statement:"SELECT supplierId_nulls FROM products_sparse p GROUP BY p.supplierId_nulls",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId_nulls:10
+        },
+        {
+          supplierId_nulls:11
+        },
+        {
+          supplierId_nulls:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'supplierId_nulls': supplierId_nulls } FROM products_sparse p GROUP BY p.supplierId_nulls",
+    statement:"SELECT VALUE { 'supplierId_nulls': supplierId_nulls } FROM products_sparse p GROUP BY p.supplierId_nulls",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId_nulls:10
+        },
+        {
+          supplierId_nulls:11
+        },
+        {
+          supplierId_nulls:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM products_sparse p GROUP BY p.supplierId_missings",
+    statement:"SELECT * FROM products_sparse p GROUP BY p.supplierId_missings",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId_missings:10
+        },
+        {
+          supplierId_missings:11
+        },
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId_missings FROM products_sparse p GROUP BY p.supplierId_missings",
+    statement:"SELECT p.supplierId_missings FROM products_sparse p GROUP BY p.supplierId_missings",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId_missings:10
+        },
+        {
+          supplierId_missings:11
+        },
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'supplierId_missings' : p.supplierId_missings } FROM products_sparse p GROUP BY p.supplierId_missings",
+    statement:"SELECT VALUE { 'supplierId_missings' : p.supplierId_missings } FROM products_sparse p GROUP BY p.supplierId_missings",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId_missings:10
+        },
+        {
+          supplierId_missings:11
+        },
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM products_sparse p GROUP BY p.supplierId_mixed",
+    statement:"SELECT * FROM products_sparse p GROUP BY p.supplierId_mixed",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId_mixed:10
+        },
+        {
+          supplierId_mixed:11
+        },
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId_mixed FROM products_sparse p GROUP BY p.supplierId_mixed",
+    statement:"SELECT p.supplierId_mixed FROM products_sparse p GROUP BY p.supplierId_mixed",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId_mixed:10
+        },
+        {
+          supplierId_mixed:11
+        },
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'supplierId_mixed' : p.supplierId_mixed } FROM products_sparse p GROUP BY p.supplierId_mixed",
+    statement:"SELECT VALUE { 'supplierId_mixed' : p.supplierId_mixed } FROM products_sparse p GROUP BY p.supplierId_mixed",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId_mixed:10
+        },
+        {
+          supplierId_mixed:11
+        },
+        {
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM products_sparse p GROUP BY p.regionId, p.supplierId_nulls",
+    statement:"SELECT * FROM products_sparse p GROUP BY p.regionId, p.supplierId_nulls",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          regionId:100,
+          supplierId_nulls:10
+        },
+        {
+          regionId:100,
+          supplierId_nulls:11
+        },
+        {
+          regionId:100,
+          supplierId_nulls:null
+        },
+        {
+          regionId:200,
+          supplierId_nulls:10
+        },
+        {
+          regionId:200,
+          supplierId_nulls:11
+        },
+        {
+          regionId:200,
+          supplierId_nulls:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT regionId, supplierId_nulls FROM products_sparse p GROUP BY p.regionId, p.supplierId_nulls",
+    statement:"SELECT regionId, supplierId_nulls FROM products_sparse p GROUP BY p.regionId, p.supplierId_nulls",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          regionId:100,
+          supplierId_nulls:10
+        },
+        {
+          regionId:100,
+          supplierId_nulls:11
+        },
+        {
+          regionId:100,
+          supplierId_nulls:null
+        },
+        {
+          regionId:200,
+          supplierId_nulls:10
+        },
+        {
+          regionId:200,
+          supplierId_nulls:11
+        },
+        {
+          regionId:200,
+          supplierId_nulls:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'regionId': regionId, 'supplierId_nulls': supplierId_nulls } FROM products_sparse p GROUP BY p.regionId, p.supplierId_nulls",
+    statement:"SELECT VALUE { 'regionId': regionId, 'supplierId_nulls': supplierId_nulls } FROM products_sparse p GROUP BY p.regionId, p.supplierId_nulls",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          regionId:100,
+          supplierId_nulls:10
+        },
+        {
+          regionId:100,
+          supplierId_nulls:11
+        },
+        {
+          regionId:100,
+          supplierId_nulls:null
+        },
+        {
+          regionId:200,
+          supplierId_nulls:10
+        },
+        {
+          regionId:200,
+          supplierId_nulls:11
+        },
+        {
+          regionId:200,
+          supplierId_nulls:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
+    statement:"SELECT * FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          regionId:100,
+          supplierId_missings:10
+        },
+        {
+          regionId:100,
+          supplierId_missings:11
+        },
+        {
+          regionId:100
+        },
+        {
+          regionId:200,
+          supplierId_missings:10
+        },
+        {
+          regionId:200,
+          supplierId_missings:11
+        },
+        {
+          regionId:200
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.regionId, p.supplierId_missings FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
+    statement:"SELECT p.regionId, p.supplierId_missings FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          regionId:100,
+          supplierId_missings:10
+        },
+        {
+          regionId:100,
+          supplierId_missings:11
+        },
+        {
+          regionId:100
+        },
+        {
+          regionId:200,
+          supplierId_missings:10
+        },
+        {
+          regionId:200,
+          supplierId_missings:11
+        },
+        {
+          regionId:200
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'regionId': p.regionId, 'supplierId_missings': p.supplierId_missings } FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
+    statement:"SELECT VALUE { 'regionId': p.regionId, 'supplierId_missings': p.supplierId_missings } FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          regionId:100,
+          supplierId_missings:10
+        },
+        {
+          regionId:100,
+          supplierId_missings:11
+        },
+        {
+          regionId:100
+        },
+        {
+          regionId:200,
+          supplierId_missings:10
+        },
+        {
+          regionId:200,
+          supplierId_missings:11
+        },
+        {
+          regionId:200
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
+    statement:"SELECT * FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          regionId:100,
+          supplierId_mixed:10
+        },
+        {
+          regionId:100,
+          supplierId_mixed:11
+        },
+        {
+          regionId:100
+        },
+        {
+          regionId:200,
+          supplierId_mixed:10
+        },
+        {
+          regionId:200,
+          supplierId_mixed:11
+        },
+        {
+          regionId:200,
+          supplierId_mixed:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT regionId, p.supplierId_mixed FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
+    statement:"SELECT regionId, p.supplierId_mixed FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          regionId:100,
+          supplierId_mixed:10
+        },
+        {
+          regionId:100,
+          supplierId_mixed:11
+        },
+        {
+          regionId:100
+        },
+        {
+          regionId:200,
+          supplierId_mixed:10
+        },
+        {
+          regionId:200,
+          supplierId_mixed:11
+        },
+        {
+          regionId:200,
+          supplierId_mixed:null
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'regionId': p.regionId, 'supplierId_mixed': p.supplierId_mixed } FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
+    statement:"SELECT VALUE { 'regionId': p.regionId, 'supplierId_mixed': p.supplierId_mixed } FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          regionId:100,
+          supplierId_mixed:10
+        },
+        {
+          regionId:100,
+          supplierId_mixed:11
+        },
+        {
+          regionId:100
+        },
+        {
+          regionId:200,
+          supplierId_mixed:10
+        },
+        {
+          regionId:200,
+          supplierId_mixed:11
+        },
+        {
+          regionId:200,
+          supplierId_mixed:null
+        }
+      ]
+    }
+  },
+]
+
+// Test cases that cover `COUNT`, `SUM`, `MIN`, `MAX`, and `AVG`
+'sql92-style-aggregates'::[
+  envs::{
+    products: [
+      { productId: 1, supplierId: 10, categoryId: 20, price: 5.0,  numInStock: 1 },
+      { productId: 2, supplierId: 10, categoryId: 20, price: 10.0, numInStock: 10 },
+      { productId: 3, supplierId: 10, categoryId: 21, price: 15.0, numInStock: 100 },
+      { productId: 4, supplierId: 11, categoryId: 21, price: 5.0,  numInStock: 1000 },
+      { productId: 5, supplierId: 11, categoryId: 21, price: 15.0, numInStock: 10000 }
+    ],
+    products_sparse: [
+      { productId: 1,  categoryId: 20, regionId: 100, supplierId_nulls: 10,   supplierId_missings: 10, supplierId_mixed: 10,   price_nulls: 1.0,  price_missings: 1.0, price_mixed: 1.0  },
+      { productId: 2,  categoryId: 20, regionId: 100, supplierId_nulls: 10,   supplierId_missings: 10, supplierId_mixed: 10,   price_nulls: 2.0,  price_missings: 2.0, price_mixed: 2.0  },
+      { productId: 3,  categoryId: 20, regionId: 200, supplierId_nulls: 10,   supplierId_missings: 10, supplierId_mixed: 10,   price_nulls: 3.0,  price_missings: 3.0, price_mixed: 3.0  },
+      { productId: 5,  categoryId: 21, regionId: 100, supplierId_nulls: null,                                                  price_nulls: null                                         },
+      { productId: 4,  categoryId: 20, regionId: 100, supplierId_nulls: null,                          supplierId_mixed: null, price_nulls: null,                      price_mixed: null },
+      { productId: 6,  categoryId: 21, regionId: 100, supplierId_nulls: 11,   supplierId_missings: 11, supplierId_mixed: 11,   price_nulls: 4.0,  price_missings: 4.0, price_mixed: 4.0  },
+      { productId: 7,  categoryId: 21, regionId: 200, supplierId_nulls: 11,   supplierId_missings: 11, supplierId_mixed: 11,   price_nulls: 5.0,  price_missings: 5.0, price_mixed: 5.0  },
+      { productId: 8,  categoryId: 21, regionId: 200, supplierId_nulls: null,                          supplierId_mixed: null, price_nulls: null,                      price_mixed: null },
+      { productId: 9,  categoryId: 21, regionId: 200, supplierId_nulls: null,                                                  price_nulls: null,                                        },
+      { productId: 10, categoryId: 21, regionId: 200, supplierId_nulls: null,                          supplierId_mixed: null, price_nulls: null,                                        }
+    ],
+  },
+  {
+    name:"SELECT COUNT(5) FROM products",
+    statement:"SELECT COUNT(5) FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM(5) FROM products",
+    statement:"SELECT SUM(5) FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:25
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN(5) FROM products",
+    statement:"SELECT MIN(5) FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX(5) FROM products",
+    statement:"SELECT MAX(5) FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG(5) FROM products",
+    statement:"SELECT AVG(5) FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:5.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(numInStock) AS agg FROM products",
+    statement:"SELECT COUNT(numInStock) AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM(numInStock) AS agg FROM products",
+    statement:"SELECT SUM(numInStock) AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11111
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN(numInStock) AS agg FROM products",
+    statement:"SELECT MIN(numInStock) AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX(numInStock) AS agg FROM products",
+    statement:"SELECT MAX(numInStock) AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG(numInStock) AS agg FROM products",
+    statement:"SELECT AVG(numInStock) AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2222.2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(p.numInStock) AS agg FROM products AS p",
+    statement:"SELECT COUNT(p.numInStock) AS agg FROM products AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM(p.numInStock) AS agg FROM products AS p",
+    statement:"SELECT SUM(p.numInStock) AS agg FROM products AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11111
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN(p.numInStock) AS agg FROM products AS p",
+    statement:"SELECT MIN(p.numInStock) AS agg FROM products AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX(p.numInStock) AS agg FROM products AS p",
+    statement:"SELECT MAX(p.numInStock) AS agg FROM products AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG(p.numInStock) AS agg FROM products AS p",
+    statement:"SELECT AVG(p.numInStock) AS agg FROM products AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2222.2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT( numInStock + 1) AS agg FROM products",
+    statement:"SELECT COUNT( numInStock + 1) AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM( numInStock + 1) AS agg FROM products",
+    statement:"SELECT SUM( numInStock + 1) AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11116
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN( numInStock + 1) AS agg FROM products",
+    statement:"SELECT MIN( numInStock + 1) AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX( numInStock + 1) AS agg FROM products",
+    statement:"SELECT MAX( numInStock + 1) AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10001
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG( numInStock + 1) AS agg FROM products",
+    statement:"SELECT AVG( numInStock + 1) AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2223.2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(p.numInStock + 1) AS agg FROM products as p",
+    statement:"SELECT COUNT(p.numInStock + 1) AS agg FROM products as p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM(p.numInStock + 1) AS agg FROM products as p",
+    statement:"SELECT SUM(p.numInStock + 1) AS agg FROM products as p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11116
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN(p.numInStock + 1) AS agg FROM products as p",
+    statement:"SELECT MIN(p.numInStock + 1) AS agg FROM products as p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX(p.numInStock + 1) AS agg FROM products as p",
+    statement:"SELECT MAX(p.numInStock + 1) AS agg FROM products as p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10001
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG(p.numInStock + 1) AS agg FROM products as p",
+    statement:"SELECT AVG(p.numInStock + 1) AS agg FROM products as p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2223.2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT( numInStock) + 2 AS agg FROM products",
+    statement:"SELECT COUNT( numInStock) + 2 AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:7
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM( numInStock) + 2 AS agg FROM products",
+    statement:"SELECT SUM( numInStock) + 2 AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11113
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN( numInStock) + 2 AS agg FROM products",
+    statement:"SELECT MIN( numInStock) + 2 AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:3
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX( numInStock) + 2 AS agg FROM products",
+    statement:"SELECT MAX( numInStock) + 2 AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10002
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG( numInStock) + 2 AS agg FROM products",
+    statement:"SELECT AVG( numInStock) + 2 AS agg FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2224.2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(p.numInStock) + 2 AS agg FROM products as p",
+    statement:"SELECT COUNT(p.numInStock) + 2 AS agg FROM products as p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:7
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM(p.numInStock) + 2 AS agg FROM products as p",
+    statement:"SELECT SUM(p.numInStock) + 2 AS agg FROM products as p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11113
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN(p.numInStock) + 2 AS agg FROM products as p",
+    statement:"SELECT MIN(p.numInStock) + 2 AS agg FROM products as p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:3
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX(p.numInStock) + 2 AS agg FROM products as p",
+    statement:"SELECT MAX(p.numInStock) + 2 AS agg FROM products as p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10002
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG(p.numInStock) + 2 AS agg FROM products as p",
+    statement:"SELECT AVG(p.numInStock) + 2 AS agg FROM products as p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2224.2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(numInStock) AS agg FROM products WHERE supplierId = 10",
+    statement:"SELECT COUNT(numInStock) AS agg FROM products WHERE supplierId = 10",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:3
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM(numInStock) AS agg FROM products WHERE supplierId = 10",
+    statement:"SELECT SUM(numInStock) AS agg FROM products WHERE supplierId = 10",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:111
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN(numInStock) AS agg FROM products WHERE supplierId = 10",
+    statement:"SELECT MIN(numInStock) AS agg FROM products WHERE supplierId = 10",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX(numInStock) AS agg FROM products WHERE supplierId = 10",
+    statement:"SELECT MAX(numInStock) AS agg FROM products WHERE supplierId = 10",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG(numInStock) AS agg FROM products WHERE supplierId = 10",
+    statement:"SELECT AVG(numInStock) AS agg FROM products WHERE supplierId = 10",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:37.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(p.numInStock) AS agg FROM products AS p WHERE supplierId = 10",
+    statement:"SELECT COUNT(p.numInStock) AS agg FROM products AS p WHERE supplierId = 10",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:3
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM(p.numInStock) AS agg FROM products AS p WHERE supplierId = 10",
+    statement:"SELECT SUM(p.numInStock) AS agg FROM products AS p WHERE supplierId = 10",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:111
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN(p.numInStock) AS agg FROM products AS p WHERE supplierId = 10",
+    statement:"SELECT MIN(p.numInStock) AS agg FROM products AS p WHERE supplierId = 10",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX(p.numInStock) AS agg FROM products AS p WHERE supplierId = 10",
+    statement:"SELECT MAX(p.numInStock) AS agg FROM products AS p WHERE supplierId = 10",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG(p.numInStock) AS agg FROM products AS p WHERE supplierId = 10",
+    statement:"SELECT AVG(p.numInStock) AS agg FROM products AS p WHERE supplierId = 10",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:37.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT( numInStock) AS agg FROM products WHERE supplierId = 11",
+    statement:"SELECT COUNT( numInStock) AS agg FROM products WHERE supplierId = 11",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM( numInStock) AS agg FROM products WHERE supplierId = 11",
+    statement:"SELECT SUM( numInStock) AS agg FROM products WHERE supplierId = 11",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN( numInStock) AS agg FROM products WHERE supplierId = 11",
+    statement:"SELECT MIN( numInStock) AS agg FROM products WHERE supplierId = 11",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX( numInStock) AS agg FROM products WHERE supplierId = 11",
+    statement:"SELECT MAX( numInStock) AS agg FROM products WHERE supplierId = 11",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG( numInStock) AS agg FROM products WHERE supplierId = 11",
+    statement:"SELECT AVG( numInStock) AS agg FROM products WHERE supplierId = 11",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:5500.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(p.numInStock) AS agg FROM products AS p WHERE supplierId = 11",
+    statement:"SELECT COUNT(p.numInStock) AS agg FROM products AS p WHERE supplierId = 11",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM(p.numInStock) AS agg FROM products AS p WHERE supplierId = 11",
+    statement:"SELECT SUM(p.numInStock) AS agg FROM products AS p WHERE supplierId = 11",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN(p.numInStock) AS agg FROM products AS p WHERE supplierId = 11",
+    statement:"SELECT MIN(p.numInStock) AS agg FROM products AS p WHERE supplierId = 11",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX(p.numInStock) AS agg FROM products AS p WHERE supplierId = 11",
+    statement:"SELECT MAX(p.numInStock) AS agg FROM products AS p WHERE supplierId = 11",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG(p.numInStock) AS agg FROM products AS p WHERE supplierId = 11",
+    statement:"SELECT AVG(p.numInStock) AS agg FROM products AS p WHERE supplierId = 11",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:5500.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT( numInStock) AS agg FROM products WHERE categoryId = 20",
+    statement:"SELECT COUNT( numInStock) AS agg FROM products WHERE categoryId = 20",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM( numInStock) AS agg FROM products WHERE categoryId = 20",
+    statement:"SELECT SUM( numInStock) AS agg FROM products WHERE categoryId = 20",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN( numInStock) AS agg FROM products WHERE categoryId = 20",
+    statement:"SELECT MIN( numInStock) AS agg FROM products WHERE categoryId = 20",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX( numInStock) AS agg FROM products WHERE categoryId = 20",
+    statement:"SELECT MAX( numInStock) AS agg FROM products WHERE categoryId = 20",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG( numInStock) AS agg FROM products WHERE categoryId = 20",
+    statement:"SELECT AVG( numInStock) AS agg FROM products WHERE categoryId = 20",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:5.5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(p.numInStock) AS agg FROM products AS p WHERE p.categoryId = 20",
+    statement:"SELECT COUNT(p.numInStock) AS agg FROM products AS p WHERE p.categoryId = 20",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM(p.numInStock) AS agg FROM products AS p WHERE p.categoryId = 20",
+    statement:"SELECT SUM(p.numInStock) AS agg FROM products AS p WHERE p.categoryId = 20",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN(p.numInStock) AS agg FROM products AS p WHERE p.categoryId = 20",
+    statement:"SELECT MIN(p.numInStock) AS agg FROM products AS p WHERE p.categoryId = 20",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX(p.numInStock) AS agg FROM products AS p WHERE p.categoryId = 20",
+    statement:"SELECT MAX(p.numInStock) AS agg FROM products AS p WHERE p.categoryId = 20",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG(p.numInStock) AS agg FROM products AS p WHERE p.categoryId = 20",
+    statement:"SELECT AVG(p.numInStock) AS agg FROM products AS p WHERE p.categoryId = 20",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:5.5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT( numInStock) AS agg FROM products WHERE categoryId = 21",
+    statement:"SELECT COUNT( numInStock) AS agg FROM products WHERE categoryId = 21",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:3
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM( numInStock) AS agg FROM products WHERE categoryId = 21",
+    statement:"SELECT SUM( numInStock) AS agg FROM products WHERE categoryId = 21",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN( numInStock) AS agg FROM products WHERE categoryId = 21",
+    statement:"SELECT MIN( numInStock) AS agg FROM products WHERE categoryId = 21",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX( numInStock) AS agg FROM products WHERE categoryId = 21",
+    statement:"SELECT MAX( numInStock) AS agg FROM products WHERE categoryId = 21",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG( numInStock) AS agg FROM products WHERE categoryId = 21",
+    statement:"SELECT AVG( numInStock) AS agg FROM products WHERE categoryId = 21",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:3700.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(p.numInStock) AS agg FROM products AS p WHERE categoryId = 21",
+    statement:"SELECT COUNT(p.numInStock) AS agg FROM products AS p WHERE categoryId = 21",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:3
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT SUM(p.numInStock) AS agg FROM products AS p WHERE categoryId = 21",
+    statement:"SELECT SUM(p.numInStock) AS agg FROM products AS p WHERE categoryId = 21",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:11100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MIN(p.numInStock) AS agg FROM products AS p WHERE categoryId = 21",
+    statement:"SELECT MIN(p.numInStock) AS agg FROM products AS p WHERE categoryId = 21",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT MAX(p.numInStock) AS agg FROM products AS p WHERE categoryId = 21",
+    statement:"SELECT MAX(p.numInStock) AS agg FROM products AS p WHERE categoryId = 21",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT AVG(p.numInStock) AS agg FROM products AS p WHERE categoryId = 21",
+    statement:"SELECT AVG(p.numInStock) AS agg FROM products AS p WHERE categoryId = 21",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          agg:3700.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, COUNT( numInStock) AS agg FROM products GROUP BY supplierId",
+    statement:"SELECT supplierId, COUNT( numInStock) AS agg FROM products GROUP BY supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:3
+        },
+        {
+          supplierId:11,
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, SUM( numInStock) AS agg FROM products GROUP BY supplierId",
+    statement:"SELECT supplierId, SUM( numInStock) AS agg FROM products GROUP BY supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:111
+        },
+        {
+          supplierId:11,
+          agg:11000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, MIN( numInStock) AS agg FROM products GROUP BY supplierId",
+    statement:"SELECT supplierId, MIN( numInStock) AS agg FROM products GROUP BY supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:1
+        },
+        {
+          supplierId:11,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, MAX( numInStock) AS agg FROM products GROUP BY supplierId",
+    statement:"SELECT supplierId, MAX( numInStock) AS agg FROM products GROUP BY supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:100
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, AVG( numInStock) AS agg FROM products GROUP BY supplierId",
+    statement:"SELECT supplierId, AVG( numInStock) AS agg FROM products GROUP BY supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:37.
+        },
+        {
+          supplierId:11,
+          agg:5500.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    statement:"SELECT supplierId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:3
+        },
+        {
+          supplierId:11,
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    statement:"SELECT supplierId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:111
+        },
+        {
+          supplierId:11,
+          agg:11000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    statement:"SELECT supplierId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:1
+        },
+        {
+          supplierId:11,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    statement:"SELECT supplierId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:100
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    statement:"SELECT supplierId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:37.
+        },
+        {
+          supplierId:11,
+          agg:5500.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    statement:"SELECT p.supplierId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:3
+        },
+        {
+          supplierId:11,
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    statement:"SELECT p.supplierId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:111
+        },
+        {
+          supplierId:11,
+          agg:11000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    statement:"SELECT p.supplierId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:1
+        },
+        {
+          supplierId:11,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    statement:"SELECT p.supplierId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:100
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    statement:"SELECT p.supplierId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:37.
+        },
+        {
+          supplierId:11,
+          agg:5500.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT( numInStock) AS agg FROM products GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT( numInStock) AS agg FROM products GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:2
+        },
+        {
+          categoryId:21,
+          agg:3
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, SUM( numInStock) AS agg FROM products GROUP BY categoryId",
+    statement:"SELECT categoryId, SUM( numInStock) AS agg FROM products GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:11
+        },
+        {
+          categoryId:21,
+          agg:11100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, MIN( numInStock) AS agg FROM products GROUP BY categoryId",
+    statement:"SELECT categoryId, MIN( numInStock) AS agg FROM products GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:1
+        },
+        {
+          categoryId:21,
+          agg:100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, MAX( numInStock) AS agg FROM products GROUP BY categoryId",
+    statement:"SELECT categoryId, MAX( numInStock) AS agg FROM products GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, AVG( numInStock) AS agg FROM products GROUP BY categoryId",
+    statement:"SELECT categoryId, AVG( numInStock) AS agg FROM products GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:5.5
+        },
+        {
+          categoryId:21,
+          agg:3700.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    statement:"SELECT categoryId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:2
+        },
+        {
+          categoryId:21,
+          agg:3
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    statement:"SELECT categoryId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:11
+        },
+        {
+          categoryId:21,
+          agg:11100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    statement:"SELECT categoryId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:1
+        },
+        {
+          categoryId:21,
+          agg:100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    statement:"SELECT categoryId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    statement:"SELECT categoryId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:5.5
+        },
+        {
+          categoryId:21,
+          agg:3700.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:2
+        },
+        {
+          categoryId:21,
+          agg:3
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:11
+        },
+        {
+          categoryId:21,
+          agg:11100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:1
+        },
+        {
+          categoryId:21,
+          agg:100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:5.5
+        },
+        {
+          categoryId:21,
+          agg:3700.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, COUNT( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY supplierId",
+    statement:"SELECT supplierId, COUNT( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:2
+        },
+        {
+          supplierId:11,
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, SUM( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY supplierId",
+    statement:"SELECT supplierId, SUM( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:110
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, MIN( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY supplierId",
+    statement:"SELECT supplierId, MIN( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:10
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, MAX( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY supplierId",
+    statement:"SELECT supplierId, MAX( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:100
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, AVG( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY supplierId",
+    statement:"SELECT supplierId, AVG( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:55.
+        },
+        {
+          supplierId:11,
+          agg:10000.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, COUNT(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    statement:"SELECT supplierId, COUNT(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:2
+        },
+        {
+          supplierId:11,
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, SUM(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    statement:"SELECT supplierId, SUM(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:110
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, MIN(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    statement:"SELECT supplierId, MIN(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:10
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, MAX(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    statement:"SELECT supplierId, MAX(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:100
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, AVG(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    statement:"SELECT supplierId, AVG(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:55.
+        },
+        {
+          supplierId:11,
+          agg:10000.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, COUNT(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    statement:"SELECT p.supplierId, COUNT(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:2
+        },
+        {
+          supplierId:11,
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, SUM(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    statement:"SELECT p.supplierId, SUM(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:110
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, MIN(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    statement:"SELECT p.supplierId, MIN(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:10
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, MAX(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    statement:"SELECT p.supplierId, MAX(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:100
+        },
+        {
+          supplierId:11,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, AVG(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    statement:"SELECT p.supplierId, AVG(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.supplierId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          agg:55.
+        },
+        {
+          supplierId:11,
+          agg:10000.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:1
+        },
+        {
+          categoryId:21,
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, SUM( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY categoryId",
+    statement:"SELECT categoryId, SUM( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:10100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, MIN( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY categoryId",
+    statement:"SELECT categoryId, MIN( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, MAX( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY categoryId",
+    statement:"SELECT categoryId, MAX( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, AVG( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY categoryId",
+    statement:"SELECT categoryId, AVG( numInStock) AS agg FROM products WHERE price >= 10 GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10.
+        },
+        {
+          categoryId:21,
+          agg:5050.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    statement:"SELECT categoryId, COUNT(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:1
+        },
+        {
+          categoryId:21,
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, SUM(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    statement:"SELECT categoryId, SUM(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:10100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, MIN(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    statement:"SELECT categoryId, MIN(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, MAX(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    statement:"SELECT categoryId, MAX(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, AVG(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    statement:"SELECT categoryId, AVG(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10.
+        },
+        {
+          categoryId:21,
+          agg:5050.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:1
+        },
+        {
+          categoryId:21,
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, SUM(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, SUM(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:10100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, MIN(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, MIN(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:100
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, MAX(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, MAX(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10
+        },
+        {
+          categoryId:21,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, AVG(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, AVG(p.numInStock) AS agg FROM products AS p WHERE price >= 10 GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          agg:10.
+        },
+        {
+          categoryId:21,
+          agg:5050.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, COUNT( numInStock) AS agg FROM products GROUP BY supplierId, categoryId",
+    statement:"SELECT supplierId, categoryId, COUNT( numInStock) AS agg FROM products GROUP BY supplierId, categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:2
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:1
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, SUM( numInStock) AS agg FROM products GROUP BY supplierId, categoryId",
+    statement:"SELECT supplierId, categoryId, SUM( numInStock) AS agg FROM products GROUP BY supplierId, categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:11
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:11000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, MIN( numInStock) AS agg FROM products GROUP BY supplierId, categoryId",
+    statement:"SELECT supplierId, categoryId, MIN( numInStock) AS agg FROM products GROUP BY supplierId, categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:1
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, MAX( numInStock) AS agg FROM products GROUP BY supplierId, categoryId",
+    statement:"SELECT supplierId, categoryId, MAX( numInStock) AS agg FROM products GROUP BY supplierId, categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:10
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, AVG( numInStock) AS agg FROM products GROUP BY supplierId, categoryId",
+    statement:"SELECT supplierId, categoryId, AVG( numInStock) AS agg FROM products GROUP BY supplierId, categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:5.5
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100.
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:5500.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT supplierId, categoryId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:2
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:1
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT supplierId, categoryId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:11
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:11000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT supplierId, categoryId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:1
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT supplierId, categoryId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:10
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT supplierId, categoryId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:5.5
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100.
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:5500.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, p.categoryId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT p.supplierId, p.categoryId, COUNT(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:2
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:1
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, p.categoryId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT p.supplierId, p.categoryId, SUM(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:11
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:11000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, p.categoryId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT p.supplierId, p.categoryId, MIN(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:1
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, p.categoryId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT p.supplierId, p.categoryId, MAX(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:10
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:10000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, p.categoryId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT p.supplierId, p.categoryId, AVG(p.numInStock) AS agg FROM products AS p GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:5.5
+        },
+        {
+          supplierId:10,
+          categoryId:21,
+          agg:100.
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:5500.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, COUNT( numInStock) AS agg FROM products WHERE price < 15 GROUP BY supplierId, categoryId",
+    statement:"SELECT supplierId, categoryId, COUNT( numInStock) AS agg FROM products WHERE price < 15 GROUP BY supplierId, categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:2
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, SUM( numInStock) AS agg FROM products WHERE price < 15 GROUP BY supplierId, categoryId",
+    statement:"SELECT supplierId, categoryId, SUM( numInStock) AS agg FROM products WHERE price < 15 GROUP BY supplierId, categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:11
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, MIN( numInStock) AS agg FROM products WHERE price < 15 GROUP BY supplierId, categoryId",
+    statement:"SELECT supplierId, categoryId, MIN( numInStock) AS agg FROM products WHERE price < 15 GROUP BY supplierId, categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:1
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, MAX( numInStock) AS agg FROM products WHERE price < 15 GROUP BY supplierId, categoryId",
+    statement:"SELECT supplierId, categoryId, MAX( numInStock) AS agg FROM products WHERE price < 15 GROUP BY supplierId, categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:10
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, AVG( numInStock) AS agg FROM products WHERE price < 15 GROUP BY supplierId, categoryId",
+    statement:"SELECT supplierId, categoryId, AVG( numInStock) AS agg FROM products WHERE price < 15 GROUP BY supplierId, categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:5.5
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, COUNT(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT supplierId, categoryId, COUNT(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:2
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, SUM(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT supplierId, categoryId, SUM(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:11
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, MIN(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT supplierId, categoryId, MIN(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:1
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, MAX(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT supplierId, categoryId, MAX(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:10
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT supplierId, categoryId, AVG(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT supplierId, categoryId, AVG(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:5.5
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, p.categoryId, COUNT(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT p.supplierId, p.categoryId, COUNT(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:2
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, p.categoryId, SUM(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT p.supplierId, p.categoryId, SUM(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:11
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, p.categoryId, MIN(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT p.supplierId, p.categoryId, MIN(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:1
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, p.categoryId, MAX(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT p.supplierId, p.categoryId, MAX(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:10
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.supplierId, p.categoryId, AVG(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    statement:"SELECT p.supplierId, p.categoryId, AVG(p.numInStock) AS agg FROM products AS p WHERE p.price < 15 GROUP BY p.supplierId, p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierId:10,
+          categoryId:20,
+          agg:5.5
+        },
+        {
+          supplierId:11,
+          categoryId:21,
+          agg:1000.
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, COUNT( price_nulls) AS the_agg FROM products_sparse",
+    statement:"SELECT COUNT(1) AS the_count, COUNT( price_nulls) AS the_agg FROM products_sparse",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, SUM( price_nulls) AS the_agg FROM products_sparse",
+    statement:"SELECT COUNT(1) AS the_count, SUM( price_nulls) AS the_agg FROM products_sparse",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:15.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MIN( price_nulls) AS the_agg FROM products_sparse",
+    statement:"SELECT COUNT(1) AS the_count, MIN( price_nulls) AS the_agg FROM products_sparse",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:1.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MAX( price_nulls) AS the_agg FROM products_sparse",
+    statement:"SELECT COUNT(1) AS the_count, MAX( price_nulls) AS the_agg FROM products_sparse",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, AVG( price_nulls) AS the_agg FROM products_sparse",
+    statement:"SELECT COUNT(1) AS the_count, AVG( price_nulls) AS the_agg FROM products_sparse",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:3.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, COUNT( price_missings) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, COUNT( price_missings) AS the_agg FROM products_sparse AS p",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:5
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, SUM( price_missings) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, SUM( price_missings) AS the_agg FROM products_sparse AS p",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:15.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MIN( price_missings) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, MIN( price_missings) AS the_agg FROM products_sparse AS p",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:1.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MAX( price_missings) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, MAX( price_missings) AS the_agg FROM products_sparse AS p",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, AVG( price_missings) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, AVG( price_missings) AS the_agg FROM products_sparse AS p",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:3.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, COUNT( price_mixed) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, COUNT( price_mixed) AS the_agg FROM products_sparse AS p",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:5
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, SUM( price_mixed) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, SUM( price_mixed) AS the_agg FROM products_sparse AS p",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:15.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MIN( price_mixed) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, MIN( price_mixed) AS the_agg FROM products_sparse AS p",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:1.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MAX( price_mixed) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, MAX( price_mixed) AS the_agg FROM products_sparse AS p",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, AVG( price_mixed) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, AVG( price_mixed) AS the_agg FROM products_sparse AS p",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:3.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, COUNT(p.price_nulls) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, COUNT(p.price_nulls) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, SUM(p.price_nulls) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, SUM(p.price_nulls) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:15.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MIN(p.price_nulls) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, MIN(p.price_nulls) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:1.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MAX(p.price_nulls) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, MAX(p.price_nulls) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, AVG(p.price_nulls) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, AVG(p.price_nulls) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:3.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:15.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:1.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:3.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:15.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:1.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p",
+    statement:"SELECT COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count:10,
+          the_agg:3.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, COUNT( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, COUNT( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, SUM( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, SUM( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:6.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:9.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MIN( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MIN( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:1.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MAX( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MAX( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, AVG( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, AVG( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:2.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, COUNT( price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, COUNT( price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:2
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, SUM( price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, SUM( price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:6.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:9.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MIN( price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MIN( price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:1.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MAX( price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MAX( price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, AVG( price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, AVG( price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:2.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.5
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, COUNT( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, COUNT( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:2
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, SUM( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, SUM( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:6.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:9.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MIN( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MIN( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:1.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MAX( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MAX( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, AVG( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, AVG( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:2.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.5
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, COUNT(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, COUNT(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, SUM(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, SUM(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:6.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:9.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MIN(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MIN(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:1.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MAX(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MAX(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, AVG(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, AVG(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:2.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:6.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:9.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:1.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:2.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:6.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:9.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:1.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT categoryId, COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    statement:"SELECT categoryId, COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:2.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, SUM( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, SUM( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:6.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:9.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MIN( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MIN( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:1.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MAX( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MAX( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, AVG( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, AVG( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:2.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT( price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT( price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:2
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, SUM( price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, SUM( price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:6.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:9.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MIN( price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MIN( price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:1.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MAX( price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MAX( price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, AVG( price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, AVG( price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:2.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.5
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:2
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, SUM( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, SUM( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:6.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:9.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MIN( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MIN( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:1.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MAX( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MAX( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, AVG( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, AVG( price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:2.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.5
+          }
+        ]
+      },
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+    ]
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, SUM(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, SUM(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:6.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:9.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MIN(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MIN(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:1.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MAX(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MAX(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, AVG(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, AVG(p.price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:2.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:6.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:9.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:1.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:2.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:2
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:6.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:9.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:1.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:3.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:5.0
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT p.categoryId, COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    statement:"SELECT p.categoryId, COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          categoryId:20,
+          the_count:4,
+          the_agg:2.0
+        },
+        {
+          categoryId:21,
+          the_count:6,
+          the_agg:4.5
+        }
+      ]
+    }
+  },
+]
+
+'group-by-aggregates'::[
+  envs::{
+    simple_1_col_1_group: [
+      {
+        col1:1
+      },
+      {
+        col1:1
+      }
+    ],
+    employees: [
+       { name: 'Joey', age: 25, manager: { name: 'John', address: { city: 'Seattle' } } },
+       { name: 'Chandler', age: 27, manager: { name: 'Rocky', address: { city: 'Seattle' } } },
+       { name: 'Ross', age: 22, manager: { 'name': 'Alex', address: { city: 'Chicago' } } }
+    ],
+    simple_1_col_1_group_2: [
+      { col1: 1 },
+      { col1: 5 }
+    ],
+    products: [
+      { productId: 1, supplierId: 10, categoryId: 20, price: 5.0,  numInStock: 1 },
+      { productId: 2, supplierId: 10, categoryId: 20, price: 10.0, numInStock: 10 },
+      { productId: 3, supplierId: 10, categoryId: 21, price: 15.0, numInStock: 100 },
+      { productId: 4, supplierId: 11, categoryId: 21, price: 5.0,  numInStock: 1000 },
+      { productId: 5, supplierId: 11, categoryId: 21, price: 15.0, numInStock: 10000 }
+    ],
+    suppliers: [
+      { supplierId: 10, supplierName: "Umbrella" },
+      { supplierId: 11, supplierName: "Initech" }
+    ]
+  },
+  {
+    name:"aggregates when used with empty from source : SELECT COUNT(doesntMatterWontBeEvaluated), SUM(doesntMatterWontBeEvaluated), MIN(doesntMatterWontBeEvaluated), MAX(doesntMatterWontBeEvaluated), AVG(doesntMatterWontBeEvaluated) FROM []",
+    statement:"SELECT COUNT(doesntMatterWontBeEvaluated), SUM(doesntMatterWontBeEvaluated), MIN(doesntMatterWontBeEvaluated), MAX(doesntMatterWontBeEvaluated), AVG(doesntMatterWontBeEvaluated) FROM []",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          _1:0,
+          _2:null,
+          _3:null,
+          _4:null,
+          _5:null
+        }
+      ]
+    }
+  },
+  {
+    name:"Expression with multiple subqueriees containing aggregates : CAST((SELECT COUNT(1) FROM products) AS LIST)[0]._1 / CAST((SELECT COUNT(1) FROM suppliers) AS LIST)[0]._1",
+    statement:"CAST((SELECT COUNT(1) FROM products) AS LIST)[0]._1 / CAST((SELECT COUNT(1) FROM suppliers) AS LIST)[0]._1",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:2
+    }
+  },
+  {
+    name:"Aggregates with subquery containing another aggregate : SELECT COUNT(1) + CAST((SELECT SUM(numInStock) FROM products) AS LIST)[0]._1 as a_number FROM products",
+    statement:"SELECT COUNT(1) + CAST((SELECT SUM(numInStock) FROM products) AS LIST)[0]._1 as a_number FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          a_number:11116
+        }
+      ]
+    }
+  },
+  {
+    name:"GROUP BY with JOIN : SELECT supplierName, COUNT(*) as the_count FROM suppliers AS s INNER JOIN products AS p ON s.supplierId = p.supplierId GROUP BY supplierName",
+    statement:"SELECT supplierName, COUNT(*) as the_count FROM suppliers AS s INNER JOIN products AS p ON s.supplierId = p.supplierId GROUP BY supplierName",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          supplierName:"Umbrella",
+          the_count:3
+        },
+        {
+          supplierName:"Initech",
+          the_count:2
+        }
+      ]
+    }
+  },
+  {
+    name:"`COUNT(*)`, should be equivalent to `COUNT(1) : SELECT COUNT(*) AS the_count_1, COUNT(1) AS the_count_2 FROM products",
+    statement:"SELECT COUNT(*) AS the_count_1, COUNT(1) AS the_count_2 FROM products",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          the_count_1:5,
+          the_count_2:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE with nested aggregates : SELECT VALUE (SELECT SUM(outerFromSource.col1) AS the_sum FROM <<1>>) FROM simple_1_col_1_group as outerFromSource",
+    statement:"SELECT VALUE (SELECT SUM(outerFromSource.col1) AS the_sum FROM <<1>>) FROM simple_1_col_1_group as outerFromSource",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        $bag::[
+          {
+            the_sum:1
+          }
+        ],
+        $bag::[
+          {
+            the_sum:1
+          }
+        ]
+      ]
+    }
+  },
+  {
+    name:"SELECT with GROUP BY path expression having more than 1 component. : SELECT avg(age) as avg_employee_age, manager.address.city FROM employees GROUP BY manager.address.city",
+    statement:"SELECT avg(age) as avg_employee_age, manager.address.city FROM employees GROUP BY manager.address.city",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          avg_employee_age:22.,
+          city:Chicago
+        },
+        {
+          avg_employee_age:26.,
+          city:Seattle
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT with nested aggregates (complex) : SELECT i2 AS outerKey, g2 AS outerGroupAs, COUNT(*) AS outerCount, SUM(innerQuery.innerSum) AS outerSum, MIN(innerQuery.innerSum) AS outerMin FROM ( SELECT i, g, SUM(col1) AS innerSum FROM simple_1_col_1_group_2 AS innerFromSource GROUP BY col1 AS i GROUP AS g ) AS innerQuery GROUP BY innerQuery.i AS i2, innerQuery.g AS g2",
+    statement:"SELECT i2 AS outerKey, g2 AS outerGroupAs, COUNT(*) AS outerCount, SUM(innerQuery.innerSum) AS outerSum, MIN(innerQuery.innerSum) AS outerMin FROM ( SELECT i, g, SUM(col1) AS innerSum FROM simple_1_col_1_group_2 AS innerFromSource GROUP BY col1 AS i GROUP AS g ) AS innerQuery GROUP BY innerQuery.i AS i2, innerQuery.g AS g2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          outerKey:1,
+          outerGroupAs:$bag::[
+            {
+              innerFromSource:{
+                col1:1
+              }
+            }
+          ],
+          outerCount:1,
+          outerSum:1,
+          outerMin:1
+        },
+        {
+          outerKey:5,
+          outerGroupAs:$bag::[
+            {
+              innerFromSource:{
+                col1:5
+              }
+            }
+          ],
+          outerCount:1,
+          outerSum:5,
+          outerMin:5
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT with nested aggregates (complex)",
+    statement:"SELECT i2 AS outerKey, g2 AS outerGroupAs, MIN(innerQuery.innerSum) AS outerMin, ( SELECT VALUE SUM(i2) FROM << 0, 1 >> ) AS projListSubQuery FROM ( SELECT i, g, SUM(col1) AS innerSum FROM simple_1_col_1_group_2 AS innerFromSource GROUP BY col1 AS i GROUP AS g ) AS innerQuery GROUP BY innerQuery.i AS i2, innerQuery.g AS g2",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          outerKey:1,
+          outerGroupAs:$bag::[
+            {
+              innerFromSource:{
+                col1:1
+              }
+            }
+          ],
+          outerMin:1,
+          projListSubQuery:$bag::[
+            2
+          ]
+        },
+        {
+          outerKey:5,
+          outerGroupAs:$bag::[
+            {
+              innerFromSource:{
+                col1:5
+              }
+            }
+          ],
+          outerMin:5,
+          projListSubQuery:$bag::[
+            10
+          ]
+        }
+      ]
+    }
+  }
+]
+
+'group-by-group-as'::[
+  envs::{
+    simple_1_col_1_group: [
+      {
+        col1: 1
+      },
+      {
+        col1: 1
+      }
+    ],
+    simple_2_col_1_group: [
+      {
+        col1: 1,
+        col2: 10
+      },
+      {
+        col1: 1,
+        col2: 10
+      }
+    ],
+    simple_1_col_2_groups:[
+      {
+        col1:1
+      },
+      {
+        col1:1
+      },
+      {
+        col1:2
+      },
+      {
+        col1:2
+      }
+    ],
+    simple_2_col_2_groups: [
+      {
+        col1: 1,
+        col2: 10
+      },
+      {
+        col1: 11,
+        col2: 110
+      },
+      {
+        col1: 1,
+        col2: 10
+      },
+      {
+        col1: 11,
+        col2: 110
+      }
+    ],
+    join_me: [
+      { 'foo': 20 }, { 'foo': 30 }
+    ],
+    different_types_per_row: [
+      { 'a': 1001 },
+      1002.0,
+      'one-thousand and three'
+    ]
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group GROUP BY col1 GROUP AS g",
+    statement:"SELECT * FROM simple_1_col_1_group GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_1_group:{
+                col1:1
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col1, g FROM simple_1_col_1_group GROUP BY col1 GROUP AS g",
+    statement:"SELECT col1, g FROM simple_1_col_1_group GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_1_group:{
+                col1:1
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group GROUP BY col1 GROUP AS g",
+    statement:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_1_group:{
+                col1:1
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col1 GROUP AS g",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col1, g FROM simple_2_col_1_group GROUP BY col1 GROUP AS g",
+    statement:"SELECT col1, g FROM simple_2_col_1_group GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_2_col_1_group GROUP BY col1 GROUP AS g",
+    statement:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_2_col_1_group GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_1_group GROUP BY col2 GROUP AS g",
+    statement:"SELECT * FROM simple_2_col_1_group GROUP BY col2 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10,
+          g:$bag::[
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col2, g FROM simple_2_col_1_group GROUP BY col2 GROUP AS g",
+    statement:"SELECT col2, g FROM simple_2_col_1_group GROUP BY col2 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10,
+          g:$bag::[
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col2': col2, 'g': g } FROM simple_2_col_1_group GROUP BY col2 GROUP AS g",
+    statement:"SELECT VALUE { 'col2': col2, 'g': g } FROM simple_2_col_1_group GROUP BY col2 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10,
+          g:$bag::[
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_1_group:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_2_groups GROUP BY col1 GROUP AS g",
+    statement:"SELECT * FROM simple_1_col_2_groups GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_2_groups:{
+                col1:1
+              }
+            },
+            {
+              simple_1_col_2_groups:{
+                col1:1
+              }
+            }
+          ]
+        },
+        {
+          col1:2,
+          g:$bag::[
+            {
+              simple_1_col_2_groups:{
+                col1:2
+              }
+            },
+            {
+              simple_1_col_2_groups:{
+                col1:2
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col1, g FROM simple_1_col_2_groups GROUP BY col1 GROUP AS g",
+    statement:"SELECT col1, g FROM simple_1_col_2_groups GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_2_groups:{
+                col1:1
+              }
+            },
+            {
+              simple_1_col_2_groups:{
+                col1:1
+              }
+            }
+          ]
+        },
+        {
+          col1:2,
+          g:$bag::[
+            {
+              simple_1_col_2_groups:{
+                col1:2
+              }
+            },
+            {
+              simple_1_col_2_groups:{
+                col1:2
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_2_groups GROUP BY col1 GROUP AS g",
+    statement:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_2_groups GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_2_groups:{
+                col1:1
+              }
+            },
+            {
+              simple_1_col_2_groups:{
+                col1:1
+              }
+            }
+          ]
+        },
+        {
+          col1:2,
+          g:$bag::[
+            {
+              simple_1_col_2_groups:{
+                col1:2
+              }
+            },
+            {
+              simple_1_col_2_groups:{
+                col1:2
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col1 GROUP AS g",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        },
+        {
+          col1:11,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col1, g FROM simple_2_col_2_groups GROUP BY col1 GROUP AS g",
+    statement:"SELECT col1, g FROM simple_2_col_2_groups GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        },
+        {
+          col1:11,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_2_col_2_groups GROUP BY col1 GROUP AS g",
+    statement:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_2_col_2_groups GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        },
+        {
+          col1:11,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_2_col_2_groups GROUP BY col2 GROUP AS g",
+    statement:"SELECT * FROM simple_2_col_2_groups GROUP BY col2 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        },
+        {
+          col2:110,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col2, g FROM simple_2_col_2_groups GROUP BY col2 GROUP AS g",
+    statement:"SELECT col2, g FROM simple_2_col_2_groups GROUP BY col2 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        },
+        {
+          col2:110,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col2': col2, 'g': g } FROM simple_2_col_2_groups GROUP BY col2 GROUP AS g",
+    statement:"SELECT VALUE { 'col2': col2, 'g': g } FROM simple_2_col_2_groups GROUP BY col2 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col2:10,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:1,
+                col2:10
+              }
+            }
+          ]
+        },
+        {
+          col2:110,
+          g:$bag::[
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            },
+            {
+              simple_2_col_2_groups:{
+                col1:11,
+                col2:110
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group, join_me GROUP BY col1 GROUP AS g",
+    statement:"SELECT * FROM simple_1_col_1_group, join_me GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:20
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:30
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:20
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:30
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col1, g FROM simple_1_col_1_group, join_me GROUP BY col1 GROUP AS g",
+    statement:"SELECT col1, g FROM simple_1_col_1_group, join_me GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:20
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:30
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:20
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:30
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, join_me GROUP BY col1 GROUP AS g",
+    statement:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, join_me GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:20
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:30
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:20
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              join_me:{
+                foo:30
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT * FROM simple_1_col_1_group, different_types_per_row GROUP BY col1 GROUP AS g",
+    statement:"SELECT * FROM simple_1_col_1_group, different_types_per_row GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:{
+                a:1001
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:1002.0
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:'one-thousand and three'
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:{
+                a:1001
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:1002.0
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:'one-thousand and three'
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT col1, g FROM simple_1_col_1_group, different_types_per_row GROUP BY col1 GROUP AS g",
+    statement:"SELECT col1, g FROM simple_1_col_1_group, different_types_per_row GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:{
+                a:1001
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:1002.0
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:'one-thousand and three'
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:{
+                a:1001
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:1002.0
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:'one-thousand and three'
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, different_types_per_row GROUP BY col1 GROUP AS g",
+    statement:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, different_types_per_row GROUP BY col1 GROUP AS g",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$bag::[
+        {
+          col1:1,
+          g:$bag::[
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:{
+                a:1001
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:1002.0
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:'one-thousand and three'
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:{
+                a:1001
+              }
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:1002.0
+            },
+            {
+              simple_1_col_1_group:{
+                col1:1
+              },
+              different_types_per_row:'one-thousand and three'
+            }
+          ]
+        }
+      ]
+    }
+  },
+]


### PR DESCRIPTION
Addresses https://github.com/partiql/partiql-tests/issues/59.

Ports more `GROUP BY` tests from partiql-lang-kotlin which were not part of the previously ported tests. This PR (in its current state) ports most of the tests from `EvaluatingCompilerGroupByTest.kt`. There still remains some tests that haven't been ported (see [EvaluatingCompilerGroupByTest.kt#L1195-L1400](https://github.com/partiql/partiql-lang-kotlin/blob/main/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerGroupByTest.kt#L1195-L1400)).

Putting this out as I'll be away for at least a couple weeks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.