### PR TITLE
Fixes to 3 tests in 0007.ion

### DIFF
--- a/partiql-tests-data/eval/rfc/0007.ion
+++ b/partiql-tests-data/eval/rfc/0007.ion
@@ -153,9 +153,9 @@ bag::[
         }
     },
     {
-        name: "Example 3 — Union of Heterogenous Relations",
+        name: "Example 3 — Outer union of Heterogenous Relations",
         statement: '''SELECT * FROM hr.employees               -- T1
-                      UNION
+                      OUTER UNION
                       SELECT title FROM engineering.employees  -- T2''',
         assert: {
             evalMode: [EvalModeCoerce, EvalModeError],
@@ -212,16 +212,16 @@ bag::[
         }
     },
     {
-        name: "Example 7 — `TABLE engineering.employees UNION << MISSING >>`",
-        statement: '''TABLE engineering.employees UNION << MISSING >>''',
+        name: "Example 7 — `engineering.employees UNION << MISSING >>`",
+        statement: '''engineering.employees UNION << MISSING >>''',
         assert: {
             evalMode:[EvalModeCoerce, EvalModeError],
             result: EvaluationFail,
         }
     },
     {
-        name: "Example 7 — `TABLE engineering.employess OUTER UNION << MISSING >>`",
-        statement: '''TABLE engineering.employess OUTER UNION << MISSING >>''',
+        name: "Example 7 — `engineering.employees OUTER UNION << MISSING >>`",
+        statement: '''engineering.employees OUTER UNION << MISSING >>''',
         assert: {
             evalMode: [EvalModeCoerce, EvalModeError],
             result: EvaluationSuccess,


### PR DESCRIPTION
With partiql-lang-kotlin, 2 of them now succeed and the other fails for a better reason.

These fixes stem from exploring the purported conformance regression in https://github.com/partiql/partiql-lang-kotlin/pull/1104. 
(The proximate cause of (wrongly) detecting the regression there was probably that `0007.ion` contained two different tests under the same name.)




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.