### PR TITLE
Add some more bag op tests with ORDER BY LIMIT OFFSET

### DIFF
--- a/partiql-tests-data/eval/primitives/operators/bag-operators.ion
+++ b/partiql-tests-data/eval/primitives/operators/bag-operators.ion
@@ -1,4 +1,50 @@
 bagOperators::[
+  envs::{
+    t1: [
+      {
+        a: 1,
+        tbl: 1
+      },
+      {
+        a: 2,
+        tbl: 1
+      },
+      {
+        a: 3,
+        tbl: 1
+      },
+      {
+        a: 4,
+        tbl: 1
+      },
+      {
+        a: 5,
+        tbl: 1
+      }
+    ],
+    t2: [
+      {
+        a: 2,
+        tbl: 2
+      },
+      {
+        a: 3,
+        tbl: 2
+      },
+      {
+        a: 4,
+        tbl: 2
+      },
+      {
+        a: 5,
+        tbl: 2
+      },
+      {
+        a: 6,
+        tbl: 2
+      }
+    ]
+  },
   {
     name:"outerUnionDistinct",
     statement:"<< 1, 2, 2, 3, 3, 3 >> OUTER UNION << 1, 2, 3, 3 >>",
@@ -136,5 +182,99 @@ bagOperators::[
         2
       ]
     }
-  }
+  },
+  {
+    name:"OUTER UNION with ORDER BY LIMIT OFFSET on children",
+    statement:"(SELECT a, tbl FROM t1 ORDER BY a LIMIT 1 OFFSET 1) OUTER UNION ALL (SELECT a, tbl FROM t2 ORDER BY a LIMIT 1 OFFSET 1)",
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        {
+          a: 2,
+          tbl: 1,
+        },
+        {
+          a: 3,
+          tbl: 2
+        }
+      ]
+    }
+  },
+  {
+    name:"OUTER INTERSECT with ORDER BY LIMIT OFFSET on children",
+    statement:"(SELECT a FROM t1 ORDER BY a LIMIT 3 OFFSET 1) OUTER INTERSECT ALL (SELECT a FROM t2 ORDER BY a LIMIT 3 OFFSET 1)",
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        {
+          a: 3,
+        },
+        {
+          a: 4,
+        },
+      ]
+    }
+  },
+  {
+    name:"OUTER EXCEPT with ORDER BY LIMIT OFFSET on children",
+    statement:"(SELECT a FROM t1 ORDER BY a LIMIT 3 OFFSET 1) OUTER EXCEPT ALL (SELECT a FROM t2 ORDER BY a LIMIT 3 OFFSET 1)",
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        {
+          a: 2,
+        },
+      ]
+    }
+  },
+  {
+    name:"OUTER UNION with ORDER BY LIMIT on children and bag op",
+    statement:"(SELECT a, tbl FROM t1 ORDER BY a LIMIT 2) OUTER UNION ALL (SELECT a, tbl FROM t2 ORDER BY a LIMIT 2) ORDER BY a LIMIT 2",
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:[
+        {
+          a: 1,
+          tbl: 1,
+        },
+        {
+          a: 2,
+          tbl: 1
+        }
+      ]
+    }
+  },
+  {
+    name:"OUTER INTERSECT with ORDER BY LIMIT on children and bag op",
+    statement:"(SELECT a FROM t1 ORDER BY a LIMIT 4) OUTER INTERSECT ALL (SELECT a FROM t2 ORDER BY a LIMIT 4) ORDER BY a LIMIT 2",
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:[
+        {
+          a: 2,
+        },
+        {
+          a: 3,
+        }
+      ]
+    }
+  },
+  {
+    name:"OUTER EXCEPT with ORDER BY LIMIT on children and bag op",
+    statement:"(SELECT a FROM t1 ORDER BY a LIMIT 2) OUTER EXCEPT ALL (SELECT a FROM t2 ORDER BY a LIMIT 2) ORDER BY a LIMIT 2",
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:[
+        {
+          a: 1,
+        },
+      ]
+    }
+  },
 ]

--- a/partiql-tests-data/success/syntax/primitives/union-except-intersect.ion
+++ b/partiql-tests-data/success/syntax/primitives/union-except-intersect.ion
@@ -20,6 +20,13 @@
             result: SyntaxSuccess
         }
     },
+    {
+        name: "a UNION DISTINCT b",
+        statement: "a UNION DISTINCT b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
 ]
 
 'except-sql'::[
@@ -37,6 +44,13 @@
             result: SyntaxSuccess
         }
     },
+    {
+        name: "a EXCEPT DISTINCT b",
+        statement: "a EXCEPT DISTINCT b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
 ]
 
 'intersect-sql'::[
@@ -50,6 +64,158 @@
     {
         name: "a INTERSECT ALL b",
         statement: "a INTERSECT ALL b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "a INTERSECT DISTINCT b",
+        statement: "a INTERSECT DISTINCT b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+]
+
+'outer-union'::[
+    {
+        name: "a OUTER UNION b",
+        statement: "a OUTER UNION b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "OUTER UNION SELECT precedence",
+        statement: "SELECT * FROM foo OUTER UNION SELECT * FROM bar",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "a OUTER UNION ALL b",
+        statement: "a OUTER UNION ALL b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "a OUTER UNION DISTINCT b",
+        statement: "a OUTER UNION DISTINCT b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+]
+
+'outer-except'::[
+    {
+        name: "a OUTER EXCEPT b",
+        statement: "a OUTER EXCEPT b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "a OUTER EXCEPT ALL b",
+        statement: "a OUTER EXCEPT ALL b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "a OUTER EXCEPT DISTINCT b",
+        statement: "a OUTER EXCEPT DISTINCT b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+]
+
+'outer-intersect'::[
+    {
+        name: "a OUTER INTERSECT b",
+        statement: "a OUTER INTERSECT b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "a OUTER INTERSECT ALL b",
+        statement: "a OUTER INTERSECT ALL b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "a OUTER INTERSECT DISTINCT b",
+        statement: "a OUTER INTERSECT DISTINCT b",
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+]
+
+'order-by-limit-offset-bag-ops'::[
+    {
+        name: "UNION SFW children with ORDER BY LIMIT OFFSET",
+        statement: '''
+            (SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
+            UNION
+            (SELECT a2 FROM b2 ORDER BY c2 LIMIT d2 OFFSET e2)
+            ORDER BY c3 LIMIT d3 OFFSET e3''',
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "INTERSECT SFW children with ORDER BY LIMIT OFFSET",
+        statement: '''
+            (SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
+            INTERSECT
+            (SELECT a2 FROM b2 ORDER BY c2 LIMIT d2 OFFSET e2)
+            ORDER BY c3 LIMIT d3 OFFSET e3''',
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "EXCEPT SFW children with ORDER BY LIMIT OFFSET",
+        statement: '''
+            (SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
+            EXCEPT
+            (SELECT a2 FROM b2 ORDER BY c2 LIMIT d2 OFFSET e2)
+            ORDER BY c3 LIMIT d3 OFFSET e3''',
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "nested bag op with ORDER BY LIMIT OFFSET",
+        statement: '''
+            (
+                (SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
+                UNION DISTINCT
+                (SELECT a2 FROM b2 ORDER BY c2 LIMIT d2 OFFSET e2)
+            )
+            OUTER UNION ALL
+            (SELECT a3 FROM b3 ORDER BY c3 LIMIT d3 OFFSET e3)
+            ORDER BY c4 LIMIT d4 OFFSET e4''',
+        assert: {
+            result: SyntaxSuccess
+        }
+    },
+    {
+        name: "deep nested bag ops with ORDER BY LIMIT OFFSET",
+        statement: '''
+            (a UNION b)
+            INTERSECT
+            (
+                c EXCEPT
+                d UNION ALL (e INTERSECT f ORDER BY g LIMIT h OFFSET i)
+            )
+            EXCEPT j
+            ORDER BY k LIMIT l OFFSET m''',
         assert: {
             result: SyntaxSuccess
         }


### PR DESCRIPTION
Adds some more syntax and evaluation tests with the bag operators. These tests focus on using the bag operators with `ORDER BY`, `LIMIT,` and `OFFSET`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.