### PR TITLE
Change classification of a HAVING test

### DIFF
--- a/partiql-tests-data/eval/query/group-by/group-by.ion
+++ b/partiql-tests-data/eval/query/group-by/group-by.ion
@@ -974,14 +974,6 @@
 
 'simple-group-by-fail'::[
   {
-    name:"having without group by",
-    statement:"SELECT rep, SUM(total_sales) as total FROM sales_report HAVING rep = \"Meg\"",
-    assert:{
-      evalMode:[EvalModeError, EvalModeCoerce],
-      result:EvaluationFail
-    },
-  },
-  {
     name:"GROUP BY binding referenced in FROM clause",
     statement:"SELECT gb_binding FROM sales_report, gb_binding WHERE fiscal_year >= `2001T` GROUP BY rep AS gb_binding",
     assert:[

--- a/partiql-tests-data/fail/static-analysis/query/select/having.ion
+++ b/partiql-tests-data/fail/static-analysis/query/select/having.ion
@@ -1,0 +1,7 @@
+{
+  name:"having without group by",
+  statement:"SELECT rep, SUM(total_sales) as total FROM sales_report HAVING rep = \"Meg\"",
+  assert:{
+    result: StaticAnalysisFail
+  },
+}


### PR DESCRIPTION
There was a test (`SELECT rep, SUM(total_sales) as total FROM sales_report HAVING rep = \"Meg\"`) that was previously classified as an evaluation fail. Should be classified as a static analysis fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.