### PR TITLE
Ports `text_replace` tests to `partiql-tests` and adds null/missing/mistyped argument tests

### DIFF
--- a/partiql-tests-data-extended/eval/primitives/functions/text_replace.ion
+++ b/partiql-tests-data-extended/eval/primitives/functions/text_replace.ion
@@ -1,0 +1,120 @@
+// Adding `text_replace` tests in the "extended" folder since the function name is not part of any SQL spec
+text_replace::[
+  {
+    name:"text_replace('abcdefabcdef', 'cd', 'XX')",
+    statement:"text_replace('abcdefabcdef', 'cd', 'XX')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"abXXefabXXef"
+    }
+  },
+  {
+    name:"text_replace('abcdefabcdef', 'xyz', 'XX')",
+    statement:"text_replace('abcdefabcdef', 'xyz', 'XX')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"abcdefabcdef"
+    }
+  },
+  {
+    name:"text_replace('abcdefabcdef', 'defab', '')",
+    statement:"text_replace('abcdefabcdef', 'defab', '')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"abccdef"
+    }
+  },
+  {
+    name:"text_replace('abcabcabcdef', 'abcabc', 'XXX')",
+    statement:"text_replace('abcabcabcdef', 'abcabc', 'XXX')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"XXXabcdef"
+    }
+  },
+  {
+    name:"text_replace('abcabcabcdef', '', 'X')",
+    statement:"text_replace('abcabcabcdef', '', 'X')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"XaXbXcXaXbXcXaXbXcXdXeXfX"
+    }
+  },
+  {
+    name:"text_replace('', 'abc', 'XX')",
+    statement:"text_replace('', 'abc', 'XX')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:""
+    }
+  },
+  {
+    name:"text_replace('', '', 'XX')",
+    statement:"text_replace('', '', 'XX')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"XX"
+    }
+  },
+  {
+    name:"text_replace('abcdefabcdef', 'def', '😁😞')",
+    statement:"text_replace('abcdefabcdef', 'def', '😁😞')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"abc😁😞abc😁😞"
+    }
+  },
+  {
+    name:"text_replace('abc😁😞abc😁😞', '😁😞', 'def')",
+    statement:"text_replace('abc😁😞abc😁😞', '😁😞', 'def')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"abcdefabcdef"
+    }
+  },
+  {
+    name:"text_replace('abcdefabcdef', 'def', 'd😁😞')",
+    statement:"text_replace('abcdefabcdef', 'def', 'd😁😞')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"abcd😁😞abcd😁😞"
+    }
+  },
+  {
+    name:"text_replace('abcdefabcdef', 'def', 'deࠫf')",
+    statement:"text_replace('abcdefabcdef', 'def', 'deࠫf')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"abcdeࠫfabcdeࠫf"
+    }
+  },
+  {
+    name:"text_replace('abcdeࠫfabcdeࠫf', 'def', 'XX')",
+    statement:"text_replace('abcdeࠫfabcdeࠫf', 'def', 'XX')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"abcdeࠫfabcdeࠫf"
+    }
+  },
+  {
+    name:"text_replace('abcdeࠫfabcdeࠫf', 'deࠫf', 'XX')",
+    statement:"text_replace('abcdeࠫfabcdeࠫf', 'deࠫf', 'XX')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:"abcXXabcXX"
+    }
+  },
+]

--- a/partiql-tests-data-extended/eval/primitives/functions/text_replace.ion
+++ b/partiql-tests-data-extended/eval/primitives/functions/text_replace.ion
@@ -117,4 +117,112 @@ text_replace::[
       output:"abcXXabcXX"
     }
   },
+  {
+    name:"text_replace NULL first arg",
+    statement:"text_replace(NULL, 'foo', 'bar')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:null
+    }
+  },
+  {
+    name:"text_replace NULL second arg",
+    statement:"text_replace('foo', NULL, 'bar')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:null
+    }
+  },
+  {
+    name:"text_replace NULL third arg",
+    statement:"text_replace('foo', 'bar', NULL)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:null
+    }
+  },
+  {
+    name:"text_replace MISSING first arg",
+    statement:"text_replace(MISSING, 'foo', 'bar')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:$missing::null
+    }
+  },
+  {
+    name:"text_replace MISSING second arg",
+    statement:"text_replace('foo', MISSING, 'bar')",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:$missing::null
+    }
+  },
+  {
+    name:"text_replace MISSING third arg",
+    statement:"text_replace('foo', 'bar', MISSING)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:$missing::null
+    }
+  },
+  {
+    name:"text_replace NULL and MISSING arg",
+    statement:"text_replace(NULL, 'foo', MISSING)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[EvalModeCoerce, EvalModeError],
+      output:$missing::null
+    }
+  },
+  {
+    name:"text_replace mistyped first argument",
+    statement:"text_replace(1, 'foo', 'bar')",
+    assert:[
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$missing::null
+      }
+    ]
+  },
+  {
+    name:"text_replace mistyped second argument",
+    statement:"text_replace('foo', 1, 'bar')",
+    assert:[
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$missing::null
+      }
+    ]
+  },
+  {
+    name:"text_replace mistyped third argument",
+    statement:"text_replace('foo', 'bar', 1)",
+    assert:[
+      {
+        result:EvaluationFail,
+        evalMode: EvalModeError,
+      },
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$missing::null
+      }
+    ]
+  },
 ]


### PR DESCRIPTION
Closes #78.

Ports the `text_replace` tests to `partiql-tests`. Also adds null/missing propagation tests and mistyped argument tests.

These tests are ported under the "extended" directory because the name isn't part of any SQL spec I could find. It appears most other SQL databases (e.g. postgresql, mysql, sqlite, oracle) use the name `REPLACE`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.