### PR TITLE
Fix omitted time zone from extract test case

### DIFF
--- a/partiql-tests-data/eval/primitives/functions/extract.ion
+++ b/partiql-tests-data/eval/primitives/functions/extract.ion
@@ -312,7 +312,7 @@ extract::[
   extract_time_with_time_zone::[
     {
       name:"EXTRACT(HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(HOUR FROM TIME WITH TIME ZONE '01:23:45.678') = 1",
+      statement:"EXTRACT(HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = 1",
       assert:{
         result:EvaluationSuccess,
         evalMode:[


### PR DESCRIPTION
Timezone was omitted from a `TIME WITH TIME ZONE` literal value in a test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.