### PR TITLE
Adjusts `EXTRACT` tests to assert on result in statement

### DIFF
--- a/partiql-tests-data/eval/primitives/functions/extract.ion
+++ b/partiql-tests-data/eval/primitives/functions/extract.ion
@@ -1,626 +1,725 @@
 extract::[
+  extract_null_propagation::[
+    {
+      name:"EXTRACT(YEAR FROM NULL)",
+      statement:"EXTRACT(YEAR FROM NULL)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:null
+      }
+    },
+    {
+      name:"EXTRACT(MONTH FROM NULL)",
+      statement:"EXTRACT(MONTH FROM NULL)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:null
+      }
+    },
+    {
+      name:"EXTRACT(DAY FROM NULL)",
+      statement:"EXTRACT(DAY FROM NULL)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:null
+      }
+    },
+    {
+      name:"EXTRACT(HOUR FROM NULL)",
+      statement:"EXTRACT(HOUR FROM NULL)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:null
+      }
+    },
+    {
+      name:"EXTRACT(MINUTE FROM NULL)",
+      statement:"EXTRACT(MINUTE FROM NULL)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:null
+      }
+    },
+    {
+      name:"EXTRACT(SECOND FROM NULL)",
+      statement:"EXTRACT(SECOND FROM NULL)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:null
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_HOUR FROM NULL)",
+      statement:"EXTRACT(TIMEZONE_HOUR FROM NULL)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:null
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_MINUTE FROM NULL)",
+      statement:"EXTRACT(TIMEZONE_MINUTE FROM NULL)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:null
+      }
+    },
+  ],
+  missing_propagation::[
+    {
+      name:"EXTRACT(YEAR FROM MISSING)",
+      statement:"EXTRACT(YEAR FROM MISSING)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:$missing::null
+      }
+    },
+    {
+      name:"EXTRACT(MONTH FROM MISSING)",
+      statement:"EXTRACT(MONTH FROM MISSING)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:$missing::null
+      }
+    },
+    {
+      name:"EXTRACT(DAY FROM MISSING)",
+      statement:"EXTRACT(DAY FROM MISSING)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:$missing::null
+      }
+    },
+    {
+      name:"EXTRACT(HOUR FROM MISSING)",
+      statement:"EXTRACT(HOUR FROM MISSING)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:$missing::null
+      }
+    },
+    {
+      name:"EXTRACT(MINUTE FROM MISSING)",
+      statement:"EXTRACT(MINUTE FROM MISSING)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:$missing::null
+      }
+    },
+    {
+      name:"EXTRACT(SECOND FROM MISSING)",
+      statement:"EXTRACT(SECOND FROM MISSING)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:$missing::null
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_HOUR FROM MISSING)",
+      statement:"EXTRACT(TIMEZONE_HOUR FROM MISSING)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:$missing::null
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_MINUTE FROM MISSING)",
+      statement:"EXTRACT(TIMEZONE_MINUTE FROM MISSING)",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:$missing::null
+      }
+    },
+  ],
+  extract_date::[
+    {
+      name:"EXTRACT(YEAR FROM DATE '2000-01-02')",
+      statement:"EXTRACT(YEAR FROM DATE '2000-01-02') = 2000",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MONTH FROM DATE '2000-01-02')",
+      statement:"EXTRACT(MONTH FROM DATE '2000-01-02') = 1",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(DAY FROM DATE '2000-01-02')",
+      statement:"EXTRACT(DAY FROM DATE '2000-01-02') = 2",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+  ],
+  extract_time::[
+    {
+      name:"EXTRACT(HOUR FROM TIME '01:23:45.678')",
+      statement:"EXTRACT(HOUR FROM TIME '01:23:45.678') = 1",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MINUTE FROM TIME '01:23:45.678')",
+      statement:"EXTRACT(MINUTE FROM TIME '01:23:45.678') = 23",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(SECOND FROM TIME '01:23:45.678')",
+      statement:"EXTRACT(SECOND FROM TIME '01:23:45.678') = 45.678",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+  ],
+  extract_time_precision::[
+    {
+      name:"EXTRACT(HOUR FROM TIME (2) '01:23:45.678')",
+      statement:"EXTRACT(HOUR FROM TIME (2) '01:23:45.678') = 1",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MINUTE FROM TIME (2) '01:23:45.678')",
+      statement:"EXTRACT(MINUTE FROM TIME (2) '01:23:45.678') = 23",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(SECOND FROM TIME (2) '01:23:45.678')",
+      statement:"EXTRACT(SECOND FROM TIME (2) '01:23:45.678') = 45.68",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+  ],
+  extract_time_with_time_zone::[
+    {
+      name:"EXTRACT(HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+      statement:"EXTRACT(HOUR FROM TIME WITH TIME ZONE '01:23:45.678') = 1",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+      statement:"EXTRACT(MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = 23",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(SECOND FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+      statement:"EXTRACT(SECOND FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = 45.678",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+      statement:"EXTRACT(TIMEZONE_HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = -6",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+      statement:"EXTRACT(TIMEZONE_MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = -30",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+  ],
+  extract_time_precision_with_time_zone::[
+    {
+      name:"EXTRACT(HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
+      statement:"EXTRACT(HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678') = 1",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
+      statement:"EXTRACT(MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = 23",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(SECOND FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
+      statement:"EXTRACT(SECOND FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = 45.68",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
+      statement:"EXTRACT(TIMEZONE_HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = -6",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
+      statement:"EXTRACT(TIMEZONE_MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = -30",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+  ],
+  extract_timestamp::[
+    {
+      name:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67Z`)",
+      statement:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67Z`) = 2000",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MONTH FROM `2000-01-02T03:04:05.67Z`)",
+      statement:"EXTRACT(MONTH FROM `2000-01-02T03:04:05.67Z`) = 1",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(DAY FROM `2000-01-02T03:04:05.67Z`)",
+      statement:"EXTRACT(DAY FROM `2000-01-02T03:04:05.67Z`) = 2",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(HOUR FROM `2000-01-02T03:04:05.67Z`)",
+      statement:"EXTRACT(HOUR FROM `2000-01-02T03:04:05.67Z`) = 3",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67Z`)",
+      statement:"EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67Z`) = 4",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(SECOND FROM `2000-01-02T03:04:05.67Z`)",
+      statement:"EXTRACT(SECOND FROM `2000-01-02T03:04:05.67Z`) = 5.67",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+  ],
+  extract_timestamp_offset::[
+    {
+      name:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67+08:09`) = 2000",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MONTH FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement:"EXTRACT(MONTH FROM `2000-01-02T03:04:05.67+08:09`) = 1",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(DAY FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement:"EXTRACT(DAY FROM `2000-01-02T03:04:05.67+08:09`) = 2",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(HOUR FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement:"EXTRACT(HOUR FROM `2000-01-02T03:04:05.67+08:09`) = 3",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement:"EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67+08:09`) = 4",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(SECOND FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement:"EXTRACT(SECOND FROM `2000-01-02T03:04:05.67+08:09`) = 5.67",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement:"EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67+08:09`) = 8",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67+08:09`) = 9",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67-08:09`)",
+      statement:"EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67-08:09`) = -8",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67-08:09`)",
+      statement:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67-08:09`) = -9",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+  ]
+]
+
+extract_invalid::[
   {
-    name:"extract valid cases{result:2017.,time_part:\"year\",timestamp:\"2017T\"}",
-    statement:"extract(year from `2017T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:2017.
-    }
+    name:"invalid extract year from time",
+    statement:"EXTRACT(YEAR FROM TIME '01:23:45.678')",
+    assert:[
+      {
+        result:EvaluationFail,
+        evalMode:EvalModeError
+      },
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$missing::null
+      }
+    ]
   },
   {
-    name:"extract valid cases{result:1.,time_part:\"month\",timestamp:\"2017T\"}",
-    statement:"extract(month from `2017T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:1.
-    }
+    name:"invalid extract month from time",
+    statement:"EXTRACT(MONTH FROM TIME '01:23:45.678')",
+    assert:[
+      {
+        result:EvaluationFail,
+        evalMode:EvalModeError
+      },
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$missing::null
+      }
+    ]
   },
   {
-    name:"extract valid cases{result:1.,time_part:\"day\",timestamp:\"2017T\"}",
-    statement:"extract(day from `2017T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:1.
-    }
+    name:"invalid extract day from time",
+    statement:"EXTRACT(DAY FROM TIME '01:23:45.678')",
+    assert:[
+      {
+        result:EvaluationFail,
+        evalMode:EvalModeError
+      },
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$missing::null
+      }
+    ]
   },
   {
-    name:"extract valid cases{result:0.,time_part:\"hour\",timestamp:\"2017T\"}",
-    statement:"extract(hour from `2017T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
+    name:"invalid extract year from time",
+    statement:"EXTRACT(YEAR FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+    assert:[
+      {
+        result:EvaluationFail,
+        evalMode:EvalModeError
+      },
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$missing::null
+      }
+    ]
   },
   {
-    name:"extract valid cases{result:0.,time_part:\"minute\",timestamp:\"2017T\"}",
-    statement:"extract(minute from `2017T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
+    name:"invalid extract month from time with time zone",
+    statement:"EXTRACT(MONTH FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+    assert:[
+      {
+        result:EvaluationFail,
+        evalMode:EvalModeError
+      },
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$missing::null
+      }
+    ]
   },
   {
-    name:"extract valid cases{result:0.,time_part:\"second\",timestamp:\"2017T\"}",
-    statement:"extract(second from `2017T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"timezone_hour\",timestamp:\"2017T\"}",
-    statement:"extract(timezone_hour from `2017T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"timezone_minute\",timestamp:\"2017T\"}",
-    statement:"extract(timezone_minute from `2017T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:2017.,time_part:\"year\",timestamp:\"2017-01T\"}",
-    statement:"extract(year from `2017-01T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:2017.
-    }
-  },
-  {
-    name:"extract valid cases{result:1.,time_part:\"month\",timestamp:\"2017-01T\"}",
-    statement:"extract(month from `2017-01T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:1.
-    }
-  },
-  {
-    name:"extract valid cases{result:1.,time_part:\"day\",timestamp:\"2017-01T\"}",
-    statement:"extract(day from `2017-01T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:1.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"hour\",timestamp:\"2017-01T\"}",
-    statement:"extract(hour from `2017-01T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"minute\",timestamp:\"2017-01T\"}",
-    statement:"extract(minute from `2017-01T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"second\",timestamp:\"2017-01T\"}",
-    statement:"extract(second from `2017-01T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"timezone_hour\",timestamp:\"2017-01T\"}",
-    statement:"extract(timezone_hour from `2017-01T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"timezone_minute\",timestamp:\"2017-01T\"}",
-    statement:"extract(timezone_minute from `2017-01T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:2017.,time_part:\"year\",timestamp:\"2017-01-02T\"}",
-    statement:"extract(year from `2017-01-02T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:2017.
-    }
-  },
-  {
-    name:"extract valid cases{result:1.,time_part:\"month\",timestamp:\"2017-01-02T\"}",
-    statement:"extract(month from `2017-01-02T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:1.
-    }
-  },
-  {
-    name:"extract valid cases{result:2.,time_part:\"day\",timestamp:\"2017-01-02T\"}",
-    statement:"extract(day from `2017-01-02T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:2.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"hour\",timestamp:\"2017-01-02T\"}",
-    statement:"extract(hour from `2017-01-02T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"minute\",timestamp:\"2017-01-02T\"}",
-    statement:"extract(minute from `2017-01-02T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"second\",timestamp:\"2017-01-02T\"}",
-    statement:"extract(second from `2017-01-02T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"timezone_hour\",timestamp:\"2017-01-02T\"}",
-    statement:"extract(timezone_hour from `2017-01-02T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"timezone_minute\",timestamp:\"2017-01-02T\"}",
-    statement:"extract(timezone_minute from `2017-01-02T`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:2017.,time_part:\"year\",timestamp:\"2017-01-02T03:04Z\"}",
-    statement:"extract(year from `2017-01-02T03:04Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:2017.
-    }
-  },
-  {
-    name:"extract valid cases{result:1.,time_part:\"month\",timestamp:\"2017-01-02T03:04Z\"}",
-    statement:"extract(month from `2017-01-02T03:04Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:1.
-    }
-  },
-  {
-    name:"extract valid cases{result:2.,time_part:\"day\",timestamp:\"2017-01-02T03:04Z\"}",
-    statement:"extract(day from `2017-01-02T03:04Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:2.
-    }
-  },
-  {
-    name:"extract valid cases{result:3.,time_part:\"hour\",timestamp:\"2017-01-02T03:04Z\"}",
-    statement:"extract(hour from `2017-01-02T03:04Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:3.
-    }
-  },
-  {
-    name:"extract valid cases{result:4.,time_part:\"minute\",timestamp:\"2017-01-02T03:04Z\"}",
-    statement:"extract(minute from `2017-01-02T03:04Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:4.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"second\",timestamp:\"2017-01-02T03:04Z\"}",
-    statement:"extract(second from `2017-01-02T03:04Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"timezone_hour\",timestamp:\"2017-01-02T03:04Z\"}",
-    statement:"extract(timezone_hour from `2017-01-02T03:04Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"timezone_minute\",timestamp:\"2017-01-02T03:04Z\"}",
-    statement:"extract(timezone_minute from `2017-01-02T03:04Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:2017.,time_part:\"year\",timestamp:\"2017-01-02T03:04:05Z\"}",
-    statement:"extract(year from `2017-01-02T03:04:05Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:2017.
-    }
-  },
-  {
-    name:"extract valid cases{result:1.,time_part:\"month\",timestamp:\"2017-01-02T03:04:05Z\"}",
-    statement:"extract(month from `2017-01-02T03:04:05Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:1.
-    }
-  },
-  {
-    name:"extract valid cases{result:2.,time_part:\"day\",timestamp:\"2017-01-02T03:04:05Z\"}",
-    statement:"extract(day from `2017-01-02T03:04:05Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:2.
-    }
-  },
-  {
-    name:"extract valid cases{result:3.,time_part:\"hour\",timestamp:\"2017-01-02T03:04:05Z\"}",
-    statement:"extract(hour from `2017-01-02T03:04:05Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:3.
-    }
-  },
-  {
-    name:"extract valid cases{result:4.,time_part:\"minute\",timestamp:\"2017-01-02T03:04:05Z\"}",
-    statement:"extract(minute from `2017-01-02T03:04:05Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:4.
-    }
-  },
-  {
-    name:"extract valid cases{result:5.,time_part:\"second\",timestamp:\"2017-01-02T03:04:05Z\"}",
-    statement:"extract(second from `2017-01-02T03:04:05Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:5.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"timezone_hour\",timestamp:\"2017-01-02T03:04:05Z\"}",
-    statement:"extract(timezone_hour from `2017-01-02T03:04:05Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:0.,time_part:\"timezone_minute\",timestamp:\"2017-01-02T03:04:05Z\"}",
-    statement:"extract(timezone_minute from `2017-01-02T03:04:05Z`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:0.
-    }
-  },
-  {
-    name:"extract valid cases{result:2017.,time_part:\"year\",timestamp:\"2017-01-02T03:04:05+07:08\"}",
-    statement:"extract(year from `2017-01-02T03:04:05+07:08`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:2017.
-    }
-  },
-  {
-    name:"extract valid cases{result:1.,time_part:\"month\",timestamp:\"2017-01-02T03:04:05+07:08\"}",
-    statement:"extract(month from `2017-01-02T03:04:05+07:08`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:1.
-    }
-  },
-  {
-    name:"extract valid cases{result:2.,time_part:\"day\",timestamp:\"2017-01-02T03:04:05+07:08\"}",
-    statement:"extract(day from `2017-01-02T03:04:05+07:08`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:2.
-    }
-  },
-  {
-    name:"extract valid cases{result:3.,time_part:\"hour\",timestamp:\"2017-01-02T03:04:05+07:08\"}",
-    statement:"extract(hour from `2017-01-02T03:04:05+07:08`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:3.
-    }
-  },
-  {
-    name:"extract valid cases{result:4.,time_part:\"minute\",timestamp:\"2017-01-02T03:04:05+07:08\"}",
-    statement:"extract(minute from `2017-01-02T03:04:05+07:08`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:4.
-    }
-  },
-  {
-    name:"extract valid cases{result:5.,time_part:\"second\",timestamp:\"2017-01-02T03:04:05+07:08\"}",
-    statement:"extract(second from `2017-01-02T03:04:05+07:08`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:5.
-    }
-  },
-  {
-    name:"extract valid cases{result:7.,time_part:\"timezone_hour\",timestamp:\"2017-01-02T03:04:05+07:08\"}",
-    statement:"extract(timezone_hour from `2017-01-02T03:04:05+07:08`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:7.
-    }
-  },
-  {
-    name:"extract valid cases{result:8.,time_part:\"timezone_minute\",timestamp:\"2017-01-02T03:04:05+07:08\"}",
-    statement:"extract(timezone_minute from `2017-01-02T03:04:05+07:08`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:8.
-    }
-  },
-  {
-    name:"extract valid cases{result:-7.,time_part:\"timezone_hour\",timestamp:\"2017-01-02T03:04:05-07:08\"}",
-    statement:"extract(timezone_hour from `2017-01-02T03:04:05-07:08`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:-7.
-    }
-  },
-  {
-    name:"extract valid cases{result:-8.,time_part:\"timezone_minute\",timestamp:\"2017-01-02T03:04:05-07:08\"}",
-    statement:"extract(timezone_minute from `2017-01-02T03:04:05-07:08`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:-8.
-    }
-  },
-  {
-    name:"extract null and missing propagation{time_part:\"year\",timestamp:\"null\"}",
-    statement:"extract(year from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"extract null and missing propagation{time_part:\"year\",timestamp:\"missing\"}",
-    statement:"extract(year from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+    name:"invalid extract day from time with time zone",
+    statement:"EXTRACT(DAY FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+    assert:[
+      {
+        result:EvaluationFail,
+        evalMode:EvalModeError
+      },
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$missing::null
+      }
+    ]
   },
 ]


### PR DESCRIPTION
Related to first part of #83.

Adjusts the `EXTRACT` builtin function tests to assert on the expected result in the PartiQL statement. This is to deal with the SQL specification's ambiguity related to the output type of `EXTRACT`. In SQL:2011 (pg 1337):

```
The declared type of <extract expression> is an implementation-defined exact numeric type. If <primary
datetime field> specifies SECOND, then the scale is implementation-defined; otherwise, the scale is
0 (zero).
```

where "exact numeric type" refers to "NUMERIC, DECIMAL, SMALLINT, INTEGER, and BIGINT" (pg 15).

Rather than defining the exact numeric type output by `EXTRACT` to be a decimal or integer, we add a PartiQL equality expression to assert the equivalent value.

E.g. rewrite

```
{
  ...
  statement:"EXTRACT(YEAR FROM DATE '2023-04-13')",
  assert:{
    ...
    output:2023
  }
},
```

as

```
{
  ...
  statement:"EXTRACT(YEAR FROM DATE '2023-04-13') = 2023",
  assert:{
    ...
    output:true
  }
},
```

This PR also adds some more tests that were omitted from the earlier test porting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.