### PR TITLE
Fix a few `COLL_` test typos

### DIFF
--- a/partiql-tests-data/eval/primitives/coll-aggregate-function.ion
+++ b/partiql-tests-data/eval/primitives/coll-aggregate-function.ion
@@ -758,7 +758,7 @@ coll_any::[
   },
   {
     name:"COLL_ANY nulls only",
-    statement:"COLL_ANY([NULL, MISSING]])",
+    statement:"COLL_ANY([NULL, MISSING])",
     assert:{
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
@@ -929,7 +929,7 @@ coll_some::[
   },
   {
     name:"COLL_SOME nulls only",
-    statement:"COLL_SOME([NULL, MISSING]])",
+    statement:"COLL_SOME([NULL, MISSING])",
     assert:{
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,

--- a/partiql-tests-data/eval/primitives/coll-aggregate-function.ion
+++ b/partiql-tests-data/eval/primitives/coll-aggregate-function.ion
@@ -387,7 +387,7 @@ coll_count::[
     assert:{
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
-      output:null
+      output:0
     }
   },
   {
@@ -396,7 +396,7 @@ coll_count::[
     assert:{
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
-      output:null
+      output:0
     }
   },
   {


### PR DESCRIPTION
Fixes a few `COLL_` tests:
- `COLL_COUNT` tests returned null rather than 0 when the collection contained `missing`
- A couple `COLL_ANY` and `COLL_SOME` tests had an extra right bracket

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.