### PR TITLE
Fix ORDER BY test typos

### DIFF
--- a/partiql-tests-data/eval/query/order-by.ion
+++ b/partiql-tests-data/eval/query/order-by.ion
@@ -291,11 +291,11 @@ edge_cases::[
   // text types compared by lexicographical ordering of Unicode scalar (ASC)
   {
     name:"text types compared by lexicographical ordering of Unicode scalar (ASC)",
-    statement:'''SELECT * FROM [{ 'a': `'\uD83D\uDCA9'`}, { 'a': 'Z'}, { 'a': '9' }, { 'a': 'A'}, { 'a1': `"\U0001F4A9"`}, { 'a': 'a'}, { 'a': 'z'}, { 'a': '0' }] ORDER BY a''',
+    statement:'''SELECT * FROM [{ 'a': `'\uD83D\uDCA9'`}, { 'a': 'Z'}, { 'a': '9' }, { 'a': 'A'}, { 'a': `"\U0001F4A9"`}, { 'a': 'a'}, { 'a': 'z'}, { 'a': '0' }] ORDER BY a''',
     assert:{
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
-      output:[{'a': '0'}, {'a': '9'}, {'a': 'A'}, {'a': 'Z'}, {'a': 'a'}, {'a': 'z'}, {'a': '\uD83D\uDCA9'}, {'a2': "\U0001F4A9"}]
+      output:[{'a': '0'}, {'a': '9'}, {'a': 'A'}, {'a': 'Z'}, {'a': 'a'}, {'a': 'z'}, {'a': '\uD83D\uDCA9'}, {'a': "\U0001F4A9"}]
     }
   },
   // text types compared by lexicographical ordering of Unicode scalar (DESC)


### PR DESCRIPTION
Ported test from https://github.com/partiql/partiql-tests/pull/66 had the wrong struct field name in statement and expected output (test source: https://github.com/partiql/partiql-lang-kotlin/blob/main/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerOrderByTests.kt#L193-L197).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.