### PR TITLE
Adds tests for checking DECIMAL types

### DIFF
--- a/partiql-tests-data/eval/primitives/operators/is-operators.ion
+++ b/partiql-tests-data/eval/primitives/operators/is-operators.ion
@@ -1,0 +1,122 @@
+is::[
+  {
+    name: "1.000 is DECIMAL(3,3)",
+    statement: "1.000 is DECIMAL(3,3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: true
+    }
+  },
+  {
+    name: "1.0000 is DECIMAL(5,3)",
+    statement: "1.0000 is DECIMAL(5,3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: false
+    }
+  },
+  {
+    name: "0.001 is DECIMAL(3,3)",
+    statement: "0.001 is DECIMAL(3,3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: true
+    }
+  },
+  {
+    name: "123.456 is DECIMAL(2,2)",
+    statement: "123.456 is DECIMAL(2,2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: false
+    }
+  },
+  {
+    name: "123.456 is DECIMAL(5,3)",
+    statement: "123.456 is DECIMAL(5,3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: false
+    }
+  },
+  {
+    name: "123.456 is DECIMAL(7,3)",
+    statement: "123.456 is DECIMAL(7,3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: false
+    }
+  },
+  {
+    name: "123.456 is DECIMAL(6,2)",
+    statement: "123.456 is DECIMAL(6,2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: false
+    }
+  },
+  {
+    name: "123.456 is DECIMAL(6,4)",
+    statement: "123.456 is DECIMAL(6,4)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: false
+    }
+  },
+  {
+    name: "0123.456 is DECIMAL(6,3)",
+    statement: "0123.456 is DECIMAL(6,3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: true
+    }
+  },
+  {
+    name: "0.00 is DECIMAL(4,3)",
+    statement: "0.00 is DECIMAL(4,3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: true
+    }
+  },
+]

--- a/partiql-tests-data/fail/static-analysis/primitives/cast.ion
+++ b/partiql-tests-data/fail/static-analysis/primitives/cast.ion
@@ -5,3 +5,19 @@
         result: StaticAnalysisFail
     },
 }
+
+{
+    name: "invalid cast type parameter - Decimal precision set to 0",
+    statement: "CAST(5 AS DECIMAL(0,0))",
+    assert: {
+        result: StaticAnalysisFail
+    },
+}
+
+{
+    name: "invalid cast type parameter - Decimal precision < scale",
+    statement: "CAST(5 AS DECIMAL(5,10))",
+    assert: {
+        result: StaticAnalysisFail
+    },
+}


### PR DESCRIPTION
Issue #71 

Description of changes:
- Add `IS` operator test for decimal type. 
- Add invalid decimal type parameter to `fail/staticAnalysis`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.