### PR TITLE
Fix bag op UNION ALL tests

### DIFF
--- a/partiql-tests-data/eval/primitives/operators/bag-operators.ion
+++ b/partiql-tests-data/eval/primitives/operators/bag-operators.ion
@@ -24,6 +24,10 @@ bagOperators::[
         2,
         3,
         3,
+        3,
+        1,
+        2,
+        3,
         3
       ]
     }
@@ -125,6 +129,7 @@ bagOperators::[
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
       output:$bag::[
+        1,
         1,
         1,
         1,


### PR DESCRIPTION
Fixes #97. Following the bag operator RFC fixes/corrections as part of https://github.com/partiql/partiql-docs/pull/44, fixes the `UNION` ALL tests that include duplicate elements.

For context, these tests were previously ported from the Kotlin implementation. Those tests in the Kotlin codebase should be fixed as part of https://github.com/partiql/partiql-lang-kotlin/issues/1132.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.