### PR TITLE
Add another outer intersect test

### DIFF
--- a/partiql-tests-data/eval/primitives/operators/bag-operators.ion
+++ b/partiql-tests-data/eval/primitives/operators/bag-operators.ion
@@ -106,6 +106,20 @@ bagOperators::[
     }
   },
   {
+    name:"outerIntersectAll switched lhs and rhs",
+    statement:"<< 1, 2, 3, 3 >> OUTER INTERSECT ALL << 1, 2, 2, 3, 3, 3 >>",
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        1,
+        2,
+        3,
+        3
+      ]
+    }
+  },
+  {
     name:"outerExceptDistinct",
     statement:"<< 1, 1, 1, 2 >> OUTER EXCEPT << 1 >>",
     assert:{


### PR DESCRIPTION
Adds an outer intersect test with the RHS containing elements that aren't on the LHS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.