### PR TITLE
timestamp type

### DIFF
--- a/partiql-tests-data/eval/primitives/functions/extract.ion
+++ b/partiql-tests-data/eval/primitives/functions/extract.ion
@@ -435,8 +435,8 @@ extract::[
   ],
   extract_timestamp::[
     {
-      name:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67Z`) = 2000",
+      name:"EXTRACT(YEAR FROM TIMESTAMP '2000-01-02 03:04:05.67')",
+      statement:"EXTRACT(YEAR FROM TIMESTAMP '2000-01-02 03:04:05.67') = 2000",
       assert:{
         result:EvaluationSuccess,
         evalMode:[
@@ -447,8 +447,8 @@ extract::[
       }
     },
     {
-      name:"EXTRACT(MONTH FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(MONTH FROM `2000-01-02T03:04:05.67Z`) = 1",
+      name:"EXTRACT(MONTH FROM TIMESTAMP '2000-01-02 03:04:05.67')",
+      statement:"EXTRACT(MONTH FROM TIMESTAMP '2000-01-02 03:04:05.67') = 1",
       assert:{
         result:EvaluationSuccess,
         evalMode:[
@@ -459,8 +459,8 @@ extract::[
       }
     },
     {
-      name:"EXTRACT(DAY FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(DAY FROM `2000-01-02T03:04:05.67Z`) = 2",
+      name:"EXTRACT(DAY FROM TIMESTAMP '2000-01-02 03:04:05.67')",
+      statement:"EXTRACT(DAY FROM TIMESTAMP '2000-01-02 03:04:05.67') = 2",
       assert:{
         result:EvaluationSuccess,
         evalMode:[
@@ -471,8 +471,8 @@ extract::[
       }
     },
     {
-      name:"EXTRACT(HOUR FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(HOUR FROM `2000-01-02T03:04:05.67Z`) = 3",
+      name:"EXTRACT(HOUR FROM TIMESTAMP '2000-01-02 03:04:05.67')",
+      statement:"EXTRACT(HOUR FROM TIMESTAMP '2000-01-02 03:04:05.67') = 3",
       assert:{
         result:EvaluationSuccess,
         evalMode:[
@@ -483,8 +483,8 @@ extract::[
       }
     },
     {
-      name:"EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67Z`) = 4",
+      name:"EXTRACT(MINUTE FROM TIMESTAMP '2000-01-02 03:04:05.67')",
+      statement:"EXTRACT(MINUTE FROM TIMESTAMP '2000-01-02 03:04:05.67') = 4",
       assert:{
         result:EvaluationSuccess,
         evalMode:[
@@ -495,8 +495,8 @@ extract::[
       }
     },
     {
-      name:"EXTRACT(SECOND FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(SECOND FROM `2000-01-02T03:04:05.67Z`) = 5.67",
+      name:"EXTRACT(SECOND FROM TIMESTAMP '2000-01-02 03:04:05.67')",
+      statement:"EXTRACT(SECOND FROM TIMESTAMP '2000-01-02 03:04:05.67') = 5.67",
       assert:{
         result:EvaluationSuccess,
         evalMode:[
@@ -507,6 +507,7 @@ extract::[
       }
     },
   ],
+  // TODO : What to do with unknown offset?
   extract_timestamp_offset::[
     {
       name:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67+08:09`)",
@@ -619,6 +620,174 @@ extract::[
     {
       name:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67-08:09`)",
       statement:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67-08:09`) = -9",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67Z`)",
+      statement:"EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67Z`) = 0",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67Z`)",
+      statement:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67Z`) = 0",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(YEAR FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09')",
+      statement:"EXTRACT(YEAR FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09') = 2000",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MONTH FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09')",
+      statement:"EXTRACT(MONTH FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09') = 1",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(DAY FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09')",
+      statement:"EXTRACT(DAY FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09') = 2",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(HOUR FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09')",
+      statement:"EXTRACT(HOUR FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09') = 3",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(MINUTE FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09')",
+      statement:"EXTRACT(MINUTE FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09') = 4",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(SECOND FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09')",
+      statement:"EXTRACT(SECOND FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09') = 5.67",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09')",
+      statement:"EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09') = 8",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_MINUTE FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09')",
+      statement:"EXTRACT(TIMEZONE_MINUTE FROM TIMESTAMP '2000-01-02 03:04:05.67+08:09') = 9",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2000-01-02 03:04:05.67-08:09')",
+      statement:"EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2000-01-02 03:04:05.67-08:09') = -8",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_MINUTE FROM TIMESTAMP '2000-01-02 03:04:05.67-08:09')",
+      statement:"EXTRACT(TIMEZONE_MINUTE FROM TIMESTAMP '2000-01-02 03:04:05.67-08:09') = -9",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2000-01-02T03:04:05.67Z')",
+      statement:"EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2000-01-02T03:04:05.67Z') = 0",
+      assert:{
+        result:EvaluationSuccess,
+        evalMode:[
+          EvalModeCoerce,
+          EvalModeError
+        ],
+        output:true
+      }
+    },
+    {
+      name:"EXTRACT(TIMEZONE_MINUTE FROM TIMESTAMP '2000-01-02T03:04:05.67Z')",
+      statement:"EXTRACT(TIMEZONE_MINUTE FROM TIMESTAMP '2000-01-02T03:04:05.67Z') = 0",
       assert:{
         result:EvaluationSuccess,
         evalMode:[

--- a/partiql-tests-data/fail/static-analysis/primitives/timestamp-constructor.ion
+++ b/partiql-tests-data/fail/static-analysis/primitives/timestamp-constructor.ion
@@ -1,0 +1,365 @@
+{
+  name: "TIMESTAMP - invalid YEAR field - beyond 9999",
+  statement: "TIMESTAMP '12345-03-10 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid YEAR field - minus before year",
+  statement: "TIMESTAMP '-9999-03-10 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid YEAR field - plus before year",
+  statement: "TIMESTAMP '+9999-03-10 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid MONTH field - above upper bound",
+  statement: "TIMESTAMP '2021-13-01 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid MONTH field - month of zero",
+  statement: "TIMESTAMP '2021-00-01 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid MONTH field - minus before month",
+  statement: "TIMESTAMP '2021--03-10 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid MONTH field - plus before month",
+  statement: "TIMESTAMP '2021-+03-10 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for January",
+  statement: "TIMESTAMP '2021-01-32 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for February leap year",
+  statement: "TIMESTAMP '2012-02-30 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for February non leap year",
+  statement: "TIMESTAMP '2021-02-29 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for March",
+  statement: "TIMESTAMP '2021-03-32 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for April",
+  statement: "TIMESTAMP '2021-04-31 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for May",
+  statement: "TIMESTAMP '2021-05-32 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for June",
+  statement: "TIMESTAMP '2021-06-31 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for July",
+  statement: "TIMESTAMP '2021-07-32 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for August",
+  statement: "TIMESTAMP '2021-08-32 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for September",
+  statement: "TIMESTAMP '2021-09-31 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for October",
+  statement: "TIMESTAMP '2021-10-32 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for November",
+  statement: "TIMESTAMP '2021-11-31 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range for December",
+  statement: "TIMESTAMP '2021-12-32 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - day of zero",
+  statement: "TIMESTAMP '2021-01-00 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid DAY field - out of range",
+  statement: "TIMESTAMP '2021-03-12345 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid Day field - minus before day",
+  statement: "TIMESTAMP '2021-03--10 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid Day field - plus before day",
+  statement: "TIMESTAMP '2021-03-+10 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid literal Format - random string",
+  statement: "TIMESTAMP 'timestamp'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid HOUR field - above upper bound",
+  statement: "TIMESTAMP '2021-03-01 24:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid HOUR field - Negative value",
+  statement: "TIMESTAMP '2021-03-01 -01:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid HOUR field - plus sign",
+  statement: "TIMESTAMP '2021-03-01 +01:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid HOUR field - plus sign",
+  statement: "TIMESTAMP '2021-03-01 +01:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid MINUTE field - above upper bound",
+  statement: "TIMESTAMP '2021-03-01 00:60:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid MINUTE field - negative value",
+  statement: "TIMESTAMP '2021-03-01 00:-01:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid MINUTE field - plus sign",
+  statement: "TIMESTAMP '2021-03-01 00:+01:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+// Setting to 62 to take account of leap second, if any implement does care.
+{
+  name: "TIMESTAMP - invalid SECOND field - above upper bound",
+  statement: "TIMESTAMP '2021-03-01 00:00:62'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid SECOND field - negative value",
+  statement: "TIMESTAMP '2021-03-01 00:00:-01'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid SECOND field - plus sign",
+  statement: "TIMESTAMP '2021-03-01 00:00:+01'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid timezone_hour field - above upper bound",
+  statement: "TIMESTAMP '2021-03-01 00:00:00+24:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid timezone_hour field - below lower bound",
+  statement: "TIMESTAMP '2021-03-01 00:00:00-24:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid timezone_minute field - above upper bound",
+  statement: "TIMESTAMP '2021-03-01 00:00:00+00:60'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid timezone_hour field - below lower bound",
+  statement: "TIMESTAMP '2021-03-01 00:00:00-00:60'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+{
+  name: "TIMESTAMP - invalid Precision - negative value",
+  statement: "TIMESTAMP(-1) '2021-03-01 00:00:00'",
+  assert: {
+    result: StaticAnalysisFail
+  },
+}
+
+// NOT sure if we want to keep the following,
+// as an implementation may choose to extend the syntax
+// and made the following valid
+
+//{
+//  name: "TIMESTAMP - invalid day field - missing padding zero",
+//  statement: "TIMESTAMP '2021-03-1 00:00:00'",
+//  assert: {
+//    result: StaticAnalysisFail
+//  },
+//}
+
+//{
+//  name: "TIMESTAMP - invalid month field - missing padding zero",
+//  statement: "TIMESTAMP '2021-3-01 00:00:00'",
+//  assert: {
+//    result: StaticAnalysisFail
+//  },
+//}
+
+//{
+//  name: "TIMESTAMP - invalid YEAR field - 2 digit year",
+//  statement: "TIMESTAMP '21-03-01 00:00:00'",
+//  assert: {
+//    result: StaticAnalysisFail
+//  },
+//}
+
+//{
+//  name: "TIMESTAMP - invalid Date Part format - missing dash",
+//  statement: "TIMESTAMP '20210310 00:00:00'",
+//  assert: {
+//    result: StaticAnalysisFail
+//  },
+//}
+
+// TODO : should we support this?
+//{
+//  name: "TIMESTAMP",
+//  statement: "TIMESTAMP '2021-03-01 00:00:00.'",
+//  assert: {
+//    result: StaticAnalysisFail
+//  },
+//}

--- a/partiql-tests-data/fail/syntax/primitives/timestamp-constructor.ion
+++ b/partiql-tests-data/fail/syntax/primitives/timestamp-constructor.ion
@@ -1,0 +1,47 @@
+{
+  name: "missing TIMESTAMP string",
+  statement: "TIMESTAMP",
+  assert: {
+    result: SyntaxFail
+  },
+}
+
+{
+  name: "invalid type INT for TIMESTAMP string",
+  statement: "TIMESTAMP 2012",
+  assert: {
+    result: SyntaxFail
+  },
+}
+
+{
+  name: "invalid TIMESTAMP string without single quotes",
+  statement: "TIMESTAMP 2012-08-28 00:00:00",
+  assert: {
+    result: SyntaxFail
+  },
+}
+
+{
+  name: "invalid TIMESTAMP string using Ion literal",
+  statement: "TIMESTAMP `2012-08-28T00:00:00Z`",
+  assert: {
+    result: SyntaxFail
+  },
+}
+
+{
+  name: "invalid TIMESTAMP string no starting single quotation",
+  statement: "TIMESTAMP 2012-08-28 00:00:00'",
+  assert: {
+    result: SyntaxFail
+  },
+}
+
+{
+  name: "invalid TIMESTAMP string no ending single quotation",
+  statement: "TIMESTAMP '2012-08-28 00:00:00",
+  assert: {
+    result: SyntaxFail
+  },
+}

--- a/partiql-tests-data/success/syntax/primitives/timestamp-constructor.ion
+++ b/partiql-tests-data/success/syntax/primitives/timestamp-constructor.ion
@@ -1,0 +1,402 @@
+// SQL style
+{
+  name: "TIMESTAMP WITHOUT TIME ZONE - SQL Style - No Second Precision ",
+  statement: "TIMESTAMP '2023-06-01 00:00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITHOUT TIME ZONE - SQL Style - Arbitrary Second Precision",
+  statement: "TIMESTAMP '2023-06-01 00:00:00.00000000000",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITHOUT TIME ZONE - SQL Style - Precision = Digit in Second Fraction",
+  statement: "TIMESTAMP(0) '2023-06-01 00:00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITHOUT TIME ZONE - SQL Style - Precision < Digit in Second Fraction",
+  statement: "TIMESTAMP(0) '2023-06-01 00:00:00.0000",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITHOUT TIME ZONE - SQL Style - Precision > Digit in Second Fraction",
+  statement: "TIMESTAMP(10) '2023-06-01 00:00:00.0000",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - SQL Style - No Second Precision ",
+  statement: "TIMESTAMP '2023-06-01 00:00:00+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - SQL Style - Arbitrary Second Precision",
+  statement: "TIMESTAMP '2023-06-01 00:00:00.00000000000+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - SQL Style - Precision = Digit in Second Fraction",
+  statement: "TIMESTAMP(0) '2023-06-01 00:00:00+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - SQL Style - Precision < Digit in Second Fraction",
+  statement: "TIMESTAMP(0) '2023-06-01 00:00:00.0000+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - SQL Style - Precision > Digit in Second Fraction",
+  statement: "TIMESTAMP(10) '2023-06-01 00:00:00.0000+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+// RFC 3339 Style
+// Note RFC 3339 requires a "full time" which include timestamp
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - No Second Precision - Time ZONE INTERVAL - Captialized T",
+  statement: "TIMESTAMP '2023-06-01T00:00:00+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Arbitrary Second Precision - Time ZONE INTERVAL - Captialized T",
+  statement: "TIMESTAMP '2023-06-01T00:00:00.00000000000+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision = Digit in Second Fraction - Time ZONE INTERVAL - Captialized T",
+  statement: "TIMESTAMP(0) '2023-06-01T00:00:00+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision < Digit in Second Fraction - Time ZONE INTERVAL - Captialized T",
+  statement: "TIMESTAMP(0) '2023-06-01T00:00:00.0000+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision > Digit in Second Fraction - Time ZONE INTERVAL - Captialized T",
+  statement: "TIMESTAMP(10) '2023-06-01T00:00:00.0000+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - No Second Precision - Time ZONE INTERVAL - Lowercase t",
+  statement: "TIMESTAMP '2023-06-01t00:00:00+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Arbitrary Second Precision - Time ZONE INTERVAL - Lowercase t",
+  statement: "TIMESTAMP '2023-06-01t00:00:00.00000000000+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision = Digit in Second Fraction - Time ZONE INTERVAL - Lowercase t",
+  statement: "TIMESTAMP(0) '2023-06-01t00:00:00+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision < Digit in Second Fraction - Time ZONE INTERVAL - Lowercase t",
+  statement: "TIMESTAMP(0) '2023-06-01t00:00:00.0000+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision > Digit in Second Fraction - Time ZONE INTERVAL - Lowercase t",
+  statement: "TIMESTAMP(10) '2023-06-01t00:00:00.0000+00:00",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - No Second Precision - Captial Z for UTC - Captialized T",
+  statement: "TIMESTAMP '2023-06-01T00:00:00Z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Arbitrary Second Precision - Captial Z for UTC - Captialized T",
+  statement: "TIMESTAMP '2023-06-01T00:00:00.00000000000Z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision = Digit in Second Fraction - Captial Z for UTC - Captialized T",
+  statement: "TIMESTAMP(0) '2023-06-01T00:00:00Z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision < Digit in Second Fraction - Captial Z for UTC - Captialized T",
+  statement: "TIMESTAMP(0) '2023-06-01T00:00:00.0000Z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision > Digit in Second Fraction - Captial Z for UTC - Captialized T",
+  statement: "TIMESTAMP(10) '2023-06-01T00:00:00.0000Z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - No Second Precision - Captial Z for UTC - Lowercase t",
+  statement: "TIMESTAMP '2023-06-01t00:00:00Z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Arbitrary Second Precision - Captial Z for UTC - Lowercase t",
+  statement: "TIMESTAMP '2023-06-01t00:00:00.00000000000Z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision = Digit in Second Fraction - Captial Z for UTC - Lowercase t",
+  statement: "TIMESTAMP(0) '2023-06-01t00:00:00Z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision < Digit in Second Fraction - Captial Z for UTC - Lowercase t",
+  statement: "TIMESTAMP(0) '2023-06-01t00:00:00.0000Z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision > Digit in Second Fraction - Captial Z for UTC - Lowercase t",
+  statement: "TIMESTAMP(10) '2023-06-01t00:00:00.0000Z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - No Second Precision - Lowercase Z for UTC - Captialized T",
+  statement: "TIMESTAMP '2023-06-01T00:00:00z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Arbitrary Second Precision - Lowercase Z for UTC - Captialized T",
+  statement: "TIMESTAMP '2023-06-01T00:00:00.00000000000z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision = Digit in Second Fraction - Lowercase Z for UTC - Captialized T",
+  statement: "TIMESTAMP(0) '2023-06-01T00:00:00z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision < Digit in Second Fraction - Lowercase Z for UTC - Captialized T",
+  statement: "TIMESTAMP(0) '2023-06-01T00:00:00.0000z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision > Digit in Second Fraction - Lowercase Z for UTC - Captialized T",
+  statement: "TIMESTAMP(10) '2023-06-01T00:00:00.0000z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - No Second Precision - Lowercase Z for UTC - Lowercase t",
+  statement: "TIMESTAMP '2023-06-01t00:00:00z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Arbitrary Second Precision - Lowercase Z for UTC - Lowercase t",
+  statement: "TIMESTAMP '2023-06-01t00:00:00.00000000000z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision = Digit in Second Fraction - Lowercase Z for UTC - Lowercase t",
+  statement: "TIMESTAMP(0) '2023-06-01t00:00:00z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision < Digit in Second Fraction - Lowercase Z for UTC - Lowercase t",
+  statement: "TIMESTAMP(0) '2023-06-01t00:00:00.0000z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}
+
+{
+  name: "TIMESTAMP WITH TIME ZONE - RFC 3339 - Precision > Digit in Second Fraction - Lowercase Z for UTC - Lowercase t",
+  statement: "TIMESTAMP(10) '2023-06-01t00:00:00.0000z",
+  assert: [
+    {
+      result: SyntaxSuccess
+    },
+  ]
+}


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Add timestamp literal parsing related tests. 
- Modify `EXTRACT` test cases:
  - all ion `timestamp` should be consider timestamp with timezone. 
  - add tests that use `TIMESTAMP` literal as EXTRACT parameter. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.