### PR TITLE
Start on conformance tests for graph query.

### DIFF
--- a/docs/partiql-tests-schema-proposal.md
+++ b/docs/partiql-tests-schema-proposal.md
@@ -203,6 +203,16 @@ $date::'2022-02-22'
 $time::'02:30:59'
 ```
 
+Similarly, graphs defined with the Ion-based format for "external" graphs 
+([org.partiql.schemas/graph.isl](https://github.com/partiql/partiql-lang-kotlin/blob/main/partiql-lang/src/main/resources/org/partiql/schemas/graph.isl))
+are annotated with `$graph`:
+
+```ion
+// graph -- a struct in graph.isl format, annotated with $graph
+$graph::{ nodes: [ {id: n1, payload: 1} ], 
+          edges: [ {id: d1, payload: 1.1, ends: (n1 -> n1) } ] }
+```
+
 ---
 
 #### PartiQL Evaluation Modes

--- a/partiql-tests-data/eval/experimental/graph/directionality.ion
+++ b/partiql-tests-data/eval/experimental/graph/directionality.ion
@@ -1,0 +1,254 @@
+envs::{
+  pairs: $graph::{
+           nodes: [ {id: a1, labels:["a1"], payload: "A1"},
+                    {id: b1, labels:["b1"], payload: "B1"},
+                    {id: a2, labels:["a2"], payload: "A2"},
+                    {id: b2, labels:["b2"], payload: "B2"} ],
+           edges: [ {id: d1, labels:["d1"], payload: "D1", ends: (a1 -> b1)},
+                    {id: u2, labels:["u2"], payload: "U2", ends: (a2 -- b2)}  ]
+  }
+}
+
+directionality::[
+    {
+        name: "Right with variables",
+        statement: '''(pairs MATCH (x)-[y]->(z))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x': "A1", 'y': "D1", 'z': "B1"} ]
+        }
+    },
+    {
+        name: "Right with spots",
+        statement: '''(pairs MATCH ()-[]->())''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {} ]
+        }
+    },
+    {
+        name: "Right shorthand",
+        statement: '''(pairs MATCH -> )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {} ]
+        }
+    },
+
+    {
+        name: "Left with variables",
+        statement: '''(pairs MATCH (x)<-[y]-(z))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x': "B1", 'y': "D1", 'z': "A1"} ]
+        }
+    },
+    {
+        name: "Left with spots",
+        statement: '''(pairs MATCH ()<-[]-())''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {} ]
+        }
+    },
+    {
+        name: "Left shorthand",
+        statement: '''(pairs MATCH <- )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {} ]
+        }
+    },
+
+    {
+        name: "Left+right with variables",
+        statement: '''(pairs MATCH (x)<-[y]->(z))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x': "A1", 'y': "D1", 'z': "B1"},
+                            {'x': "B1", 'y': "D1", 'z': "A1"}]
+        }
+    },
+    {
+        name: "Left+right with spots",
+        statement: '''(pairs MATCH ()<-[]->())''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {}, {} ]
+        }
+    },
+    {
+        name: "Left+right shorthand",
+        statement: '''(pairs MATCH <-> )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {}, {} ]
+        }
+    },
+    {
+        name: "Left+right with variables and label",
+        statement: '''(pairs MATCH (x:a1)<-[y]->(z))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x': "A1", 'y': "D1", 'z': "B1"} ]
+        }
+    },
+
+    {
+        name: "Undirected with variables",
+        statement: '''(pairs MATCH (x)~[y]~(z))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x': "A2", 'y': "U2", 'z': "B2"},
+                            {'x': "B2", 'y': "U2", 'z': "A2"}]
+        }
+    },
+    {
+        name: "Undirected with spots",
+        statement: '''(pairs MATCH ()~[]~())''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {}, {} ]
+        }
+    },
+    {
+        name: "Undirected shorthand",
+        statement: '''(pairs MATCH ~ )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {}, {} ]
+        }
+    },
+    {
+        name: "Undirected with variables and label",
+        statement: '''(pairs MATCH (x)~[y]~(z:b2))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x': "A2", 'y': "U2", 'z': "B2"} ]
+        }
+    },
+
+    {
+        name: "Right+undirected with variables",
+        statement: '''(pairs MATCH (x)~[y]~>(z))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x': "A1", 'y': "D1", 'z': "B1"},
+                            {'x': "A2", 'y': "U2", 'z': "B2"},
+                            {'x': "B2", 'y': "U2", 'z': "A2"}]
+        }
+    },
+    {
+        name: "Right+undirected with spots",
+        statement: '''(pairs MATCH ()~[]~>())''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {}, {}, {} ]
+        }
+    },
+    {
+        name: "Right+undirected shorthand",
+        statement: '''(pairs MATCH ~> )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {}, {}, {} ]
+        }
+    },
+    {
+        name: "Right+undirected with variables and labels",
+        statement: '''(pairs MATCH (x:a1)~[y]~>(z:a2) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+
+    {
+        name: "Left+undirected with variables",
+        statement: '''(pairs MATCH (x)<~[y]~(z))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x': "B1", 'y': "D1", 'z': "A1"},
+                            {'x': "A2", 'y': "U2", 'z': "B2"},
+                            {'x': "B2", 'y': "U2", 'z': "A2"} ]
+        }
+    },
+    {
+        name: "Left+undirected with spots",
+        statement: '''(pairs MATCH ()<~[]~())''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {}, {}, {} ]
+        }
+    },
+    {
+        name: "Left+undirected shorthand",
+        statement: '''(pairs MATCH <~ )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {}, {}, {} ]
+        }
+    },
+    {
+        name: "Left+undirected with variables and label",
+        statement: '''(pairs MATCH (x)<~[y:u2]~(z))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x': "A2", 'y': "U2", 'z': "B2"},
+                            {'x': "B2", 'y': "U2", 'z': "A2"} ]
+        }
+    },
+
+    {
+        name: "Left+right+undirected with variables",
+        statement: '''(pairs MATCH (x)-[y]-(z))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x': "A1", 'y': "D1", 'z': "B1"},
+                            {'x': "B1", 'y': "D1", 'z': "A1"},
+                            {'x': "A2", 'y': "U2", 'z': "B2"},
+                            {'x': "B2", 'y': "U2", 'z': "A2"} ]
+        }
+    },
+    {
+        name: "Left+right+undirected with spots",
+        statement: '''(pairs MATCH ()-[]-())''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {}, {}, {}, {} ]
+        }
+    },
+    {
+        name: "Left+right+undirected shorthand",
+        statement: '''(pairs MATCH - )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {}, {}, {}, {} ]
+        }
+    },
+]

--- a/partiql-tests-data/eval/experimental/graph/small_graphs.ion
+++ b/partiql-tests-data/eval/experimental/graph/small_graphs.ion
@@ -1,0 +1,643 @@
+envs::{
+            // The empty graph
+            N0E0: $graph::{ nodes: [], edges: [] },
+            // n1  -- one solitary node
+            N1E0: $graph::{ nodes: [ {id: n1, payload: 1} ], edges: [] },
+            // n1  -- a single node with a directed self-loop edge
+            N1D1: $graph::{ nodes: [ {id: n1, payload: 1} ],
+                            edges: [ {id: d1, payload: 1.1, ends: (n1 -> n1) } ] },
+            // n1 -- a single node with an undirected self-loop
+            N1U1: $graph::{ nodes: [ {id: n1, payload: 1} ],
+                          edges: [ {id: u1, payload: 1.1, ends: (n1 -- n1)} ] },
+            // n1  -- a single node with two self-loop edges
+            N1D2: $graph::{ nodes: [ {id: n1, payload: 1} ],
+                          edges: [ {id: d1, payload: 1.1, ends: (n1 -> n1) },
+                                   {id: d2, payload: 11.11, ends: (n1 -> n1)} ] },
+            // n1  n2  -- two disconnected nodes
+            N2E0: $graph::{ nodes: [ {id: n1, payload: 1}, {id: n2, payload: 2} ], edges: [] },
+            // n1 -[d1]-> n2
+            N2D1: $graph::{ nodes: [ {id: n1, payload: 1}, {id: n2, payload: 2} ],
+                          edges: [ {id: d1, payload: 1.2, ends: (n1 -> n2) } ] },
+            // n1 -[u1]- n2
+            N2U1: $graph::{ nodes: [ {id: n1, payload: 1}, {id: n2, payload: 2} ],
+                          edges: [ {id: u1, payload: 1.2, ends: (n1 -- n2) } ] },
+            // n1 -[d1]-> n2   --- two parallel edges
+            //    -[d2]->
+            N2D2: $graph::{ nodes: [ {id: n1, payload: 1}, {id: n2, payload: 2} ],
+                          edges: [ {id: d1, payload: 1.2,   ends: (n1 -> n2) },
+                                   {id: d2, payload: 11.22, ends: (n1 -> n2) } ] },
+            // n1 -[d1]-> n2   --- two cycling edges
+            //    <-[d2]-
+            N2D2c: $graph::{ nodes: [ {id: n1, payload: 1}, {id: n2, payload: 2} ],
+                           edges: [ {id: d1, payload: 1.2, ends: (n1 -> n2) },
+                                   {id: d2, payload: 2.1, ends: (n2 -> n1) } ] },
+            // n1 -[u1]- n2   --- two parallel undirected edges
+            //    -[u2]-
+            N2U2: $graph::{ nodes: [ {id: n1, payload: 1}, {id: n2, payload: 2} ],
+                         edges: [ {id: u1, payload: 1.2, ends: (n1 -- n2) },
+                                  {id: u2, payload: 2.1, ends: (n2 -- n1) } ] },
+}
+
+small_graphs::[
+    {
+        name: "(N0E0 MATCH (x))",
+        statement: '''(N0E0 MATCH (x))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N0E0 MATCH -[y]-> )",
+        statement: '''(N0E0 MATCH -[y]-> )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N0E0 MATCH (x)-[y]->(z) )",
+        statement: '''(N0E0 MATCH (x)-[y]->(z) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+
+    {
+        name: "(N1E0 MATCH (x))",
+        statement: '''(N1E0 MATCH (x))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1} ]
+        }
+    },
+    {
+        name: "(N1E0 MATCH -[y]-> )",
+        statement: '''(N1E0 MATCH -[y]-> )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N1E0 MATCH (x)-[y]->(z) )",
+        statement: '''(N1E0 MATCH (x)-[y]->(z) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N1E0 MATCH (x)-[y]->(x) )",
+        statement: '''(N1E0 MATCH (x)-[y]->(x) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+
+    {
+        name: "(N1U1 MATCH (x))",
+        statement: '''(N1U1 MATCH (x))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1} ]
+        }
+    },
+    {
+        name: "(N1U1 MATCH ~[y]~ )",
+        statement: '''(N1U1 MATCH ~[y]~ )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'y':1.1} ]
+        }
+    },
+    {
+        name: "(N1U1 MATCH (x)~[y]~(z) )",
+        statement: '''(N1U1 MATCH (x)~[y]~(z) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1, 'y':1.1, 'z':1} ]
+        }
+    },
+    {
+        name: "(N1U1 MATCH (x)~[y]~(x) )",
+        statement: '''(N1U1 MATCH (x)~[y]~(x) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1, 'y':1.1} ]
+        }
+    },
+    {
+        name: "(N1U1 MATCH (x1)~[y1]~(x2)~[y2]~(x3) )",
+        statement: '''(N1U1 MATCH (x1)~[y1]~(x2)~[y2]~(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.1, 'x2':1, 'y2':1.1, 'x3':1} ]
+        }
+    },
+
+    {
+        name: "(N1D2 MATCH (x))",
+        statement: '''(N1D2 MATCH (x))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1} ]
+        }
+    },
+    {
+        name: "(N1D2 MATCH -[y]-> )",
+        statement: '''(N1D2 MATCH -[y]-> )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'y':1.1}, {'y':11.11} ]
+        }
+    },
+    {
+        name: "(N1D2 MATCH (x)-[y]->(z) )",
+        statement: '''(N1D2 MATCH (x)-[y]->(z) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1, 'y':1.1, 'z':1}, {'x':1, 'y':11.11, 'z':1} ]
+        }
+    },
+    {
+        name: "(N1D2 MATCH (x)-[y]->(x) )",
+        statement: '''(N1D2 MATCH (x)-[y]->(x) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1, 'y':1.1}, {'x':1, 'y':11.11} ]
+        }
+    },
+    {
+        name: "(N1D2 MATCH (x1)-[y1]->(x2)-[y2]->(x3) )",
+        statement: '''(N1D2 MATCH (x1)-[y1]->(x2)-[y2]->(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.1,   'x2':1, 'y2':1.1,   'x3':1},
+                            {'x1':1, 'y1':1.1,   'x2':1, 'y2':11.11, 'x3':1},
+                            {'x1':1, 'y1':11.11, 'x2':1, 'y2':1.1,   'x3':1},
+                            {'x1':1, 'y1':11.11, 'x2':1, 'y2':11.11, 'x3':1} ]
+        }
+    },
+
+    {
+        name: "(N2E0 MATCH (x))",
+        statement: '''(N2E0 MATCH (x))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1}, {'x':2} ]
+        }
+    },
+    {
+        name: "(N2E0 MATCH -[y]-> )",
+        statement: '''(N2E0 MATCH -[y]-> )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N2E0 MATCH (x)-[y]->(z) )",
+        statement: '''(N2E0 MATCH (x)-[y]->(z) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N2E0 MATCH (x)-[y]->(x) )",
+        statement: '''(N2E0 MATCH (x)-[y]->(x) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+
+    {
+        name: "(N2D1 MATCH (x))",
+        statement: '''(N2D1 MATCH (x))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1}, {'x':2} ]
+        }
+    },
+    {
+        name: "(N2D1 MATCH -[y]-> )",
+        statement: '''(N2D1 MATCH -[y]-> )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'y':1.2} ]
+        }
+    },
+    {
+        name: "(N2D1 MATCH (x)-[y]->(z) )",
+        statement: '''(N2D1 MATCH (x)-[y]->(z) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1, 'y':1.2, 'z':2} ]
+        }
+    },
+    {
+        name: "(N2D1 MATCH (x)-[y]->(x) )",
+        statement: '''(N2D1 MATCH (x)-[y]->(x) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N2D1 MATCH (x1)-[y1]->(x2)-[y2]->(x3) )",
+        statement: '''(N2D1 MATCH (x1)-[y1]->(x2)-[y2]->(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N2D1 MATCH (x1)-[y1]->(x2)-[y2]-(x3) )",
+        statement: '''(N2D1 MATCH (x1)-[y1]->(x2)-[y2]-(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1} ]
+        }
+    },
+    {
+        name: "(N2D1 MATCH (x1)-[y1]-(x2)-[y2]->(x3) )",
+        statement: '''(N2D1 MATCH (x1)-[y1]-(x2)-[y2]->(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2} ]
+        }
+    },
+    {
+        name: "(N2D1 MATCH (x1)-[y1]-(x2)-[y2]-(x3) )",
+        statement: '''(N2D1 MATCH (x1)-[y1]-(x2)-[y2]-(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2} ]
+        }
+    },
+
+    {
+        name: "(N2U1 MATCH (x))",
+        statement: '''(N2U1 MATCH (x))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1}, {'x':2} ]
+        }
+    },
+    {
+        name: "(N2U1 MATCH ~[y]~ )",
+        statement: '''(N2U1 MATCH ~[y]~ )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'y':1.2} ]
+        }
+    },
+    {
+        name: "(N2U1 MATCH (x)~[y]~(z) )",
+        statement: '''(N2U1 MATCH (x)~[y]~(z) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1, 'y':1.2, 'z':2},
+                            {'x':2, 'y':1.2, 'z':1} ]
+        }
+    },
+    {
+        name: "(N2U1 MATCH (x)~[y]~(x) )",
+        statement: '''(N2U1 MATCH (x)~[y]~(x) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N2U1 MATCH (x1)~[y1]~(x2)~[y2]~(x3) )",
+        statement: '''(N2U1 MATCH (x1)~[y1]~(x2)~[y2]~(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2} ]
+        }
+    },
+    {
+        name: "(N2U1 MATCH (x1)~[y1]~(x2)-[y2]-(x3) )",
+        statement: '''(N2U1 MATCH (x1)~[y1]~(x2)-[y2]-(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2} ]
+        }
+    },
+    {
+        name: "(N2U1 MATCH (x1)-[y1]-(x2)~[y2]~(x3) )",
+        statement: '''(N2U1 MATCH (x1)-[y1]-(x2)~[y2]~(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2} ]
+        }
+    },
+    {
+        name: "(N2U1 MATCH (x1)-[y1]-(x2)-[y2]-(x3) )",
+        statement: '''(N2U1 MATCH (x1)-[y1]-(x2)-[y2]-(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2} ]
+        }
+    },
+
+    {
+        name: "(N2D2 MATCH (x))",
+        statement: '''(N2D2 MATCH (x))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1}, {'x':2} ]
+        }
+    },
+    {
+        name: "(N2D2 MATCH -[y]-> )",
+        statement: '''(N2D2 MATCH -[y]-> )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'y':1.2}, {'y':11.22} ]
+        }
+    },
+    {
+        name: "(N2D2 MATCH (x)-[y]->(z) )",
+        statement: '''(N2D2 MATCH (x)-[y]->(z) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1, 'y':1.2, 'z':2}, {'x':1, 'y':11.22, 'z':2} ]
+        }
+    },
+    {
+        name: "(N2D2 MATCH (x)-[y]->(x) )",
+        statement: '''(N2D2 MATCH (x)-[y]->(x) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N2D2 MATCH (x1)-[y1]->(x2)-[y2]->(x3) )",
+        statement: '''(N2D2 MATCH (x1)-[y1]->(x2)-[y2]->(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N2D2 MATCH (x1)-[y1]->(x2)-[y2]-(x3) )",
+        statement: '''(N2D2 MATCH (x1)-[y1]->(x2)-[y2]-(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':1, 'y1':1.2, 'x2':2, 'y2':11.22, 'x3':1},
+                            {'x1':1, 'y1':11.22, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':1, 'y1':11.22, 'x2':2, 'y2':11.22, 'x3':1} ]
+        }
+    },
+    {
+        name: "(N2D2 MATCH (x1)-[y1]-(x2)-[y2]->(x3) )",
+        statement: '''(N2D2 MATCH (x1)-[y1]-(x2)-[y2]->(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':11.22, 'x3':2},
+                            {'x1':2, 'y1':11.22, 'x2':1, 'y2':1.2, 'x3':2},
+                            {'x1':2, 'y1':11.22, 'x2':1, 'y2':11.22, 'x3':2} ]
+        }
+    },
+    {
+        name: "(N2D2 MATCH (x1)-[y1]-(x2)-[y2]-(x3) )",
+        statement: '''(N2D2 MATCH (x1)-[y1]-(x2)-[y2]-(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':1, 'y1':1.2, 'x2':2, 'y2':11.22, 'x3':1},
+                            {'x1':1, 'y1':11.22, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':1, 'y1':11.22, 'x2':2, 'y2':11.22, 'x3':1},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':11.22, 'x3':2},
+                            {'x1':2, 'y1':11.22, 'x2':1, 'y2':1.2, 'x3':2},
+                            {'x1':2, 'y1':11.22, 'x2':1, 'y2':11.22, 'x3':2} ]
+        }
+    },
+
+    {
+        name: "(N2D2c MATCH (x))",
+        statement: '''(N2D2c MATCH (x))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1}, {'x':2} ]
+        }
+    },
+    {
+        name: "(N2D2c MATCH -[y]-> )",
+        statement: '''(N2D2c MATCH -[y]-> )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'y':1.2}, {'y':2.1} ]
+        }
+    },
+    {
+        name: "(N2D2c MATCH (x)-[y]->(z) )",
+        statement: '''(N2D2c MATCH (x)-[y]->(z) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1, 'y':1.2, 'z':2}, {'x':2, 'y':2.1, 'z':1} ]
+        }
+    },
+    {
+        name: "(N2D2c MATCH (x)-[y]->(x) )",
+        statement: '''(N2D2c MATCH (x)-[y]->(x) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N2D2c MATCH (x1)-[y1]->(x2)-[y2]->(x3) )",
+        statement: '''(N2D2c MATCH (x1)-[y1]->(x2)-[y2]->(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':2.1, 'x3':1},
+                            {'x1':2, 'y1':2.1, 'x2':1, 'y2':1.2, 'x3':2} ]
+        }
+    },
+    {
+        name: "(N2D2c MATCH (x1)-[y1]->(x2)-[y2]->(x1) )",
+        statement: '''(N2D2c MATCH (x1)-[y1]->(x2)-[y2]->(x1) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[  {'x1':1, 'y1':1.2, 'x2':2, 'y2':2.1 },
+                             {'x1':2, 'y1':2.1, 'x2':1, 'y2':1.2 } ]
+        }
+    },
+    {
+        name: "(N2D2c MATCH (x1)-[y1]->(x2)-[y2]-(x3) )",
+        statement: '''(N2D2c MATCH (x1)-[y1]->(x2)-[y2]-(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':1, 'y1':1.2, 'x2':2, 'y2':2.1, 'x3':1},
+                            {'x1':2, 'y1':2.1, 'x2':1, 'y2':1.2, 'x3':2},
+                            {'x1':2, 'y1':2.1, 'x2':1, 'y2':2.1, 'x3':2} ]
+        }
+    },
+    {
+        name: "(N2D2c MATCH (x1)-[y1]-(x2)-[y2]->(x3) )",
+        statement: '''(N2D2c MATCH (x1)-[y1]-(x2)-[y2]->(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[  {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2},
+                             {'x1':2, 'y1':2.1, 'x2':1, 'y2':1.2, 'x3':2},
+                             {'x1':1, 'y1':1.2, 'x2':2, 'y2':2.1, 'x3':1},
+                             {'x1':1, 'y1':2.1, 'x2':2, 'y2':2.1, 'x3':1} ]
+        }
+    },
+    {
+        name: "(N2D2c MATCH (x1)-[y1]-(x2)-[y2]-(x3) )",
+        statement: '''(N2D2c MATCH (x1)-[y1]-(x2)-[y2]-(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[    {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
+                               {'x1':1, 'y1':1.2, 'x2':2, 'y2':2.1, 'x3':1},
+                               {'x1':1, 'y1':2.1, 'x2':2, 'y2':1.2, 'x3':1},
+                               {'x1':1, 'y1':2.1, 'x2':2, 'y2':2.1, 'x3':1},
+                               {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2},
+                               {'x1':2, 'y1':1.2, 'x2':1, 'y2':2.1, 'x3':2},
+                               {'x1':2, 'y1':2.1, 'x2':1, 'y2':1.2, 'x3':2},
+                               {'x1':2, 'y1':2.1, 'x2':1, 'y2':2.1, 'x3':2} ]
+        }
+    },
+
+    {
+        name: "(N2U2 MATCH (x))",
+        statement: '''(N2U2 MATCH (x))''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1}, {'x':2} ]
+        }
+    },
+    {
+        name: "(N2U2 MATCH ~[y]~ )",
+        statement: '''(N2U2 MATCH ~[y]~ )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'y':1.2}, {'y':2.1} ]
+        }
+    },
+    {
+        name: "(N2U2 MATCH (x)~[y]~(z) )",
+        statement: '''(N2U2 MATCH (x)~[y]~(z) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x':1, 'y':1.2, 'z':2}, {'x':2, 'y':2.1, 'z':1},
+                            {'x':2, 'y':1.2, 'z':1}, {'x':1, 'y':2.1, 'z':2} ]
+        }
+    },
+    {
+        name: "(N2U2 MATCH (x)~[y]~(x) )",
+        statement: '''(N2U2 MATCH (x)~[y]~(x) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ ]
+        }
+    },
+    {
+        name: "(N2U2 MATCH (x1)~[y1]~(x2)~[y2]~(x3) )",
+        statement: '''(N2U2 MATCH (x1)~[y1]~(x2)~[y2]~(x3) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':2.1, 'x3':1},
+                            {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':1, 'y1':2.1, 'x2':2, 'y2':1.2, 'x3':1},
+                            {'x1':1, 'y1':2.1, 'x2':2, 'y2':2.1, 'x3':1},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':2.1, 'x3':2},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2},
+                            {'x1':2, 'y1':2.1, 'x2':1, 'y2':1.2, 'x3':2},
+                            {'x1':2, 'y1':2.1, 'x2':1, 'y2':2.1, 'x3':2} ]
+        }
+    },
+    {
+        name: "(N2U2 MATCH (x1)~[y1]~(x2)~[y2]~(x1) )",
+        statement: '''(N2U2 MATCH (x1)~[y1]~(x2)~[y2]~(x1) )''',
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[ {'x1':1, 'y1':1.2, 'x2':2, 'y2':2.1},
+                            {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2},
+                            {'x1':1, 'y1':2.1, 'x2':2, 'y2':1.2},
+                            {'x1':1, 'y1':2.1, 'x2':2, 'y2':2.1},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':2.1},
+                            {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2},
+                            {'x1':2, 'y1':2.1, 'x2':1, 'y2':1.2},
+                            {'x1':2, 'y1':2.1, 'x2':1, 'y2':2.1} ]
+        }
+    },
+]


### PR DESCRIPTION
These conformance tests are ported from some of the unit tests in EvaluatingCompilerGraphMatchTests in partiql-lang-kotlin, https://github.com/partiql/partiql-lang-kotlin/pull/1104

Adjustments to reading-in Ion made in #1104 are necessary for reading in and running these new conformance tests here. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.