### PR TITLE
Corrects tests regarding coercion, indexing, bag operators, and missing attributes

### DIFF
--- a/partiql-tests-data/eval/misc.ion
+++ b/partiql-tests-data/eval/misc.ion
@@ -110,18 +110,24 @@ uncategorized::[
   {
     name:"selectValueStructConstructorWithMissing",
     statement:"SELECT VALUE {'x': a.x, 'y': a.y} FROM `[{x:5}, {y:6}]` AS a",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          x:5
-        },
-        {
-          y:6
-        }
-      ]
-    }
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
+            x:5
+          },
+          {
+            y:6
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"selectIndexStruct",

--- a/partiql-tests-data/eval/primitives/date-time.ion
+++ b/partiql-tests-data/eval/primitives/date-time.ion
@@ -2,26 +2,20 @@ regression::[
   {
     name:"dateTimePartsAsVariableNames",
     statement:"SELECT VALUE [year, month, day, hour, minute, second] FROM 1968 AS year, 4 AS month, 3 as day, 12 as hour, 31 as minute, 59 as second",
-    assert:[
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
-          [
-            1968,
-            4,
-            3,
-            12,
-            31,
-            59
-          ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        [
+          1968,
+          4,
+          3,
+          12,
+          31,
+          59
         ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail,
-      },
-    ]
+      ]
+    }
   },
   {
     name:"dateTimePartsAsStructFieldNames",

--- a/partiql-tests-data/eval/primitives/date-time.ion
+++ b/partiql-tests-data/eval/primitives/date-time.ion
@@ -2,20 +2,26 @@ regression::[
   {
     name:"dateTimePartsAsVariableNames",
     statement:"SELECT VALUE [year, month, day, hour, minute, second] FROM 1968 AS year, 4 AS month, 3 as day, 12 as hour, 31 as minute, 59 as second",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          1968,
-          4,
-          3,
-          12,
-          31,
-          59
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            1968,
+            4,
+            3,
+            12,
+            31,
+            59
+          ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"dateTimePartsAsStructFieldNames",

--- a/partiql-tests-data/eval/primitives/operators/bag-operators.ion
+++ b/partiql-tests-data/eval/primitives/operators/bag-operators.ion
@@ -126,7 +126,6 @@ bagOperators::[
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
       output:$bag::[
-        1,
         2
       ]
     }

--- a/partiql-tests-data/eval/query/group-by/group-by.ion
+++ b/partiql-tests-data/eval/query/group-by/group-by.ion
@@ -7375,8 +7375,8 @@
     }
   },
   {
-    name:"Expression with multiple subqueriees containing aggregates : CAST((SELECT COUNT(1) FROM products) AS LIST)[0]._1 / CAST((SELECT COUNT(1) FROM suppliers) AS LIST)[0]._1",
-    statement:"CAST((SELECT COUNT(1) FROM products) AS LIST)[0]._1 / CAST((SELECT COUNT(1) FROM suppliers) AS LIST)[0]._1",
+    name:"Expression with multiple subqueries containing aggregates : (SELECT COUNT(1) FROM products) / (SELECT COUNT(1) FROM suppliers)",
+    statement:"(SELECT COUNT(1) FROM products) / (SELECT COUNT(1) FROM suppliers)",
     assert:{
       result:EvaluationSuccess,
       evalMode:[
@@ -7387,8 +7387,8 @@
     }
   },
   {
-    name:"Aggregates with subquery containing another aggregate : SELECT COUNT(1) + CAST((SELECT SUM(numInStock) FROM products) AS LIST)[0]._1 as a_number FROM products",
-    statement:"SELECT COUNT(1) + CAST((SELECT SUM(numInStock) FROM products) AS LIST)[0]._1 as a_number FROM products",
+    name:"Aggregates with subquery containing another aggregate : SELECT COUNT(1) + (SELECT SUM(numInStock) FROM products) as a_number FROM products",
+    statement:"SELECT COUNT(1) + (SELECT SUM(numInStock) FROM products) as a_number FROM products",
     assert:{
       result:EvaluationSuccess,
       evalMode:[

--- a/partiql-tests-data/eval/query/group-by/group-by.ion
+++ b/partiql-tests-data/eval/query/group-by/group-by.ion
@@ -7449,18 +7449,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-        $bag::[
-          {
-            the_sum:1
-          }
-        ],
-        $bag::[
-          {
-            the_sum:1
-          }
-        ]
-      ]
+      output:$bag::[1, 1]
     }
   },
   {

--- a/partiql-tests-data/eval/query/group-by/group-by.ion
+++ b/partiql-tests-data/eval/query/group-by/group-by.ion
@@ -1666,134 +1666,153 @@
   {
     name:"SELECT supplierId_missings FROM products_sparse p GROUP BY p.supplierId_missings",
     statement:"SELECT supplierId_missings FROM products_sparse p GROUP BY p.supplierId_missings",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          supplierId_missings:10
-        },
-        {
-          supplierId_missings:11
-        },
-        {
-          supplierId_missings:null  // missing coerced to null as per 11.1.1
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            supplierId_missings:10
+          },
+          {
+            supplierId_missings:11
+          },
+          {
+            supplierId_missings:null  // missing coerced to null as per 11.1.1
+          }
+        ]
+      },
+
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.supplierId_missings FROM products_sparse p GROUP BY p.supplierId_missings",
     statement:"SELECT p.supplierId_missings FROM products_sparse p GROUP BY p.supplierId_missings",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          supplierId_missings:10
-        },
-        {
-          supplierId_missings:11
-        },
-        {
-          supplierId_missings:null  // missing coerced to null as per 11.1.1
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            supplierId_missings:10
+          },
+          {
+            supplierId_missings:11
+          },
+          {
+            supplierId_missings:null  // missing coerced to null as per 11.1.1
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT VALUE { 'supplierId_missings' : p.supplierId_missings } FROM products_sparse p GROUP BY p.supplierId_missings",
     statement:"SELECT VALUE { 'supplierId_missings' : p.supplierId_missings } FROM products_sparse p GROUP BY p.supplierId_missings",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          supplierId_missings:10
-        },
-        {
-          supplierId_missings:11
-        },
-        {
-          supplierId_missings:null  // missing coerced to null as per 11.1.1
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            supplierId_missings:10
+          },
+          {
+            supplierId_missings:11
+          },
+          {
+            supplierId_missings:null  // missing coerced to null as per 11.1.1
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT supplierId_mixed FROM products_sparse p GROUP BY p.supplierId_mixed",
     statement:"SELECT supplierId_mixed FROM products_sparse p GROUP BY p.supplierId_mixed",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          supplierId_mixed:10
-        },
-        {
-          supplierId_mixed:11
-        },
-        {
-          supplierId_mixed:null  // missing coerced to null as per 11.1.1
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            supplierId_mixed:10
+          },
+          {
+            supplierId_mixed:11
+          },
+          {
+            supplierId_mixed:null  // missing coerced to null as per 11.1.1
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.supplierId_mixed FROM products_sparse p GROUP BY p.supplierId_mixed",
     statement:"SELECT p.supplierId_mixed FROM products_sparse p GROUP BY p.supplierId_mixed",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          supplierId_mixed:10
-        },
-        {
-          supplierId_mixed:11
-        },
-        {
-          supplierId_mixed:null  // missing coerced to null as per 11.1.1
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            supplierId_mixed:10
+          },
+          {
+            supplierId_mixed:11
+          },
+          {
+            supplierId_mixed:null  // missing coerced to null as per 11.1.1
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT VALUE { 'supplierId_mixed' : p.supplierId_mixed } FROM products_sparse p GROUP BY p.supplierId_mixed",
     statement:"SELECT VALUE { 'supplierId_mixed' : p.supplierId_mixed } FROM products_sparse p GROUP BY p.supplierId_mixed",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          supplierId_mixed:10
-        },
-        {
-          supplierId_mixed:11
-        },
-        {
-          supplierId_mixed:null  // missing coerced to null as per 11.1.1
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            supplierId_mixed:10
+          },
+          {
+            supplierId_mixed:11
+          },
+          {
+            supplierId_mixed:null  // missing coerced to null as per 11.1.1
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT regionId, supplierId_nulls FROM products_sparse p GROUP BY p.regionId, p.supplierId_nulls",
@@ -1872,224 +1891,242 @@
   {
     name:"SELECT regionId, supplierId_missings FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
     statement:"SELECT regionId, supplierId_missings FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          regionId:100,
-          supplierId_missings:10
-        },
-        {
-          regionId:100,
-          supplierId_missings:11
-        },
-        {
-          regionId:100,
-          supplierId_missings:null  // missing coerced to null as per 11.1.1
-        },
-        {
-          regionId:200,
-          supplierId_missings:10
-        },
-        {
-          regionId:200,
-          supplierId_missings:11
-        },
-        {
-          regionId:200,
-          supplierId_missings:null  // missing coerced to null as per 11.1.1
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            regionId:100,
+            supplierId_missings:10
+          },
+          {
+            regionId:100,
+            supplierId_missings:11
+          },
+          {
+            regionId:100,
+            supplierId_missings:null  // missing coerced to null as per 11.1.1
+          },
+          {
+            regionId:200,
+            supplierId_missings:10
+          },
+          {
+            regionId:200,
+            supplierId_missings:11
+          },
+          {
+            regionId:200,
+            supplierId_missings:null  // missing coerced to null as per 11.1.1
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.regionId, p.supplierId_missings FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
     statement:"SELECT p.regionId, p.supplierId_missings FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          regionId:100,
-          supplierId_missings:10
-        },
-        {
-          regionId:100,
-          supplierId_missings:11
-        },
-        {
-          regionId:100,
-          supplierId_missings:null  // missing coerced to null as per 11.1.1
-        },
-        {
-          regionId:200,
-          supplierId_missings:10
-        },
-        {
-          regionId:200,
-          supplierId_missings:11
-        },
-        {
-          regionId:200,
-          supplierId_missings:null  // missing coerced to null as per 11.1.1
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            regionId:100,
+            supplierId_missings:10
+          },
+          {
+            regionId:100,
+            supplierId_missings:11
+          },
+          {
+            regionId:100,
+            supplierId_missings:null  // missing coerced to null as per 11.1.1
+          },
+          {
+            regionId:200,
+            supplierId_missings:10
+          },
+          {
+            regionId:200,
+            supplierId_missings:11
+          },
+          {
+            regionId:200,
+            supplierId_missings:null  // missing coerced to null as per 11.1.1
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT VALUE { 'regionId': p.regionId, 'supplierId_missings': p.supplierId_missings } FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
     statement:"SELECT VALUE { 'regionId': p.regionId, 'supplierId_missings': p.supplierId_missings } FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          regionId:100,
-          supplierId_missings:10
-        },
-        {
-          regionId:100,
-          supplierId_missings:11
-        },
-        {
-          regionId:100,
-          supplierId_missings:null  // missing coerced to null as per 11.1.1
-        },
-        {
-          regionId:200,
-          supplierId_missings:10
-        },
-        {
-          regionId:200,
-          supplierId_missings:11
-        },
-        {
-          regionId:200,
-          supplierId_missings:null  // missing coerced to null as per 11.1.1
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            regionId:100,
+            supplierId_missings:10
+          },
+          {
+            regionId:100,
+            supplierId_missings:11
+          },
+          {
+            regionId:100,
+            supplierId_missings:null  // missing coerced to null as per 11.1.1
+          },
+          {
+            regionId:200,
+            supplierId_missings:10
+          },
+          {
+            regionId:200,
+            supplierId_missings:11
+          },
+          {
+            regionId:200,
+            supplierId_missings:null  // missing coerced to null as per 11.1.1
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT regionId, supplierId_mixed FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
     statement:"SELECT regionId, supplierId_mixed FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          regionId:100,
-          supplierId_mixed:10
-        },
-        {
-          regionId:100,
-          supplierId_mixed:11
-        },
-        {
-          regionId:100,
-          supplierId_mixed:null  // missing coerced to null as per 11.1.1
-        },
-        {
-          regionId:200,
-          supplierId_mixed:10
-        },
-        {
-          regionId:200,
-          supplierId_mixed:11
-        },
-        {
-          regionId:200,
-          supplierId_mixed:null
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            regionId:100,
+            supplierId_mixed:10
+          },
+          {
+            regionId:100,
+            supplierId_mixed:11
+          },
+          {
+            regionId:100,
+            supplierId_mixed:null  // missing coerced to null as per 11.1.1
+          },
+          {
+            regionId:200,
+            supplierId_mixed:10
+          },
+          {
+            regionId:200,
+            supplierId_mixed:11
+          },
+          {
+            regionId:200,
+            supplierId_mixed:null
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT regionId, p.supplierId_mixed FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
     statement:"SELECT regionId, p.supplierId_mixed FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          regionId:100,
-          supplierId_mixed:10
-        },
-        {
-          regionId:100,
-          supplierId_mixed:11
-        },
-        {
-          regionId:100,
-          supplierId_mixed:null  // missing coerced to null as per 11.1.1
-        },
-        {
-          regionId:200,
-          supplierId_mixed:10
-        },
-        {
-          regionId:200,
-          supplierId_mixed:11
-        },
-        {
-          regionId:200,
-          supplierId_mixed:null
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            regionId:100,
+            supplierId_mixed:10
+          },
+          {
+            regionId:100,
+            supplierId_mixed:11
+          },
+          {
+            regionId:100,
+            supplierId_mixed:null  // missing coerced to null as per 11.1.1
+          },
+          {
+            regionId:200,
+            supplierId_mixed:10
+          },
+          {
+            regionId:200,
+            supplierId_mixed:11
+          },
+          {
+            regionId:200,
+            supplierId_mixed:null
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT VALUE { 'regionId': p.regionId, 'supplierId_mixed': p.supplierId_mixed } FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
     statement:"SELECT VALUE { 'regionId': p.regionId, 'supplierId_mixed': p.supplierId_mixed } FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          regionId:100,
-          supplierId_mixed:10
-        },
-        {
-          regionId:100,
-          supplierId_mixed:11
-        },
-        {
-          regionId:100,
-          supplierId_mixed:null  // missing coerced to null as per 11.1.1
-        },
-        {
-          regionId:200,
-          supplierId_mixed:10
-        },
-        {
-          regionId:200,
-          supplierId_mixed:11
-        },
-        {
-          regionId:200,
-          supplierId_mixed:null
-        }
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            regionId:100,
+            supplierId_mixed:10
+          },
+          {
+            regionId:100,
+            supplierId_mixed:11
+          },
+          {
+            regionId:100,
+            supplierId_mixed:null  // missing coerced to null as per 11.1.1
+          },
+          {
+            regionId:200,
+            supplierId_mixed:10
+          },
+          {
+            regionId:200,
+            supplierId_mixed:11
+          },
+          {
+            regionId:200,
+            supplierId_mixed:null
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
 ]
 
@@ -5714,172 +5751,202 @@
   {
     name:"SELECT COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p",
     statement:"SELECT COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          the_count:10,
-          the_agg:5
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:5
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p",
     statement:"SELECT COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          the_count:10,
-          the_agg:15.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:15.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p",
     statement:"SELECT COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          the_count:10,
-          the_agg:1.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:1.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p",
     statement:"SELECT COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          the_count:10,
-          the_agg:5.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p",
     statement:"SELECT COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          the_count:10,
-          the_agg:3.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:3.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p",
     statement:"SELECT COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          the_count:10,
-          the_agg:5
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:5
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p",
     statement:"SELECT COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          the_count:10,
-          the_agg:15.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:15.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p",
     statement:"SELECT COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          the_count:10,
-          the_agg:1.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:1.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p",
     statement:"SELECT COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          the_count:10,
-          the_agg:5.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p",
     statement:"SELECT COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          the_count:10,
-          the_agg:3.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            the_count:10,
+            the_agg:3.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, COUNT( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
@@ -6374,232 +6441,262 @@
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
     statement:"SELECT categoryId, COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:3
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:2
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:2
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
     statement:"SELECT categoryId, COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:6.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:9.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:6.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:9.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
     statement:"SELECT categoryId, COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:1.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:4.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:1.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
     statement:"SELECT categoryId, COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:3.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:5.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
     statement:"SELECT categoryId, COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:2.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:4.5
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:2.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.5
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
     statement:"SELECT categoryId, COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:3
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:2
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:2
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
     statement:"SELECT categoryId, COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:6.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:9.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:6.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:9.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
     statement:"SELECT categoryId, COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:1.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:4.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:1.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
     statement:"SELECT categoryId, COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:3.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:5.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT categoryId, COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
     statement:"SELECT categoryId, COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:2.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:4.5
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:2.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.5
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
@@ -7094,232 +7191,262 @@
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
     statement:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:3
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:2
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:2
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
     statement:"SELECT p.categoryId, COUNT(1) AS the_count, SUM(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:6.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:9.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:6.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:9.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
     statement:"SELECT p.categoryId, COUNT(1) AS the_count, MIN(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:1.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:4.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:1.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
     statement:"SELECT p.categoryId, COUNT(1) AS the_count, MAX(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:3.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:5.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
     statement:"SELECT p.categoryId, COUNT(1) AS the_count, AVG(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:2.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:4.5
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:2.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.5
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
     statement:"SELECT p.categoryId, COUNT(1) AS the_count, COUNT(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:3
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:2
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:2
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
     statement:"SELECT p.categoryId, COUNT(1) AS the_count, SUM(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:6.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:9.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:6.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:9.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
     statement:"SELECT p.categoryId, COUNT(1) AS the_count, MIN(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:1.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:4.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:1.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
     statement:"SELECT p.categoryId, COUNT(1) AS the_count, MAX(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:3.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:5.0
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:3.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:5.0
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SELECT p.categoryId, COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
     statement:"SELECT p.categoryId, COUNT(1) AS the_count, AVG(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          categoryId:20,
-          the_count:4,
-          the_agg:2.0
-        },
-        {
-          categoryId:21,
-          the_count:6,
-          the_agg:4.5
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output:$bag::[
+          {
+            categoryId:20,
+            the_count:4,
+            the_agg:2.0
+          },
+          {
+            categoryId:21,
+            the_count:6,
+            the_agg:4.5
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
 ]
 

--- a/partiql-tests-data/eval/query/select/from-clause.ion
+++ b/partiql-tests-data/eval/query/select/from-clause.ion
@@ -86,82 +86,64 @@ envs::{
   {
     name:"selectFromScalarAndAtUnpivotWildCardOverScalar",
     statement:"SELECT VALUE [n, v] FROM (100).* AS v AT n",
-    assert: [
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
-          [
-            $missing::null,
-            100
-          ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        [
+          "_1",
+          100
         ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail,
-      },
-    ]
+      ]
+    }
   },
   {
     name:"selectFromListAndAtUnpivotWildCardOverScalar",
     statement:"SELECT VALUE [n, (SELECT VALUE [i, x] FROM @v AS x AT i)] FROM [100, 200].*.*.* AS v AT n",
-    assert: [
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
-          [
-            $missing::null,
-            $bag::[
-              [
-                0,
-                100
-              ],
-              [
-                1,
-                200
-              ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        [
+          "_1",
+          $bag::[
+            [
+              0,
+              100
+            ],
+            [
+              1,
+              200
             ]
           ]
         ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail,
-      },
-    ]
+      ]
+    }
   },
   {
     name:"selectFromBagAndAtUnpivotWildCardOverScalar",
     statement:"SELECT VALUE [n, (SELECT VALUE [i IS MISSING, i, x] FROM @v AS x AT i)] FROM <<100, 200>>.* AS v AT n",
-    assert: [
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
-          [
-            $missing::null,
-            $bag::[
-              [
-                true,
-                $missing::null,
-                100
-              ],
-              [
-                true,
-                $missing::null,
-                200
-              ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        [
+          "_1",
+          $bag::[
+            [
+              true,
+              $missing::null,
+              100
+            ],
+            [
+              true,
+              $missing::null,
+              200
             ]
           ]
         ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail,
-      },
-    ]
+      ]
+    }
   },
   {
     name:"selectPathUnpivotWildCardOverStructMultiple",
@@ -249,37 +231,27 @@ envs::{
   {
     name:"rangeOverScalar",
     statement:"SELECT VALUE v FROM 1 AS v",
-    assert:[
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[ 1 ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail,
-      },
-    ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        1
+      ]
+    }
   },
   {
     name:"rangeTwiceOverScalar",
     statement:"SELECT VALUE [v1, v2] FROM 1 AS v1, @v1 AS v2",
-    assert:[
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
-          [
-            1,
-            1
-          ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        [
+          1,
+          1
         ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail,
-      },
-    ]
+      ]
+    }
   },
   {
     name:"rangeOverSexp",
@@ -297,21 +269,15 @@ envs::{
   {
     name:"rangeOverStruct",
     statement:"SELECT VALUE v FROM `{a:5}` AS v",
-    assert: [
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
-          {
-            a:5
-          }
-        ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail,
-      },
-    ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        {
+          a:5
+        }
+      ]
+    }
   },
   {
     name:"rangeOverList",

--- a/partiql-tests-data/eval/query/select/from-clause.ion
+++ b/partiql-tests-data/eval/query/select/from-clause.ion
@@ -86,64 +86,82 @@ envs::{
   {
     name:"selectFromScalarAndAtUnpivotWildCardOverScalar",
     statement:"SELECT VALUE [n, v] FROM (100).* AS v AT n",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          "_1",
-          100
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            $missing::null,
+            100
+          ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"selectFromListAndAtUnpivotWildCardOverScalar",
     statement:"SELECT VALUE [n, (SELECT VALUE [i, x] FROM @v AS x AT i)] FROM [100, 200].*.*.* AS v AT n",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          "_1",
-          $bag::[
-            [
-              0,
-              100
-            ],
-            [
-              1,
-              200
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            $missing::null,
+            $bag::[
+              [
+                0,
+                100
+              ],
+              [
+                1,
+                200
+              ]
             ]
           ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"selectFromBagAndAtUnpivotWildCardOverScalar",
     statement:"SELECT VALUE [n, (SELECT VALUE [i IS MISSING, i, x] FROM @v AS x AT i)] FROM <<100, 200>>.* AS v AT n",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          "_1",
-          $bag::[
-            [
-              true,
-              $missing::null,
-              100
-            ],
-            [
-              true,
-              $missing::null,
-              200
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            $missing::null,
+            $bag::[
+              [
+                true,
+                $missing::null,
+                100
+              ],
+              [
+                true,
+                $missing::null,
+                200
+              ]
             ]
           ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"selectPathUnpivotWildCardOverStructMultiple",
@@ -270,26 +288,30 @@ envs::{
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
       output:$bag::[
-        (
-          a
-          b
-          c
-        )
+        a,
+        b,
+        c
       ]
     }
   },
   {
     name:"rangeOverStruct",
     statement:"SELECT VALUE v FROM `{a:5}` AS v",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          a:5
-        }
-      ]
-    }
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
+            a:5
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"rangeOverList",
@@ -377,45 +399,57 @@ envs::{
   {
     name:"rangeOverBagWithAt",
     statement:"SELECT VALUE [i, v] FROM <<1, 2, 3>> AS v AT i",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          $missing::null,
-          1
-        ],
-        [
-          $missing::null,
-          2
-        ],
-        [
-          $missing::null,
-          3
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            $missing::null,
+            1
+          ],
+          [
+            $missing::null,
+            2
+          ],
+          [
+            $missing::null,
+            3
+          ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"rangeOverNestedWithAt",
     statement:"SELECT VALUE [i, v] FROM (SELECT VALUE v FROM `[1, 2, 3]` AS v) AS v AT i",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          $missing::null,
-          1
-        ],
-        [
-          $missing::null,
-          2
-        ],
-        [
-          $missing::null,
-          3
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            $missing::null,
+            1
+          ],
+          [
+            $missing::null,
+            2
+          ],
+          [
+            $missing::null,
+            3
+          ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   }
 ]

--- a/partiql-tests-data/eval/query/select/from-clause.ion
+++ b/partiql-tests-data/eval/query/select/from-clause.ion
@@ -198,26 +198,32 @@ envs::{
   {
     name:"ordinalAccessWithNegativeIndex",
     statement:"SELECT temp[-2] FROM <<[1,2,3,4]>> AS temp",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-        }
-      ]
-    }
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[ {} ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"ordinalAccessWithNegativeIndexAndBindings",
     statement:"SELECT temp[-2] FROM [[1,2,3,4]] AS temp",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-        }
-      ]
-    }
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[ {} ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   }
 ]
 
@@ -225,27 +231,37 @@ envs::{
   {
     name:"rangeOverScalar",
     statement:"SELECT VALUE v FROM 1 AS v",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        1
-      ]
-    }
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[ 1 ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"rangeTwiceOverScalar",
     statement:"SELECT VALUE [v1, v2] FROM 1 AS v1, @v1 AS v2",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          1,
-          1
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            1,
+            1
+          ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"rangeOverSexp",

--- a/partiql-tests-data/eval/query/select/projection.ion
+++ b/partiql-tests-data/eval/query/select/projection.ion
@@ -4,16 +4,22 @@
   {
     name:"undefinedUnqualifiedVariable_inSelect_withProjectionOption",
     statement:"SELECT s.a, s.undefined_variable, s.b FROM `[{a:100, b:200}]` s",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          a:100,
-          b:200
-        }
-      ]
-    }
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
+            a:100,
+            b:200
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"projectionIterationBehaviorUnfiltered_select_list",

--- a/partiql-tests-data/eval/query/select/select.ion
+++ b/partiql-tests-data/eval/query/select/select.ion
@@ -239,18 +239,24 @@ envs::{
   {
     name:"selectListWithMissing",
     statement:"SELECT a.x AS x, a.y AS y FROM `[{x:5}, {y:6}]` AS a",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          x:5
-        },
-        {
-          y:6
-        }
-      ]
-    }
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
+            x:5
+          },
+          {
+            y:6
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   }
 ]
 

--- a/partiql-tests-data/eval/query/select/sql-aggregate.ion
+++ b/partiql-tests-data/eval/query/select/sql-aggregate.ion
@@ -832,31 +832,11 @@ multiple_sql_aggregates::[
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
       output:$bag::[
-        $bag::[
-          {
-            result:27.
-          }
-        ],
-        $bag::[
-          {
-            result:29.0
-          }
-        ],
-        $bag::[
-          {
-            result:31.
-          }
-        ],
-        $bag::[
-          {
-            result:33.
-          }
-        ],
-        $bag::[
-          {
-            result:35.
-          }
-        ]
+        27.,
+        29.0,
+        31.,
+        33.,
+        35.
       ]
     }
   },

--- a/partiql-tests-data/eval/query/select/sql-aggregate.ion
+++ b/partiql-tests-data/eval/query/select/sql-aggregate.ion
@@ -653,24 +653,30 @@ sql_any::[
               FROM << {'a': 1, 'b': 10}, {'a': 1, 'b': 17}, {'a': 2, 'b': 20}, {'a': 3} >> AS x
               GROUP BY x.a
               ''',
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[EvalModeCoerce, EvalModeError],
-      output:$bag::[
-        {
-          a: 1,
-          e: true
-        },
-        {
-          a: 2,
-          e: false
-        },
-        {
-          a: 3,
-          e: null
-        },
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            a: 1,
+            e: true
+          },
+          {
+            a: 2,
+            e: false
+          },
+          {
+            a: 3,
+            e: null
+          },
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"ANY DISTINCT with GROUP BY",
@@ -679,24 +685,30 @@ sql_any::[
               FROM [ {'a': 1, 'b': 10}, {'a': 1, 'b': 17}, {'a': 2, 'b': 20}, {'a': 3} ] AS x
               GROUP BY x.a
               ''',
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[EvalModeCoerce, EvalModeError],
-      output:$bag::[
-        {
-          a: 1,
-          e: true
-        },
-        {
-          a: 2,
-          e: false
-        },
-        {
-          a: 3,
-          e: null
-        },
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            a: 1,
+            e: true
+          },
+          {
+            a: 2,
+            e: false
+          },
+          {
+            a: 3,
+            e: null
+          },
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   }
 ]
 
@@ -708,24 +720,30 @@ sql_some::[
               FROM << {'a': 1, 'b': 10}, {'a': 1, 'b': 17}, {'a': 2, 'b': 20}, {'a': 3} >> AS x
               GROUP BY x.a
               ''',
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[EvalModeCoerce, EvalModeError],
-      output:$bag::[
-        {
-          a: 1,
-          e: true
-        },
-        {
-          a: 2,
-          e: false
-        },
-        {
-          a: 3,
-          e: null
-        },
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            a: 1,
+            e: true
+          },
+          {
+            a: 2,
+            e: false
+          },
+          {
+            a: 3,
+            e: null
+          },
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"SOME DISTINCT with GROUP BY",
@@ -734,24 +752,30 @@ sql_some::[
               FROM [ {'a': 1, 'b': 10}, {'a': 1, 'b': 17}, {'a': 2, 'b': 20}, {'a': 3} ] AS x
               GROUP BY x.a
               ''',
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[EvalModeCoerce, EvalModeError],
-      output:$bag::[
-        {
-          a: 1,
-          e: true
-        },
-        {
-          a: 2,
-          e: false
-        },
-        {
-          a: 3,
-          e: null
-        },
-      ]
-    }
+    assert:[
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            a: 1,
+            e: true
+          },
+          {
+            a: 2,
+            e: false
+          },
+          {
+            a: 3,
+            e: null
+          },
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   }
 ]
 
@@ -763,24 +787,30 @@ sql_every::[
               FROM << {'a': 1, 'b': 10}, {'a': 1, 'b': 11}, {'a': 2, 'b': 20}, {'a': 3} >> AS x
               GROUP BY x.a
               ''',
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[EvalModeCoerce, EvalModeError],
-      output:$bag::[
-        {
-          a: 1,
-          e: true
-        },
-        {
-          a: 2,
-          e: false
-        },
-        {
-          a: 3,
-          e: null
-        },
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            a: 1,
+            e: true
+          },
+          {
+            a: 2,
+            e: false
+          },
+          {
+            a: 3,
+            e: null
+          },
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   },
   {
     name:"EVERY DISTINCT with GROUP BY",
@@ -789,24 +819,30 @@ sql_every::[
               FROM [ {'a': 1, 'b': 10}, {'a': 1, 'b': 11}, {'a': 2, 'b': 20}, {'a': 3} ] AS x
               GROUP BY x.a
               ''',
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[EvalModeCoerce, EvalModeError],
-      output:$bag::[
-        {
-          a: 1,
-          e: true
-        },
-        {
-          a: 2,
-          e: false
-        },
-        {
-          a: 3,
-          e: null
-        },
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            a: 1,
+            e: true
+          },
+          {
+            a: 2,
+            e: false
+          },
+          {
+            a: 3,
+            e: null
+          },
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   }
 ]
 

--- a/partiql-tests-data/eval/query/undefined-variable-behavior.ion
+++ b/partiql-tests-data/eval/query/undefined-variable-behavior.ion
@@ -51,15 +51,21 @@ undefined_variable_behavior::[
   {
     name:"undefinedUnqualifiedVariableInSelectWithUndefinedVariableBehaviorMissing",
     statement:"SELECT s.a, s.undefined_variable, s.b FROM `[{a:100, b:200}]` s",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          a:100,
-          b:200
-        }
-      ]
-    }
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
+            a:100,
+            b:200
+          }
+        ]
+      },
+      {
+        evalMode:EvalModeError,
+        result:EvaluationFail
+      },
+    ]
   }
 ]

--- a/partiql-tests-data/eval/spec-tests.ion
+++ b/partiql-tests-data/eval/spec-tests.ion
@@ -329,38 +329,62 @@
     {
         name: "attribute value evaluates to MISSING",
         statement: "SELECT VALUE {'a':v.a, 'b':v.b} FROM [{'a':1, 'b':1}, {'a':2}] AS v",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{a:1, b:1}, {a:2}]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[{a:1, b:1}, {a:2}]
+            },
+            {
+                evalMode:EvalModeError,
+                result:EvaluationFail
+            },
+        ]
     },
     {
         name: "array element evaluates to MISSING",
         statement: "SELECT VALUE [v.a, v.b] FROM [{'a':1, 'b':1}, {'a':2}] AS v",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[[1, 1], [2, $missing::null]]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[[1, 1], [2, $missing::null]]
+            },
+            {
+                evalMode:EvalModeError,
+                result:EvaluationFail
+            },
+        ]
     },
     {
         name: "bag element evaluates to MISSING",
         statement: "SELECT VALUE v.b FROM [{'a':1, 'b':1}, {'a':2}] AS v",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[1, $missing::null]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[1, $missing::null]
+            },
+            {
+                evalMode:EvalModeError,
+                result:EvaluationFail
+            },
+        ]
     },
     {
         name: "bag element evaluates to MISSING in bag constructor",
         statement: "SELECT VALUE <<v.a, v.b>> FROM [{'a':1, 'b':1}, {'a':2}] AS v",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[$bag::[1, 1], $bag::[2, $missing::null]]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[$bag::[1, 1], $bag::[2, $missing::null]]
+            },
+            {
+                evalMode:EvalModeError,
+                result:EvaluationFail
+            },
+        ]
     },
     {
         name: "pivot into a tuple",
@@ -412,11 +436,17 @@
     {
         name: "cast and operations with missing argument",
         statement: "SELECT VALUE {'a':3*v.a, 'b':3*(CAST(v.b AS INTEGER))} FROM [{'a':1, 'b':'1'}, {'a':2}] v",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{a:3, b:3}, {a:6}]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[{a:3, b:3}, {a:6}]
+            },
+            {
+                evalMode:EvalModeError,
+                result:EvaluationFail
+            },
+        ]
     },
     {
         name: "missing value in arithmetic expression",
@@ -721,15 +751,21 @@
                 {co:0.5}
             ]
         },
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[
-                {sensor:1, readings:$bag::[0.4, 0.2]},
-                {sensor:2, readings:$bag::[0.3]},
-                {sensor:null, readings:$bag::[0.1, 0.5]}
-            ]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[
+                    {sensor:1, readings:$bag::[0.4, 0.2]},
+                    {sensor:2, readings:$bag::[0.3]},
+                    {sensor:null, readings:$bag::[0.1, 0.5]}
+                ]
+            },
+            {
+                evalMode:EvalModeError,
+                result:EvaluationFail
+            },
+        ]
     },
     {
         name: "group by with differenciated absent values",
@@ -749,16 +785,22 @@
                 {co:0.5}
             ]
         },
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[
-                {sensor:1, readings:$bag::[0.4, 0.2]},
-                {sensor:2, readings:$bag::[0.3]},
-                {sensor:null, readings:$bag::[0.1]},
-                {readings:$bag::[0.5]}
-            ]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[
+                    {sensor:1, readings:$bag::[0.4, 0.2]},
+                    {sensor:2, readings:$bag::[0.3]},
+                    {sensor:null, readings:$bag::[0.1]},
+                    {readings:$bag::[0.5]}
+                ]
+            },
+            {
+                evalMode:EvalModeError,
+                result:EvaluationFail
+            },
+        ]
     },
     {
         name: "windowing simplified with grouping",

--- a/partiql-tests-data/eval/spec-tests.ion
+++ b/partiql-tests-data/eval/spec-tests.ion
@@ -147,7 +147,7 @@
         statement: "SELECT x FROM someOrderedTable[0].a AS x",
         assert: [
             {
-                evalMode: [EvalModeCoerce, EvalModeError],
+                evalMode: EvalModeCoerce,
                 result: EvaluationSuccess,
                 output: $bag::[{x: 0}]
             },
@@ -637,11 +637,17 @@
     {
         name: "WHERE clause eliminating absent values",
         statement: "SELECT VALUE v.a FROM [{'a':1, 'b':true}, {'a':2, 'b':null}, {'a':3}] v WHERE v.b",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[1]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[1]
+            },
+            {
+                evalMode:EvalModeError,
+                result:EvaluationFail
+            },
+        ]
     },
     {
         name: "null is missing",

--- a/partiql-tests-data/eval/spec-tests.ion
+++ b/partiql-tests-data/eval/spec-tests.ion
@@ -145,11 +145,17 @@
     {
         name: "single source FROM with scalar",
         statement: "SELECT x FROM someOrderedTable[0].a AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{x: 0}]
-        }
+        assert: [
+            {
+                evalMode: [EvalModeCoerce, EvalModeError],
+                result: EvaluationSuccess,
+                output: $bag::[{x: 0}]
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail,
+            }
+        ]
     },
     {
         name: "single source FROM with scalar and AT clause",
@@ -169,11 +175,17 @@
     {
         name: "single source FROM with tuple",
         statement: "SELECT x FROM {'someKey': 'someValue' } AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{x: {someKey: "someValue"}}]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[{x: {someKey: "someValue"}}]
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail,
+            }
+        ]
     },
     {
         name: "single source FROM with tuple and AT clause",
@@ -193,11 +205,17 @@
     {
         name: "single source FROM with absent value null",
         statement: "SELECT x FROM NULL AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{x: null}]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[{x: null}]
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail,
+            }
+        ]
     },
     {
         name: "single source FROM with absent value null and AT clause",
@@ -217,11 +235,17 @@
     {
         name: "single source FROM with absent value missing",
         statement: "SELECT x FROM MISSING AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{}]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[{}]
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail,
+            },
+        ]
     },
     {
         name: "single source FROM with absent value missing and AT clause",

--- a/partiql-tests-data/eval/spec-tests.ion
+++ b/partiql-tests-data/eval/spec-tests.ion
@@ -145,17 +145,11 @@
     {
         name: "single source FROM with scalar",
         statement: "SELECT x FROM someOrderedTable[0].a AS x",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{x: 0}]
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            }
-        ]
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[{x: 0}]
+        }
     },
     {
         name: "single source FROM with scalar and AT clause",
@@ -175,17 +169,11 @@
     {
         name: "single source FROM with tuple",
         statement: "SELECT x FROM {'someKey': 'someValue' } AS x",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{x: {someKey: "someValue"}}]
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            }
-        ]
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[{x: {someKey: "someValue"}}]
+        }
     },
     {
         name: "single source FROM with tuple and AT clause",
@@ -205,17 +193,11 @@
     {
         name: "single source FROM with absent value null",
         statement: "SELECT x FROM NULL AS x",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{x: null}]
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            }
-        ]
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[{x: null}]
+        }
     },
     {
         name: "single source FROM with absent value null and AT clause",
@@ -235,17 +217,11 @@
     {
         name: "single source FROM with absent value missing",
         statement: "SELECT x FROM MISSING AS x",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{}]
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            },
-        ]
+        assert: {
+            evalMode: [EvalModeCoerce, EvalModeError],
+            result: EvaluationSuccess,
+            output: $bag::[{}]
+        }
     },
     {
         name: "single source FROM with absent value missing and AT clause",


### PR DESCRIPTION
## Description
- Corrects 80+ incorrect tests.
- The following sections break down each test and why they're wrong according to the PartiQL Specification.

### FROM RHS Coercion
The excerpt below comes from the PartiQL Specification and states that, in strict mode, the query will FAIL when the RHS of a FROM is a scalar. In permissive, it'll be coerced to a bag holding the scalar.
> In the following cases the expression in the FROM clause item has the wrong type. Under the type checking option, all of these cases raise an error and the query fails. Under the permissive option, the cases proceed as follows:
>
> Iteration over a scalar value: Consider the query:
> FROM s AS v AT p
> or the query:
> FROM s AS v
>
> where s is a scalar value. Then s coerces into the bag \<\< s \>\>, i.e., the bag that has a single element, the s. The
> rest of the semantics is identical to what happens when the lhs of the FROM item is a bag.

This is applicable to the following 11 tests:
- `dateTimePartsAsVariableNames`
- `various types in from clause`
- `rangeTwiceOverScalar`
- `single source FROM with scalar`
- `single source FROM with scalar and AT clause`
- `single source FROM with tuple`
- `single source FROM with tuple and AT clause`
- `single source FROM with absent value null`
- `single source FROM with absent value null and AT clause`
- `single source FROM with absent value missing`
- `single source FROM with absent value missing and AT clause`

### Negative Indexing
From the PartiQL Specification:
> In the permissive mode, an array navigation evaluation a[i] will result into missing in each of the following cases:
> • a does not evaluate into an array, or
> • i does not evaluate into a positive integer within the array’s bounds.
> ...
> In type checking mode, the query will fail in each one of the cases above.

This is applicable to the following 2 tests:
- `ordinalAccessWithNegativeIndex`
- `ordinalAccessWithNegativeIndexAndBindings`

### SFW Coercion
The excerpt below comes from the PartiQL Specification and states that SELECT queries shall be coerced.
> In each of the following cases a SFW subquery coerces into a scalar...
> if it is an SFW subquery expression that (a) is not the collection expression of a FROM clause item and (b) is not
the rhs of an IN. (If it is the rhs of an IN then it should not be coerced; see note on semantics of IN, Section ??.)

This is applicable to the following 4 tests:
- `SELECT VALUE with nested aggregates : SELECT VALUE (SELECT SUM(outerFromSource.col1) AS the_sum FROM <<1>>) FROM simple_1_col_1_group as outerFromSource`
- `selectListMultipleAggregatesNestedQuery`
- `Expression with multiple subqueriees containing aggregates : CAST((SELECT COUNT(1) FROM products) AS LIST)[0]._1 / CAST((SELECT COUNT(1) FROM suppliers) AS LIST)[0]._1`
- `Aggregates with subquery containing another aggregate : SELECT COUNT(1) + CAST((SELECT SUM(numInStock) FROM products) AS LIST)[0]._1 as a_number FROM products`

Note: I had to rename some of these due to the inclusion of the queries in their names.

### EXCEPT DISTINCT Bug

For more information, please see partiql/partiql-lang#75

This is applicable to the following 1 test:
- `outerExceptDistinct`.

### Tuple Path Navigation Failures

From the PartiQL Specification:
> In the case of tuple paths, since PartiQL does not assume a schema, the semantics must also specify the return value
when:
> 1. t is not a tuple (i.e., when the expression t does not evaluate into a tuple), or
> 2. t is a tuple that does not have an a attribute.
> ...
> PartiQL can operate in a permissive mode or in a conventional type checking mode, where the
> query fails once typing errors (such as the above mentioned ones) happen. In the permissive mode, typing errors are
> typically neglected by using the semantics outlined next...
> In all of the above cases PartiQL returns the special value missing.

Notably, it seems that, in type checking mode, grouping does NOT coerce any type checking errors to NULL/MISSING. However, if a MISSING is encountered (not an error), then it will be coerced to `NULL`.
> If a grouping expression evaluates to MISSING, it is first coerced into NULL, thus bringing MISSING and NULL in the same group.

Similarly, aggregate functions are modeled as scalar functions that take in BAGS and output scalars. It seems that a type check exception occurring within the arguments of an aggregate function will result in a query failure (it won't be caught) with type checking mode. In permissive, these failures are coerced to MISSING, and the aggregate functions handle them appropriately.

This is applicable to the following 58 tests:
- `selectValueStructConstructorWithMissing`
- `SELECT supplierId_missings FROM products_sparse p GROUP BY p.supplierId_missings`
- `SELECT p.supplierId_missings FROM products_sparse p GROUP BY p.supplierId_missings`
- `SELECT VALUE { 'supplierId_missings' : p.supplierId_missings } FROM products_sparse p GROUP BY p.supplierId_missings`
- `SELECT supplierId_mixed FROM products_sparse p GROUP BY p.supplierId_mixed`
- `SELECT p.supplierId_mixed FROM products_sparse p GROUP BY p.supplierId_mixed`
- `SELECT VALUE { 'supplierId_mixed' : p.supplierId_mixed } FROM products_sparse p GROUP BY p.supplierId_mixed`
- `SELECT regionId, supplierId_missings FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings`
- `SELECT p.regionId, p.supplierId_missings FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings`
- `SELECT VALUE { 'regionId': p.regionId, 'supplierId_missings': p.supplierId_missings } FROM products_sparse p GROUP BY p.regionId, p.supplierId_missings`
- `SELECT regionId, supplierId_mixed FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed`
- `SELECT regionId, p.supplierId_mixed FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed`
- `SELECT VALUE { 'regionId': p.regionId, 'supplierId_mixed': p.supplierId_mixed } FROM products_sparse p GROUP BY p.regionId, p.supplierId_mixed`
- `SELECT COUNT(1) AS the_count, <ALL_AGGS>(p.price_missings) AS the_agg FROM products_sparse AS p`
- `SELECT COUNT(1) AS the_count, <ALL_AGGS>(p.price_mixed) AS the_agg FROM products_sparse AS p`
- `SELECT categoryId, COUNT(1) AS the_count, <ALL_AGGS>(p.price_missings) AS the_agg FROM products_sparse AS p GROUP BY categoryId`
- `SELECT categoryId, COUNT(1) AS the_count, <ALL_AGGS>(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY categoryId`
- `SELECT p.categoryId, COUNT(1) AS the_count, <ALL_AGGS>( price_nulls) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId`
- `SELECT p.categoryId, COUNT(1) AS the_count, <ALL_AGGS>(p.price_mixed) AS the_agg FROM products_sparse AS p GROUP BY p.categoryId`
- `undefinedUnqualifiedVariable_inSelect_withProjectionOption`
- `selectListWithMissing`
- `ANY with GROUP BY`
- `ANY DISTINCT with GROUP BY`
- `SOME with GROUP BY`
- `SOME DISTINCT with GROUP BY`
- `EVERY with GROUP BY`
- `EVERY DISTINCT with GROUP BY`
- `undefinedUnqualifiedVariableInSelectWithUndefinedVariableBehaviorMissing`
- `array element evaluates to MISSING`
- `bag element evaluates to MISSING`
- `bag element evaluates to MISSING in bag constructor`
- `cast and operations with missing argument`
- `group by with absent values`
- `group by with differenciated absent values`

### UNPIVOT Coercion

I fixed a handful of tests that do not handle the Unpivot mistyping scenarios. According to the PartiQL Specification:
> In the following cases the expression in the FROM UNPIVOT clause item has the “wrong" type, i.e., it is not a tuple.
> Under the type checking option, all of these cases raise an error and the query fails. Under the permissive option, the cases proceed as follows:
> FROM UNPIVOT x AS v AT n
> whereas x is not a tuple and is not MISSING, is equivalent to:
FROM UNPIVOT {'_1': x} AS v AT n

### AT Alias When Unordered

I fixed some tests that previously contradicted the following excerpt from the PartiQL Specification:
> In the following cases the expression in the FROM clause item has the wrong type. Under the type checking option, all of these cases raise an error and the query fails. Under the permissive option, the cases proceed as follows
> • Position variable on bags: Consider the clause:
> FROM b AS v AT p
> and assume that b is a bag << e0, . . . , en−1 >>. The output is a bag with binding tuples 〈v : ei, p : MISSING. The value MISSING for the variable p indicates that the order of elements in the bag was meaningless.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.