### PR TITLE
Fix unterminated strings in `MOD` tests

### DIFF
--- a/partiql-tests-data/eval/primitives/functions/mod.ion
+++ b/partiql-tests-data/eval/primitives/functions/mod.ion
@@ -180,8 +180,8 @@ mod::[
     }
   },
   {
-    name:"MOD('some string, MISSING)",
-    statement:"MOD('some string, MISSING)",
+    name:"MOD('some string', MISSING)",
+    statement:"MOD('some string', MISSING)",
     assert:{
       result:EvaluationSuccess,
       evalMode:[
@@ -204,8 +204,8 @@ mod::[
     }
   },
   {
-    name:"MOD('some string, NULL)",
-    statement:"MOD('some string, NULL)",
+    name:"MOD('some string', NULL)",
+    statement:"MOD('some string', NULL)",
     assert:{
       result:EvaluationSuccess,
       evalMode:[


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.