### PR TITLE
Fixes missing arguments tests

### DIFF
--- a/partiql-tests-data/eval/primitives/coll-aggregate-function.ion
+++ b/partiql-tests-data/eval/primitives/coll-aggregate-function.ion
@@ -1,11 +1,11 @@
 envs::{
-  data:[
+  data: [
     1,
     1,
     1,
     2
   ],
-  numbers:[
+  numbers: [
     1,
     2.0,
     3e0,
@@ -16,275 +16,333 @@ envs::{
 
 coll_max::[
   {
-    name:"max top level{agg:'COLL_MAX(data)',result:(success 2)}",
-    statement:"COLL_MAX(data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "max top level{agg:'COLL_MAX(data)',result:(success 2)}",
+    statement: "COLL_MAX(data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"coll_max top level{agg:'COLL_MAX(ALL data)',result:(success 2)}",
-    statement:"COLL_MAX(ALL data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_max top level{agg:'COLL_MAX(ALL data)',result:(success 2)}",
+    statement: "COLL_MAX(ALL data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"coll_max top level{agg:'COLL_MAX(DISTINCT data)',result:(success 2)}",
-    statement:"COLL_MAX(DISTINCT data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_max top level{agg:'COLL_MAX(DISTINCT data)',result:(success 2)}",
+    statement: "COLL_MAX(DISTINCT data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"topLevelCollMax",
-    statement:"COLL_MAX(numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:5.
+    name: "topLevelCollMax",
+    statement: "COLL_MAX(numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 5.
     }
   },
   {
-    name:"topLevelDistinctCollMax",
-    statement:"COLL_MAX(DISTINCT numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:5.
+    name: "topLevelDistinctCollMax",
+    statement: "COLL_MAX(DISTINCT numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 5.
     }
   },
   {
-    name:"topLevelAllCollMax",
-    statement:"COLL_MAX(ALL numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:5.
+    name: "topLevelAllCollMax",
+    statement: "COLL_MAX(ALL numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 5.
     }
   },
   {
-    name:"COLL_MAX empty collection",
-    statement:"COLL_MAX(<< >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_MAX empty collection",
+    statement: "COLL_MAX(<< >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_MAX null",
-    statement:"COLL_MAX(NULL)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_MAX null",
+    statement: "COLL_MAX(NULL)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_MAX missing",
-    statement:"COLL_MAX(MISSING)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$missing::null
-    }
-  },
-  {
-    name:"COLL_MAX list of missing element",
-    statement:"COLL_MAX([MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_MAX bag of missing elements",
-    statement:"COLL_MAX(<<MISSING, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_MAX non-collection",
-    statement:"COLL_MAX('non-collection')",
-    assert:[
+    name: "COLL_MAX missing",
+    statement: "COLL_MAX(MISSING)",
+    assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        result: EvaluationFail,
+        evalMode: EvalModeError
       }
     ]
   },
   {
-    name:"COLL_MAX bag of heterogeneous element types",
-    statement:"COLL_MAX(<<1, 'non-number', NULL, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:"non-number"
+    name: "COLL_MAX list of missing element",
+    statement: "COLL_MAX([MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_MAX bag of missing elements",
+    statement: "COLL_MAX(<<MISSING, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_MAX non-collection",
+    statement: "COLL_MAX('non-collection')",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "COLL_MAX bag of heterogeneous element types",
+    statement: "COLL_MAX(<<1, 'non-number', NULL, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: "non-number"
     }
   },
 ]
 
 coll_avg::[
   {
-    name:"coll_avg top level{agg:'COLL_AVG(data)',result:(success 1.25)}",
-    statement:"COLL_AVG(data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_avg top level{agg:'COLL_AVG(data)',result:(success 1.25)}",
+    statement: "COLL_AVG(data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1.25
+      output: 1.25
     }
   },
   {
-    name:"coll_avg top level{agg:'COLL_AVG(ALL data)',result:(success 1.25)}",
-    statement:"COLL_AVG(ALL data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_avg top level{agg:'COLL_AVG(ALL data)',result:(success 1.25)}",
+    statement: "COLL_AVG(ALL data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1.25
+      output: 1.25
     }
   },
   {
-    name:"coll_avg top level{agg:'COLL_AVG(DISTINCT data)',result:(success 1.5)}",
-    statement:"COLL_AVG(DISTINCT data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_avg top level{agg:'COLL_AVG(DISTINCT data)',result:(success 1.5)}",
+    statement: "COLL_AVG(DISTINCT data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1.5
+      output: 1.5
     }
   },
   {
-    name:"topLevelCollAvg",
-    statement:"COLL_AVG(numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:3.0
+    name: "topLevelCollAvg",
+    statement: "COLL_AVG(numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 3.0
     }
   },
   {
-    name:"topLevelDistinctCollAvg",
-    statement:"COLL_AVG(DISTINCT [1,1,1,1,1,3])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:2.
+    name: "topLevelDistinctCollAvg",
+    statement: "COLL_AVG(DISTINCT [1,1,1,1,1,3])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 2.
     }
   },
   {
-    name:"topLevelCollAvgOnlyInt",
-    statement:"COLL_AVG([2,2,2,4])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:2.5
+    name: "topLevelCollAvgOnlyInt",
+    statement: "COLL_AVG([2,2,2,4])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 2.5
     }
   },
   {
-    name:"COLL_AVG empty collection",
-    statement:"COLL_AVG(<< >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_AVG empty collection",
+    statement: "COLL_AVG(<< >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_AVG null",
-    statement:"COLL_AVG(NULL)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_AVG null",
+    statement: "COLL_AVG(NULL)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_AVG missing",
-    statement:"COLL_AVG(MISSING)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$missing::null
-    }
-  },
-  {
-    name:"COLL_AVG list of missing element",
-    statement:"COLL_AVG([MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_AVG bag of missing elements",
-    statement:"COLL_AVG(<<MISSING, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_AVG non-collection",
-    statement:"COLL_AVG('non-collection')",
-    assert:[
+    name: "COLL_AVG missing",
+    statement: "COLL_AVG(MISSING)",
+    assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        evalMode:
+        EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        result: EvaluationFail,
+        evalMode: EvalModeError
       }
     ]
   },
   {
-    name:"COLL_AVG mistyped element",
-    statement:"COLL_AVG(<<1, 'non-number'>>)",
-    assert:[
+    name: "COLL_AVG list of missing element",
+    statement: "COLL_AVG([MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_AVG bag of missing elements",
+    statement: "COLL_AVG(<<MISSING, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_AVG non-collection",
+    statement: "COLL_AVG('non-collection')",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "COLL_AVG mistyped element",
+    statement: "COLL_AVG(<<1, 'non-number'>>)",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
@@ -292,275 +350,334 @@ coll_avg::[
 
 coll_count::[
   {
-    name:"coll_count top level{agg:'COLL_COUNT(data)',result:(success 4)}",
-    statement:"COLL_COUNT(data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_count top level{agg:'COLL_COUNT(data)',result:(success 4)}",
+    statement: "COLL_COUNT(data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"coll_count top level{agg:'COLL_COUNT(ALL data)',result:(success 4)}",
-    statement:"COLL_COUNT(ALL data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_count top level{agg:'COLL_COUNT(ALL data)',result:(success 4)}",
+    statement: "COLL_COUNT(ALL data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"coll_count top level{agg:'COLL_COUNT(DISTINCT data)',result:(success 2)}",
-    statement:"COLL_COUNT(DISTINCT data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_count top level{agg:'COLL_COUNT(DISTINCT data)',result:(success 2)}",
+    statement: "COLL_COUNT(DISTINCT data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"topLevelCollCountDistinct",
-    statement:"COLL_COUNT(DISTINCT [1,1,1,1,2])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:2
+    name: "topLevelCollCountDistinct",
+    statement: "COLL_COUNT(DISTINCT [1,1,1,1,2])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 2
     }
   },
   {
-    name:"topLevelCollCount",
-    statement:"COLL_COUNT(numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:5
+    name: "topLevelCollCount",
+    statement: "COLL_COUNT(numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 5
     }
   },
   {
-    name:"topLevelAllCollCount",
-    statement:"COLL_COUNT(ALL numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:5
+    name: "topLevelAllCollCount",
+    statement: "COLL_COUNT(ALL numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 5
     }
   },
   {
-    name:"COLL_COUNT empty collection",
-    statement:"COLL_COUNT(<< >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:0
+    name: "COLL_COUNT empty collection",
+    statement: "COLL_COUNT(<< >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 0
     }
   },
   {
-    name:"COLL_COUNT null",
-    statement:"COLL_COUNT(NULL)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_COUNT null",
+    statement: "COLL_COUNT(NULL)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_COUNT missing",
-    statement:"COLL_COUNT(MISSING)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$missing::null
-    }
-  },
-  {
-    name:"COLL_COUNT list of missing element",
-    statement:"COLL_COUNT([MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:0
-    }
-  },
-  {
-    name:"COLL_COUNT bag of missing elements",
-    statement:"COLL_COUNT(<<MISSING, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:0
-    }
-  },
-  {
-    name:"COLL_COUNT non-collection",
-    statement:"COLL_COUNT('non-collection')",
-    assert:[
+    name: "COLL_COUNT missing",
+    statement: "COLL_COUNT(MISSING)",
+    assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        evalMode:
+        EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        result: EvaluationFail,
+        evalMode: EvalModeError
       }
     ]
   },
   {
-    name:"COLL_COUNT bag of heterogeneous element types",
-    statement:"COLL_COUNT(<<1, 'non-number', NULL, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:2
+    name: "COLL_COUNT list of missing element",
+    statement: "COLL_COUNT([MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 0
+    }
+  },
+  {
+    name: "COLL_COUNT bag of missing elements",
+    statement: "COLL_COUNT(<<MISSING, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 0
+    }
+  },
+  {
+    name: "COLL_COUNT non-collection",
+    statement: "COLL_COUNT('non-collection')",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "COLL_COUNT bag of heterogeneous element types",
+    statement: "COLL_COUNT(<<1, 'non-number', NULL, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 2
     }
   },
 ]
 
 coll_sum::[
   {
-    name:"coll_sum top level{agg:'COLL_SUM(data)',result:(success 5)}",
-    statement:"COLL_SUM(data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_sum top level{agg:'COLL_SUM(data)',result:(success 5)}",
+    statement: "COLL_SUM(data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"coll_sum top level{agg:'COLL_SUM(ALL data)',result:(success 5)}",
-    statement:"COLL_SUM(ALL data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_sum top level{agg:'COLL_SUM(ALL data)',result:(success 5)}",
+    statement: "COLL_SUM(ALL data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"coll_sum top level{agg:'COLL_SUM(DISTINCT data)',result:(success 3)}",
-    statement:"COLL_SUM(DISTINCT data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_sum top level{agg:'COLL_SUM(DISTINCT data)',result:(success 3)}",
+    statement: "COLL_SUM(DISTINCT data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"topLevelCollSum",
-    statement:"COLL_SUM(numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:15.0
+    name: "topLevelCollSum",
+    statement: "COLL_SUM(numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 15.0
     }
   },
   {
-    name:"topLevelAllCollSum",
-    statement:"COLL_SUM(ALL numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:15.0
+    name: "topLevelAllCollSum",
+    statement: "COLL_SUM(ALL numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 15.0
     }
   },
   {
-    name:"topLevelDistinctCollSum",
-    statement:"COLL_SUM(DISTINCT [1,1,1,1,1,1,1,2])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:3
+    name: "topLevelDistinctCollSum",
+    statement: "COLL_SUM(DISTINCT [1,1,1,1,1,1,1,2])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 3
     }
   },
   {
-    name:"COLL_SUM empty collection",
-    statement:"COLL_SUM(<< >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_SUM empty collection",
+    statement: "COLL_SUM(<< >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_SUM null",
-    statement:"COLL_SUM(NULL)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_SUM null",
+    statement: "COLL_SUM(NULL)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_SUM missing",
-    statement:"COLL_SUM(MISSING)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$missing::null
-    }
-  },
-  {
-    name:"COLL_SUM list of missing element",
-    statement:"COLL_SUM([MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_SUM bag of missing elements",
-    statement:"COLL_SUM(<<MISSING, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_SUM non-collection",
-    statement:"COLL_SUM('non-collection')",
-    assert:[
+    name: "COLL_SUM missing",
+    statement: "COLL_SUM(MISSING)",
+    assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        evalMode:
+        EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        result: EvaluationFail,
+        evalMode: EvalModeError
       }
     ]
   },
   {
-    name:"COLL_SUM mistyped element",
-    statement:"COLL_SUM(<<1, 'non-number'>>)",
-    assert:[
+    name: "COLL_SUM list of missing element",
+    statement: "COLL_SUM([MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_SUM bag of missing elements",
+    statement: "COLL_SUM(<<MISSING, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_SUM non-collection",
+    statement: "COLL_SUM('non-collection')",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "COLL_SUM mistyped element",
+    statement: "COLL_SUM(<<1, 'non-number'>>)",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
@@ -568,305 +685,376 @@ coll_sum::[
 
 coll_min::[
   {
-    name:"coll_min top level{agg:'COLL_MIN(data)',result:(success 1)}",
-    statement:"COLL_MIN(data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_min top level{agg:'COLL_MIN(data)',result:(success 1)}",
+    statement: "COLL_MIN(data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"coll_min top level{agg:'COLL_MIN(ALL data)',result:(success 1)}",
-    statement:"COLL_MIN(ALL data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_min top level{agg:'COLL_MIN(ALL data)',result:(success 1)}",
+    statement: "COLL_MIN(ALL data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"coll_min top level{agg:'COLL_MIN(DISTINCT data)',result:(success 1)}",
-    statement:"COLL_MIN(DISTINCT data)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "coll_min top level{agg:'COLL_MIN(DISTINCT data)',result:(success 1)}",
+    statement: "COLL_MIN(DISTINCT data)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"topLevelCollMin",
-    statement:"COLL_MIN(numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:1
+    name: "topLevelCollMin",
+    statement: "COLL_MIN(numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 1
     }
   },
   {
-    name:"topLevelDistinctCollMin",
-    statement:"COLL_MIN(DISTINCT numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:1
+    name: "topLevelDistinctCollMin",
+    statement: "COLL_MIN(DISTINCT numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 1
     }
   },
   {
-    name:"topLevelAllCollMin",
-    statement:"COLL_MIN(ALL numbers)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:1
+    name: "topLevelAllCollMin",
+    statement: "COLL_MIN(ALL numbers)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 1
     }
   },
   {
-    name:"COLL_MIN empty collection",
-    statement:"COLL_MIN(<< >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_MIN empty collection",
+    statement: "COLL_MIN(<< >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_MIN null",
-    statement:"COLL_MIN(NULL)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_MIN null",
+    statement: "COLL_MIN(NULL)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_MIN missing",
-    statement:"COLL_MIN(MISSING)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$missing::null
-    }
-  },
-  {
-    name:"COLL_MIN list of missing element",
-    statement:"COLL_MIN([MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_MIN bag of missing elements",
-    statement:"COLL_MIN(<<MISSING, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_MIN non-collection",
-    statement:"COLL_MIN('non-collection')",
-    assert:[
+    name: "COLL_MIN missing",
+    statement: "COLL_MIN(MISSING)",
+    assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        evalMode:
+        EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        result: EvaluationFail,
+        evalMode: EvalModeError
       }
     ]
   },
   {
-    name:"COLL_MIN bag of heterogeneous element types",
-    statement:"COLL_MIN(<<1, 'non-number', NULL, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:1
+    name: "COLL_MIN list of missing element",
+    statement: "COLL_MIN([MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_MIN bag of missing elements",
+    statement: "COLL_MIN(<<MISSING, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_MIN non-collection",
+    statement: "COLL_MIN('non-collection')",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "COLL_MIN bag of heterogeneous element types",
+    statement: "COLL_MIN(<<1, 'non-number', NULL, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 1
     }
   },
 ]
 
 coll_any::[
   {
-    name:"COLL_ANY bag literals",
-    statement:"COLL_ANY(<< false, true, false >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_ANY bag literals",
+    statement: "COLL_ANY(<< false, true, false >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_ANY list expressions",
-    statement:"COLL_ANY([ 1 < 5, false, 5 IS NULL ])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_ANY list expressions",
+    statement: "COLL_ANY([ 1 < 5, false, 5 IS NULL ])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_ANY single true",
-    statement:"COLL_ANY(<<true>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_ANY single true",
+    statement: "COLL_ANY(<<true>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_ANY single false",
-    statement:"COLL_ANY([false])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:false
+    name: "COLL_ANY single false",
+    statement: "COLL_ANY([false])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
     }
   },
   {
-    name:"COLL_ANY nulls with true",
-    statement:"COLL_ANY(<< NULL, 2<3, MISSING, false >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_ANY nulls with true",
+    statement: "COLL_ANY(<< NULL, 2<3, MISSING, false >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_ANY nulls with false",
-    statement:"COLL_ANY([ 2>3, NULL ])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:false
+    name: "COLL_ANY nulls with false",
+    statement: "COLL_ANY([ 2>3, NULL ])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
     }
   },
   {
-    name:"COLL_ANY nulls only",
-    statement:"COLL_ANY([NULL, MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_ANY nulls only",
+    statement: "COLL_ANY([NULL, MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_ANY null",
-    statement:"COLL_ANY(NULL)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_ANY null",
+    statement: "COLL_ANY(NULL)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_ANY missing",
-    statement:"COLL_ANY(MISSING)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$missing::null
-    }
-  },
-  {
-    name:"COLL_ANY list of missing element",
-    statement:"COLL_ANY([MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_ANY bag of missing elements",
-    statement:"COLL_ANY(<<MISSING, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_ANY some empty",
-    statement:"COLL_ANY(<< >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_ANY non-collection",
-    statement:"COLL_ANY('non-collection')",
-    assert:[
+    name: "COLL_ANY missing",
+    statement: "COLL_ANY(MISSING)",
+    assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        evalMode:
+        EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        result: EvaluationFail,
+        evalMode: EvalModeError
       }
     ]
   },
   {
-    name:"COLL_ANY one non-bool, non-unknown",
-    statement:"COLL_ANY(<< true, 5, true >>)",
-    assert:[
+    name: "COLL_ANY list of missing element",
+    statement: "COLL_ANY([MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_ANY bag of missing elements",
+    statement: "COLL_ANY(<<MISSING, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_ANY some empty",
+    statement: "COLL_ANY(<< >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_ANY non-collection",
+    statement: "COLL_ANY('non-collection')",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"COLL_ANY all non-bool, non-unknown",
-    statement:"COLL_ANY([ 5, 'hello', 3.14])",
-    assert:[
+    name: "COLL_ANY one non-bool, non-unknown",
+    statement: "COLL_ANY(<< true, 5, true >>)",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"COLL_ANY nested collection",
-    statement:"COLL_ANY([[ true, false]])",
-    assert:[
+    name: "COLL_ANY all non-bool, non-unknown",
+    statement: "COLL_ANY([ 5, 'hello', 3.14])",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "COLL_ANY nested collection",
+    statement: "COLL_ANY([[ true, false]])",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
@@ -874,170 +1062,210 @@ coll_any::[
 
 coll_some::[
   {
-    name:"COLL_SOME bag literals",
-    statement:"COLL_SOME(<< false, true, false >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_SOME bag literals",
+    statement: "COLL_SOME(<< false, true, false >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_SOME list expressions",
-    statement:"COLL_SOME([ 1 < 5, false, 5 IS NULL ])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_SOME list expressions",
+    statement: "COLL_SOME([ 1 < 5, false, 5 IS NULL ])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_SOME single true",
-    statement:"COLL_SOME(<<true>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_SOME single true",
+    statement: "COLL_SOME(<<true>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_SOME single false",
-    statement:"COLL_SOME([false])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:false
+    name: "COLL_SOME single false",
+    statement: "COLL_SOME([false])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
     }
   },
   {
-    name:"COLL_SOME nulls with true",
-    statement:"COLL_SOME(<< NULL, 2<3, MISSING, false >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_SOME nulls with true",
+    statement: "COLL_SOME(<< NULL, 2<3, MISSING, false >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_SOME nulls with false",
-    statement:"COLL_SOME([ 2>3, NULL ])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:false
+    name: "COLL_SOME nulls with false",
+    statement: "COLL_SOME([ 2>3, NULL ])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
     }
   },
   {
-    name:"COLL_SOME nulls only",
-    statement:"COLL_SOME([NULL, MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_SOME nulls only",
+    statement: "COLL_SOME([NULL, MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_SOME null",
-    statement:"COLL_SOME(NULL)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_SOME null",
+    statement: "COLL_SOME(NULL)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_SOME missing",
-    statement:"COLL_SOME(MISSING)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$missing::null
-    }
-  },
-  {
-    name:"COLL_SOME list of missing element",
-    statement:"COLL_SOME([MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_SOME bag of missing elements",
-    statement:"COLL_SOME(<<MISSING, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_SOME some empty",
-    statement:"COLL_SOME(<< >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_SOME non-collection",
-    statement:"COLL_SOME('non-collection')",
-    assert:[
+    name: "COLL_SOME missing",
+    statement: "COLL_SOME(MISSING)",
+    assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        evalMode:
+        EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        result: EvaluationFail,
+        evalMode: EvalModeError
       }
     ]
   },
   {
-    name:"COLL_SOME one non-bool, non-unknown",
-    statement:"COLL_SOME(<< true, 5, true >>)",
-    assert:[
+    name: "COLL_SOME list of missing element",
+    statement: "COLL_SOME([MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_SOME bag of missing elements",
+    statement: "COLL_SOME(<<MISSING, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_SOME some empty",
+    statement: "COLL_SOME(<< >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_SOME non-collection",
+    statement: "COLL_SOME('non-collection')",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"COLL_SOME all non-bool, non-unknown",
-    statement:"COLL_SOME([ 5, 'hello', 3.14])",
-    assert:[
+    name: "COLL_SOME one non-bool, non-unknown",
+    statement: "COLL_SOME(<< true, 5, true >>)",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"COLL_SOME nested collection",
-    statement:"COLL_SOME([[ true, false]])",
-    assert:[
+    name: "COLL_SOME all non-bool, non-unknown",
+    statement: "COLL_SOME([ 5, 'hello', 3.14])",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "COLL_SOME nested collection",
+    statement: "COLL_SOME([[ true, false]])",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
@@ -1045,170 +1273,210 @@ coll_some::[
 
 coll_every::[
   {
-    name:"COLL_EVERY bag literals",
-    statement:"COLL_EVERY(<< true, false, true >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:false
+    name: "COLL_EVERY bag literals",
+    statement: "COLL_EVERY(<< true, false, true >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
     }
   },
   {
-    name:"COLL_EVERY list expressions",
-    statement:"COLL_EVERY([ 1 < 5, true, NULL IS NULL])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_EVERY list expressions",
+    statement: "COLL_EVERY([ 1 < 5, true, NULL IS NULL])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_EVERY single true",
-    statement:"COLL_EVERY(<<true>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_EVERY single true",
+    statement: "COLL_EVERY(<<true>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_EVERY single false",
-    statement:"COLL_EVERY([false])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:false
+    name: "COLL_EVERY single false",
+    statement: "COLL_EVERY([false])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
     }
   },
   {
-    name:"COLL_EVERY null and missing with true",
-    statement:"COLL_EVERY(<< NULL, 2<3, MISSING, true >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:true
+    name: "COLL_EVERY null and missing with true",
+    statement: "COLL_EVERY(<< NULL, 2<3, MISSING, true >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
     }
   },
   {
-    name:"COLL_EVERY null with false",
-    statement:"COLL_EVERY([ 2>3, NULL ])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:false
+    name: "COLL_EVERY null with false",
+    statement: "COLL_EVERY([ 2>3, NULL ])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
     }
   },
   {
-    name:"COLL_EVERY null and missing only",
-    statement:"COLL_EVERY([NULL, MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_EVERY null and missing only",
+    statement: "COLL_EVERY([NULL, MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_EVERY null",
-    statement:"COLL_EVERY(NULL)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
+    name: "COLL_EVERY null",
+    statement: "COLL_EVERY(NULL)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
     }
   },
   {
-    name:"COLL_EVERY missing",
-    statement:"COLL_EVERY(MISSING)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$missing::null
-    }
-  },
-  {
-    name:"COLL_EVERY list of missing element",
-    statement:"COLL_EVERY([MISSING])",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_EVERY bag of missing elements",
-    statement:"COLL_EVERY(<<MISSING, MISSING>>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_EVERY empty collection",
-    statement:"COLL_EVERY(<< >>)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:null
-    }
-  },
-  {
-    name:"COLL_EVERY non-collection",
-    statement:"COLL_EVERY('non-collection')",
-    assert:[
+    name: "COLL_EVERY missing",
+    statement: "COLL_EVERY(MISSING)",
+    assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        evalMode:
+        EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        result: EvaluationFail,
+        evalMode: EvalModeError
       }
     ]
   },
   {
-    name:"COLL_EVERY one non-bool, non-unknown",
-    statement:"COLL_EVERY(<< true, 5, true >>)",
-    assert:[
+    name: "COLL_EVERY list of missing element",
+    statement: "COLL_EVERY([MISSING])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_EVERY bag of missing elements",
+    statement: "COLL_EVERY(<<MISSING, MISSING>>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_EVERY empty collection",
+    statement: "COLL_EVERY(<< >>)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "COLL_EVERY non-collection",
+    statement: "COLL_EVERY('non-collection')",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"COLL_EVERY all non-bool, non-unknown",
-    statement:"COLL_EVERY([ 5, 'hello', 3.14])",
-    assert:[
+    name: "COLL_EVERY one non-bool, non-unknown",
+    statement: "COLL_EVERY(<< true, 5, true >>)",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"COLL_EVERY nested collection",
-    statement:"COLL_EVERY([[ true, false]])",
-    assert:[
+    name: "COLL_EVERY all non-bool, non-unknown",
+    statement: "COLL_EVERY([ 5, 'hello', 3.14])",
+    assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "COLL_EVERY nested collection",
+    statement: "COLL_EVERY([[ true, false]])",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
       }
     ]
   },
@@ -1216,12 +1484,15 @@ coll_every::[
 
 coll_agg_in_select::[
   {
-    name:"selectValueCollAggregate",
-    statement:"SELECT VALUE COLL_COUNT(v) + COLL_SUM(v) FROM <<numbers, numbers>> AS v",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectValueCollAggregate",
+    statement: "SELECT VALUE COLL_COUNT(v) + COLL_SUM(v) FROM <<numbers, numbers>> AS v",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         20.0,
         20.0
       ]

--- a/partiql-tests-data/eval/primitives/functions/abs.ion
+++ b/partiql-tests-data/eval/primitives/functions/abs.ion
@@ -1,256 +1,259 @@
 abs::[
   {
-    name:"ABS(1) INT",
-    statement:"ABS(1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(1) INT",
+    statement: "ABS(1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"ABS(1.0) DECIMAL",
-    statement:"ABS(1.0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(1.0) DECIMAL",
+    statement: "ABS(1.0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10d-1
+      output: 10d-1
     }
   },
   {
-    name:"ABS(`1d0`) Ion DECIMAL",
-    statement:"ABS(`1d0`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`1d0`) Ion DECIMAL",
+    statement: "ABS(`1d0`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1d0
+      output: 1d0
     }
   },
   {
-    name:"ABS(`1e0`) Ion FLOAT",
-    statement:"ABS(`1e0`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`1e0`) Ion FLOAT",
+    statement: "ABS(`1e0`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1e0
+      output: 1e0
     }
   },
   {
-    name:"ABS(1.9999999999999999999900)",
-    statement:"ABS(1.9999999999999999999900)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(1.9999999999999999999900)",
+    statement: "ABS(1.9999999999999999999900)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:19999999999999999999900d-22
+      output: 19999999999999999999900d-22
     }
   },
   {
-    name:"ABS(-1)",
-    statement:"ABS(-1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(-1)",
+    statement: "ABS(-1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"ABS(-1.0)",
-    statement:"ABS(-1.0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(-1.0)",
+    statement: "ABS(-1.0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10d-1
+      output: 10d-1
     }
   },
   {
-    name:"ABS(`-1d0`)",
-    statement:"ABS(`-1d0`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`-1d0`)",
+    statement: "ABS(`-1d0`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1d0
+      output: 1d0
     }
   },
   {
-    name:"ABS(`-1e0`)",
-    statement:"ABS(`-1e0`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`-1e0`)",
+    statement: "ABS(`-1e0`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1e0
+      output: 1e0
     }
   },
   {
-    name:"ABS(-1.9999999999999999999900)",
-    statement:"ABS(-1.9999999999999999999900)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(-1.9999999999999999999900)",
+    statement: "ABS(-1.9999999999999999999900)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:19999999999999999999900d-22
+      output: 19999999999999999999900d-22
     }
   },
   {
-    name:"ABS(`-0.`)",
-    statement:"ABS(`-0.`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`-0.`)",
+    statement: "ABS(`-0.`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0d0
+      output: 0d0
     }
   },
   {
-    name:"ABS(`-0d0`)",
-    statement:"ABS(`-0d0`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`-0d0`)",
+    statement: "ABS(`-0d0`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0d0
+      output: 0d0
     }
   },
   {
-    name:"ABS(`-0d-0`)",
-    statement:"ABS(`-0d-0`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`-0d-0`)",
+    statement: "ABS(`-0d-0`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0d0
+      output: 0d0
     }
   },
   {
-    name:"ABS(`-0.0d1`)",
-    statement:"ABS(`-0.0d1`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`-0.0d1`)",
+    statement: "ABS(`-0.0d1`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0d0
+      output: 0d0
     }
   },
   {
-    name:"ABS(`-0.0000`) preserve scale",
-    statement:"ABS(`-0.0000`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`-0.0000`) preserve scale",
+    statement: "ABS(`-0.0000`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0d-4
+      output: 0d-4
     }
   },
   {
-    name:"ABS(`-inf`) special value",
-    statement:"ABS(`-inf`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`-inf`) special value",
+    statement: "ABS(`-inf`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:+inf
+      output: +inf
     }
   },
   {
-    name:"ABS(`+inf`) special value",
-    statement:"ABS(`+inf`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`+inf`) special value",
+    statement: "ABS(`+inf`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:+inf
+      output: +inf
     }
   },
   {
-    name:"ABS(`nan`) special value",
-    statement:"ABS(`nan`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(`nan`) special value",
+    statement: "ABS(`nan`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:nan
+      output: nan
     }
   },
   {
-    name:"ABS(MISSING) null propogation",
-    statement:"ABS(MISSING)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "ABS(MISSING) null propogation",
+    statement: "ABS(MISSING)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null,
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "ABS(NULL) null propogation",
+    statement: "ABS(NULL)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null,
+      output: null
     }
   },
   {
-    name:"ABS(NULL) null propogation",
-    statement:"ABS(NULL)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"ABS('foo')",
-    statement:"ABS('foo')",
+    name: "ABS('foo')",
+    statement: "ABS('foo')",
     assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        result:EvaluationSuccess,
+        result: EvaluationSuccess,
         evalMode: EvalModeCoerce,
-        output:$missing::null
+        output: $missing::null
       }
     ]
   }

--- a/partiql-tests-data/eval/primitives/functions/bit_length.ion
+++ b/partiql-tests-data/eval/primitives/functions/bit_length.ion
@@ -1,77 +1,80 @@
 bit_length::[
   {
-    name:"BIT_LENGTH empty string",
-    statement:"BIT_LENGTH('')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "BIT_LENGTH empty string",
+    statement: "BIT_LENGTH('')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"BIT_LENGTH string",
-    statement:"BIT_LENGTH('abc')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "BIT_LENGTH string",
+    statement: "BIT_LENGTH('abc')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:24
+      output: 24
     }
   },
   {
-    name:"BIT_LENGTH NULL",
-    statement:"BIT_LENGTH(NULL)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "BIT_LENGTH NULL",
+    statement: "BIT_LENGTH(NULL)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"BIT_LENGTH MISSING",
-    statement:"BIT_LENGTH(MISSING)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"BIT_LENGTH invalid type",
-    statement:"BIT_LENGTH(1)",
-    assert:[
+    name: "BIT_LENGTH MISSING",
+    statement: "BIT_LENGTH(MISSING)",
+    assert: [
       {
-        evalMode:EvalModeError,
-        result:EvaluationFail
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "BIT_LENGTH invalid type",
+    statement: "BIT_LENGTH(1)",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ],
   },
   {
-    name:"BIT_LENGTH special character",
-    statement:"BIT_LENGTH('français')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "BIT_LENGTH special character",
+    statement: "BIT_LENGTH('français')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:72
+      output: 72
     }
   },
 ]

--- a/partiql-tests-data/eval/primitives/functions/cardinality.ion
+++ b/partiql-tests-data/eval/primitives/functions/cardinality.ion
@@ -1,244 +1,248 @@
 cardinality::[
   {
-    name:"cardinality valid cases{param:\"`[]`\",result:0}",
-    statement:"cardinality(`[]`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`[]`\",result:0}",
+    statement: "cardinality(`[]`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"cardinality valid cases{param:\"<<>>\",result:0}",
-    statement:"cardinality(<<>>)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"<<>>\",result:0}",
+    statement: "cardinality(<<>>)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"cardinality valid cases{param:\"`{}`\",result:0}",
-    statement:"cardinality(`{}`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`{}`\",result:0}",
+    statement: "cardinality(`{}`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"cardinality valid cases{param:\"`[1]`\",result:1}",
-    statement:"cardinality(`[1]`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`[1]`\",result:1}",
+    statement: "cardinality(`[1]`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"cardinality valid cases{param:\"<<1>>\",result:1}",
-    statement:"cardinality(<<1>>)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"<<1>>\",result:1}",
+    statement: "cardinality(<<1>>)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"cardinality valid cases{param:\"`{a: 1}`\",result:1}",
-    statement:"cardinality(`{a: 1}`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`{a: 1}`\",result:1}",
+    statement: "cardinality(`{a: 1}`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"cardinality valid cases{param:\"`[1, 1.0]`\",result:2}",
-    statement:"cardinality(`[1, 1.0]`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`[1, 1.0]`\",result:2}",
+    statement: "cardinality(`[1, 1.0]`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"cardinality valid cases{param:\"<<1, 2, 3>>\",result:3}",
-    statement:"cardinality(<<1, 2, 3>>)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"<<1, 2, 3>>\",result:3}",
+    statement: "cardinality(<<1, 2, 3>>)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"cardinality valid cases{param:\"`{a: 1, b: foo}`\",result:2}",
-    statement:"cardinality(`{a: 1, b: foo}`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`{a: 1, b: foo}`\",result:2}",
+    statement: "cardinality(`{a: 1, b: foo}`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"cardinality valid cases{param:\"`[[], [1,2,3,4,[5,6], ()], ({a: 1, b: 2})]`\",result:3}",
-    statement:"cardinality(`[[], [1,2,3,4,[5,6], ()], ({a: 1, b: 2})]`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`[[], [1,2,3,4,[5,6], ()], ({a: 1, b: 2})]`\",result:3}",
+    statement: "cardinality(`[[], [1,2,3,4,[5,6], ()], ({a: 1, b: 2})]`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"cardinality valid cases{param:\"`{a: 1, a: 2}`\",result:2}",
-    statement:"cardinality(`{a: 1, a: 2}`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`{a: 1, a: 2}`\",result:2}",
+    statement: "cardinality(`{a: 1, a: 2}`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"cardinality valid cases{param:\"`[null]`\",result:1}",
-    statement:"cardinality(`[null]`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`[null]`\",result:1}",
+    statement: "cardinality(`[null]`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"cardinality valid cases{param:\"<<null>>\",result:1}",
-    statement:"cardinality(<<null>>)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"<<null>>\",result:1}",
+    statement: "cardinality(<<null>>)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"cardinality valid cases{param:\"`{a: null}`\",result:1}",
-    statement:"cardinality(`{a: null}`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`{a: null}`\",result:1}",
+    statement: "cardinality(`{a: null}`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"cardinality valid cases{param:\"`[missing]`\",result:1}",
-    statement:"cardinality(`[missing]`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`[missing]`\",result:1}",
+    statement: "cardinality(`[missing]`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"cardinality valid cases{param:\"<<missing>>\",result:1}",
-    statement:"cardinality(<<missing>>)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"<<missing>>\",result:1}",
+    statement: "cardinality(<<missing>>)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"cardinality valid cases{param:\"`{a: missing}`\",result:1}",
-    statement:"cardinality(`{a: missing}`)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality valid cases{param:\"`{a: missing}`\",result:1}",
+    statement: "cardinality(`{a: missing}`)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"cardinality null and missing propagation{param:\"null\"}",
-    statement:"cardinality(null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality null and missing propagation{param:\"null\"}",
+    statement: "cardinality(null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"cardinality null and missing propagation{param:\"missing\"}",
-    statement:"cardinality(missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "cardinality null and missing propagation{param:\"missing\"}",
+    statement: "cardinality(missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
         EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
   },
   {
-    name:"CARDINALITY('foo') type mismatch",
-    statement:"CARDINALITY('foo')",
+    name: "CARDINALITY('foo') type mismatch",
+    statement: "CARDINALITY('foo')",
     assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        result:EvaluationSuccess,
+        result: EvaluationSuccess,
         evalMode: EvalModeCoerce,
-        output:$missing::null
+        output: $missing::null
       }
     ]
   }

--- a/partiql-tests-data/eval/primitives/functions/char_length.ion
+++ b/partiql-tests-data/eval/primitives/functions/char_length.ion
@@ -1,3509 +1,3516 @@
 char_length::[
   {
-    name:"char_length valid cases{in:\"\",result:(success 0)}",
-    statement:"char_length('')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\",result:(success 0)}",
+    statement: "char_length('')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"char_length valid cases{in:\"a\",result:(success 1)}",
-    statement:"char_length('a')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"a\",result:(success 1)}",
+    statement: "char_length('a')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"char_length valid cases{in:\"123456789\",result:(success 9)}",
-    statement:"char_length('123456789')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"123456789\",result:(success 9)}",
+    statement: "char_length('123456789')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"char_length valid cases{in:\"avi\\xe3o\",result:(success 5)}",
-    statement:"char_length('avião')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"avi\\xe3o\",result:(success 5)}",
+    statement: "char_length('avião')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"e\\u082b\",result:(success 2)}",
-    statement:"char_length('eࠫ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"e\\u082b\",result:(success 2)}",
+    statement: "char_length('eࠫ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",result:(success 4)}",
-    statement:"char_length('😁😞😸😸')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",result:(success 4)}",
+    statement: "char_length('😁😞😸😸')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",result:(success 12)}",
-    statement:"char_length('話家身圧費谷料村能計税金')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",result:(success 12)}",
+    statement: "char_length('話家身圧費谷料村能計税金')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"undefined\",result:(success 9)}",
-    statement:"char_length('undefined')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"undefined\",result:(success 9)}",
+    statement: "char_length('undefined')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"char_length valid cases{in:\"undef\",result:(success 5)}",
-    statement:"char_length('undef')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"undef\",result:(success 5)}",
+    statement: "char_length('undef')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"null\",result:(success 4)}",
-    statement:"char_length('null')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"null\",result:(success 4)}",
+    statement: "char_length('null')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"NULL\",result:(success 4)}",
-    statement:"char_length('NULL')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"NULL\",result:(success 4)}",
+    statement: "char_length('NULL')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"(null)\",result:(success 6)}",
-    statement:"char_length('(null)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"(null)\",result:(success 6)}",
+    statement: "char_length('(null)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"char_length valid cases{in:\"nil\",result:(success 3)}",
-    statement:"char_length('nil')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"nil\",result:(success 3)}",
+    statement: "char_length('nil')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"NIL\",result:(success 3)}",
-    statement:"char_length('NIL')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"NIL\",result:(success 3)}",
+    statement: "char_length('NIL')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"true\",result:(success 4)}",
-    statement:"char_length('true')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"true\",result:(success 4)}",
+    statement: "char_length('true')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"false\",result:(success 5)}",
-    statement:"char_length('false')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"false\",result:(success 5)}",
+    statement: "char_length('false')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"True\",result:(success 4)}",
-    statement:"char_length('True')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"True\",result:(success 4)}",
+    statement: "char_length('True')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"False\",result:(success 5)}",
-    statement:"char_length('False')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"False\",result:(success 5)}",
+    statement: "char_length('False')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"TRUE\",result:(success 4)}",
-    statement:"char_length('TRUE')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"TRUE\",result:(success 4)}",
+    statement: "char_length('TRUE')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"FALSE\",result:(success 5)}",
-    statement:"char_length('FALSE')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"FALSE\",result:(success 5)}",
+    statement: "char_length('FALSE')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"None\",result:(success 4)}",
-    statement:"char_length('None')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"None\",result:(success 4)}",
+    statement: "char_length('None')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"hasOwnProperty\",result:(success 14)}",
-    statement:"char_length('hasOwnProperty')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"hasOwnProperty\",result:(success 14)}",
+    statement: "char_length('hasOwnProperty')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:14
+      output: 14
     }
   },
   {
-    name:"char_length valid cases{in:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\",result:(success 96)}",
-    statement:"char_length('999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\",result:(success 96)}",
+    statement: "char_length('999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:96
+      output: 96
     }
   },
   {
-    name:"char_length valid cases{in:\"123456789012345678901234567890123456789\",result:(success 39)}",
-    statement:"char_length('123456789012345678901234567890123456789')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"123456789012345678901234567890123456789\",result:(success 39)}",
+    statement: "char_length('123456789012345678901234567890123456789')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:39
+      output: 39
     }
   },
   {
-    name:"char_length valid cases{in:\"0\",result:(success 1)}",
-    statement:"char_length('0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0\",result:(success 1)}",
+    statement: "char_length('0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"char_length valid cases{in:\"1\",result:(success 1)}",
-    statement:"char_length('1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1\",result:(success 1)}",
+    statement: "char_length('1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"char_length valid cases{in:\"1.00\",result:(success 4)}",
-    statement:"char_length('1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1.00\",result:(success 4)}",
+    statement: "char_length('1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"1.00\",result:(success 5)}",
-    statement:"char_length('$1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1.00\",result:(success 5)}",
+    statement: "char_length('$1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"1/2\",result:(success 3)}",
-    statement:"char_length('1/2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1/2\",result:(success 3)}",
+    statement: "char_length('1/2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"1E2\",result:(success 3)}",
-    statement:"char_length('1E2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1E2\",result:(success 3)}",
+    statement: "char_length('1E2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"1E02\",result:(success 4)}",
-    statement:"char_length('1E02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1E02\",result:(success 4)}",
+    statement: "char_length('1E02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"1E+02\",result:(success 5)}",
-    statement:"char_length('1E+02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1E+02\",result:(success 5)}",
+    statement: "char_length('1E+02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"-1\",result:(success 2)}",
-    statement:"char_length('-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-1\",result:(success 2)}",
+    statement: "char_length('-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"char_length valid cases{in:\"-1.00\",result:(success 5)}",
-    statement:"char_length('-1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-1.00\",result:(success 5)}",
+    statement: "char_length('-1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"-1.00\",result:(success 6)}",
-    statement:"char_length('-$1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-1.00\",result:(success 6)}",
+    statement: "char_length('-$1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"char_length valid cases{in:\"-1/2\",result:(success 4)}",
-    statement:"char_length('-1/2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-1/2\",result:(success 4)}",
+    statement: "char_length('-1/2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"-1E2\",result:(success 4)}",
-    statement:"char_length('-1E2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-1E2\",result:(success 4)}",
+    statement: "char_length('-1E2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"-1E02\",result:(success 5)}",
-    statement:"char_length('-1E02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-1E02\",result:(success 5)}",
+    statement: "char_length('-1E02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"-1E+02\",result:(success 6)}",
-    statement:"char_length('-1E+02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-1E+02\",result:(success 6)}",
+    statement: "char_length('-1E+02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"char_length valid cases{in:\"1/0\",result:(success 3)}",
-    statement:"char_length('1/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1/0\",result:(success 3)}",
+    statement: "char_length('1/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"0/0\",result:(success 3)}",
-    statement:"char_length('0/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0/0\",result:(success 3)}",
+    statement: "char_length('0/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"-2147483648/-1\",result:(success 14)}",
-    statement:"char_length('-2147483648/-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-2147483648/-1\",result:(success 14)}",
+    statement: "char_length('-2147483648/-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:14
+      output: 14
     }
   },
   {
-    name:"char_length valid cases{in:\"-9223372036854775808/-1\",result:(success 23)}",
-    statement:"char_length('-9223372036854775808/-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-9223372036854775808/-1\",result:(success 23)}",
+    statement: "char_length('-9223372036854775808/-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:23
+      output: 23
     }
   },
   {
-    name:"char_length valid cases{in:\"-0\",result:(success 2)}",
-    statement:"char_length('-0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-0\",result:(success 2)}",
+    statement: "char_length('-0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"char_length valid cases{in:\"-0.0\",result:(success 4)}",
-    statement:"char_length('-0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-0.0\",result:(success 4)}",
+    statement: "char_length('-0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"+0\",result:(success 2)}",
-    statement:"char_length('+0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"+0\",result:(success 2)}",
+    statement: "char_length('+0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"char_length valid cases{in:\"+0.0\",result:(success 4)}",
-    statement:"char_length('+0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"+0.0\",result:(success 4)}",
+    statement: "char_length('+0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"0.00\",result:(success 4)}",
-    statement:"char_length('0.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0.00\",result:(success 4)}",
+    statement: "char_length('0.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"0..0\",result:(success 4)}",
-    statement:"char_length('0..0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0..0\",result:(success 4)}",
+    statement: "char_length('0..0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\".\",result:(success 1)}",
-    statement:"char_length('.')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\".\",result:(success 1)}",
+    statement: "char_length('.')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"char_length valid cases{in:\"0.0.0\",result:(success 5)}",
-    statement:"char_length('0.0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0.0.0\",result:(success 5)}",
+    statement: "char_length('0.0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"0,00\",result:(success 4)}",
-    statement:"char_length('0,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0,00\",result:(success 4)}",
+    statement: "char_length('0,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"0,,0\",result:(success 4)}",
-    statement:"char_length('0,,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0,,0\",result:(success 4)}",
+    statement: "char_length('0,,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\",\",result:(success 1)}",
-    statement:"char_length(',')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\",\",result:(success 1)}",
+    statement: "char_length(',')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"char_length valid cases{in:\"0,0,0\",result:(success 5)}",
-    statement:"char_length('0,0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0,0,0\",result:(success 5)}",
+    statement: "char_length('0,0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"0.0/0\",result:(success 5)}",
-    statement:"char_length('0.0/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0.0/0\",result:(success 5)}",
+    statement: "char_length('0.0/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"1.0/0.0\",result:(success 7)}",
-    statement:"char_length('1.0/0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1.0/0.0\",result:(success 7)}",
+    statement: "char_length('1.0/0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"char_length valid cases{in:\"0.0/0.0\",result:(success 7)}",
-    statement:"char_length('0.0/0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0.0/0.0\",result:(success 7)}",
+    statement: "char_length('0.0/0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"char_length valid cases{in:\"1,0/0,0\",result:(success 7)}",
-    statement:"char_length('1,0/0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1,0/0,0\",result:(success 7)}",
+    statement: "char_length('1,0/0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"char_length valid cases{in:\"0,0/0,0\",result:(success 7)}",
-    statement:"char_length('0,0/0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0,0/0,0\",result:(success 7)}",
+    statement: "char_length('0,0/0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"char_length valid cases{in:\"--1\",result:(success 3)}",
-    statement:"char_length('--1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"--1\",result:(success 3)}",
+    statement: "char_length('--1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"-\",result:(success 1)}",
-    statement:"char_length('-')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-\",result:(success 1)}",
+    statement: "char_length('-')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"char_length valid cases{in:\"-.\",result:(success 2)}",
-    statement:"char_length('-.')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-.\",result:(success 2)}",
+    statement: "char_length('-.')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"char_length valid cases{in:\"-,\",result:(success 2)}",
-    statement:"char_length('-,')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-,\",result:(success 2)}",
+    statement: "char_length('-,')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"char_length valid cases{in:\"NaN\",result:(success 3)}",
-    statement:"char_length('NaN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"NaN\",result:(success 3)}",
+    statement: "char_length('NaN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"Infinity\",result:(success 8)}",
-    statement:"char_length('Infinity')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"Infinity\",result:(success 8)}",
+    statement: "char_length('Infinity')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
   {
-    name:"char_length valid cases{in:\"-Infinity\",result:(success 9)}",
-    statement:"char_length('-Infinity')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-Infinity\",result:(success 9)}",
+    statement: "char_length('-Infinity')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"char_length valid cases{in:\"INF\",result:(success 3)}",
-    statement:"char_length('INF')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"INF\",result:(success 3)}",
+    statement: "char_length('INF')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"1#INF\",result:(success 5)}",
-    statement:"char_length('1#INF')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1#INF\",result:(success 5)}",
+    statement: "char_length('1#INF')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"-1#IND\",result:(success 6)}",
-    statement:"char_length('-1#IND')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"-1#IND\",result:(success 6)}",
+    statement: "char_length('-1#IND')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"char_length valid cases{in:\"1#QNAN\",result:(success 6)}",
-    statement:"char_length('1#QNAN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1#QNAN\",result:(success 6)}",
+    statement: "char_length('1#QNAN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"char_length valid cases{in:\"1#SNAN\",result:(success 6)}",
-    statement:"char_length('1#SNAN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1#SNAN\",result:(success 6)}",
+    statement: "char_length('1#SNAN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"char_length valid cases{in:\"1#IND\",result:(success 5)}",
-    statement:"char_length('1#IND')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1#IND\",result:(success 5)}",
+    statement: "char_length('1#IND')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"0x0\",result:(success 3)}",
-    statement:"char_length('0x0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0x0\",result:(success 3)}",
+    statement: "char_length('0x0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"0xffffffff\",result:(success 10)}",
-    statement:"char_length('0xffffffff')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0xffffffff\",result:(success 10)}",
+    statement: "char_length('0xffffffff')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"char_length valid cases{in:\"0xffffffffffffffff\",result:(success 18)}",
-    statement:"char_length('0xffffffffffffffff')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0xffffffffffffffff\",result:(success 18)}",
+    statement: "char_length('0xffffffffffffffff')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:18
+      output: 18
     }
   },
   {
-    name:"char_length valid cases{in:\"0xabad1dea\",result:(success 10)}",
-    statement:"char_length('0xabad1dea')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0xabad1dea\",result:(success 10)}",
+    statement: "char_length('0xabad1dea')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"char_length valid cases{in:\"1,000.00\",result:(success 8)}",
-    statement:"char_length('1,000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1,000.00\",result:(success 8)}",
+    statement: "char_length('1,000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
   {
-    name:"char_length valid cases{in:\"1 000.00\",result:(success 8)}",
-    statement:"char_length('1 000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1 000.00\",result:(success 8)}",
+    statement: "char_length('1 000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
   {
-    name:"char_length valid cases{in:\"1,000,000.00\",result:(success 12)}",
-    statement:"char_length('1,000,000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1,000,000.00\",result:(success 12)}",
+    statement: "char_length('1,000,000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"1 000 000.00\",result:(success 12)}",
-    statement:"char_length('1 000 000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1 000 000.00\",result:(success 12)}",
+    statement: "char_length('1 000 000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"1.000,00\",result:(success 8)}",
-    statement:"char_length('1.000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1.000,00\",result:(success 8)}",
+    statement: "char_length('1.000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
   {
-    name:"char_length valid cases{in:\"1 000,00\",result:(success 8)}",
-    statement:"char_length('1 000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1 000,00\",result:(success 8)}",
+    statement: "char_length('1 000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
   {
-    name:"char_length valid cases{in:\"1.000.000,00\",result:(success 12)}",
-    statement:"char_length('1.000.000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1.000.000,00\",result:(success 12)}",
+    statement: "char_length('1.000.000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"1 000 000,00\",result:(success 12)}",
-    statement:"char_length('1 000 000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"1 000 000,00\",result:(success 12)}",
+    statement: "char_length('1 000 000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"01000\",result:(success 5)}",
-    statement:"char_length('01000')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"01000\",result:(success 5)}",
+    statement: "char_length('01000')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"08\",result:(success 2)}",
-    statement:"char_length('08')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"08\",result:(success 2)}",
+    statement: "char_length('08')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"char_length valid cases{in:\"09\",result:(success 2)}",
-    statement:"char_length('09')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"09\",result:(success 2)}",
+    statement: "char_length('09')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"char_length valid cases{in:\"2.2250738585072011e-308\",result:(success 23)}",
-    statement:"char_length('2.2250738585072011e-308')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"2.2250738585072011e-308\",result:(success 23)}",
+    statement: "char_length('2.2250738585072011e-308')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:23
+      output: 23
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:(success 79)}",
-    statement:"char_length('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:(success 79)}",
+    statement: "char_length('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:79
+      output: 79
     }
   },
   {
-    name:"char_length valid cases{in:\"<>?:\\\"{}|_+\",result:(success 10)}",
-    statement:"char_length('<>?:\"{}|_+')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"<>?:\\\"{}|_+\",result:(success 10)}",
+    statement: "char_length('<>?:\"{}|_+')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"char_length valid cases{in:\"!@#%^&*()`~\",result:(success 12)}",
-    statement:"char_length('!@#$%^&*()`~')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"!@#%^&*()`~\",result:(success 12)}",
+    statement: "char_length('!@#$%^&*()`~')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u03a9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\",result:(success 10)}",
-    statement:"char_length('Ω≈ç√∫˜µ≤≥÷')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u03a9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\",result:(success 10)}",
+    statement: "char_length('Ω≈ç√∫˜µ≤≥÷')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"char_length valid cases{in:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\",result:(success 11)}",
-    statement:"char_length('åß∂ƒ©˙∆˚¬…æ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\",result:(success 11)}",
+    statement: "char_length('åß∂ƒ©˙∆˚¬…æ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\",result:(success 12)}",
-    statement:"char_length('œ∑´®†¥¨ˆøπ“‘')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\",result:(success 12)}",
+    statement: "char_length('œ∑´®†¥¨ˆøπ“‘')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\",result:(success 12)}",
-    statement:"char_length('¡™£¢∞§¶•ªº–≠')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\",result:(success 12)}",
+    statement: "char_length('¡™£¢∞§¶•ªº–≠')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"\\xb8\\u02db\\xc7\\u25ca\\u0131\\u02dc\\xc2\\xaf\\u02d8\\xbf\",result:(success 10)}",
-    statement:"char_length('¸˛Ç◊ı˜Â¯˘¿')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\xb8\\u02db\\xc7\\u25ca\\u0131\\u02dc\\xc2\\xaf\\u02d8\\xbf\",result:(success 10)}",
+    statement: "char_length('¸˛Ç◊ı˜Â¯˘¿')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"char_length valid cases{in:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\",result:(success 12)}",
-    statement:"char_length('ÅÍÎÏ˝ÓÔÒÚÆ☃')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\",result:(success 12)}",
+    statement: "char_length('ÅÍÎÏ˝ÓÔÒÚÆ☃')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\",result:(success 12)}",
-    statement:"char_length('Œ„´‰ˇÁ¨ˆØ∏”’')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\",result:(success 12)}",
+    statement: "char_length('Œ„´‰ˇÁ¨ˆØ∏”’')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\",result:(success 13)}",
-    statement:"char_length('`⁄€‹›ﬁﬂ‡°·‚—±')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\",result:(success 13)}",
+    statement: "char_length('`⁄€‹›ﬁﬂ‡°·‚—±')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:13
+      output: 13
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u215b\\u215c\\u215d\\u215e\",result:(success 4)}",
-    statement:"char_length('⅛⅜⅝⅞')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u215b\\u215c\\u215d\\u215e\",result:(success 4)}",
+    statement: "char_length('⅛⅜⅝⅞')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\",result:(success 10)}",
-    statement:"char_length('٠١٢٣٤٥٦٧٨٩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\",result:(success 10)}",
+    statement: "char_length('٠١٢٣٤٥٦٧٨٩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\",result:(success 11)}",
-    statement:"char_length('田中さんにあげて下さい')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\",result:(success 11)}",
+    statement: "char_length('田中さんにあげて下さい')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\",result:(success 11)}",
-    statement:"char_length('パーティーへ行かないか')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\",result:(success 11)}",
+    statement: "char_length('パーティーへ行かないか')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u548c\\u88fd\\u6f22\\u8a9e\",result:(success 4)}",
-    statement:"char_length('和製漢語')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u548c\\u88fd\\u6f22\\u8a9e\",result:(success 4)}",
+    statement: "char_length('和製漢語')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u90e8\\u843d\\u683c\",result:(success 3)}",
-    statement:"char_length('部落格')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u90e8\\u843d\\u683c\",result:(success 3)}",
+    statement: "char_length('部落格')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"char_length valid cases{in:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\",result:(success 11)}",
-    statement:"char_length('사회과학원 어학연구소')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\",result:(success 11)}",
+    statement: "char_length('사회과학원 어학연구소')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"char_length valid cases{in:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\",result:(success 22)}",
-    statement:"char_length('찦차를 타고 온 펲시맨과 쑛다리 똠방각하')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\",result:(success 22)}",
+    statement: "char_length('찦차를 타고 온 펲시맨과 쑛다리 똠방각하')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:22
+      output: 22
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\",result:(success 10)}",
-    statement:"char_length('社會科學院語學研究所')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\",result:(success 10)}",
+    statement: "char_length('社會科學院語學研究所')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"char_length valid cases{in:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\",result:(success 5)}",
-    statement:"char_length('울란바토르')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\",result:(success 5)}",
+    statement: "char_length('울란바토르')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\",result:(success 7)}",
-    statement:"char_length('𠜎𠜱𠝹𠱓𠱸𠲖𠳏')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\",result:(success 7)}",
+    statement: "char_length('𠜎𠜱𠝹𠱓𠱸𠲖𠳏')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u023a\",result:(success 1)}",
-    statement:"char_length('Ⱥ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u023a\",result:(success 1)}",
+    statement: "char_length('Ⱥ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u023e\",result:(success 1)}",
-    statement:"char_length('Ⱦ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u023e\",result:(success 1)}",
+    statement: "char_length('Ⱦ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\",result:(success 17)}",
-    statement:"char_length('ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\",result:(success 17)}",
+    statement: "char_length('ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:17
+      output: 17
     }
   },
   {
-    name:"char_length valid cases{in:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\",result:(success 9)}",
-    statement:"char_length('(｡◕ ∀ ◕｡)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\",result:(success 9)}",
+    statement: "char_length('(｡◕ ∀ ◕｡)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"char_length valid cases{in:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\",result:(success 7)}",
-    statement:"char_length('｀ｨ(´∀｀∩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\",result:(success 7)}",
+    statement: "char_length('｀ｨ(´∀｀∩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"char_length valid cases{in:\"__\\uff9b(,_,*)\",result:(success 9)}",
-    statement:"char_length('__ﾛ(,_,*)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"__\\uff9b(,_,*)\",result:(success 9)}",
+    statement: "char_length('__ﾛ(,_,*)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\",result:(success 10)}",
-    statement:"char_length('・(￣∀￣)・:*:')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\",result:(success 10)}",
+    statement: "char_length('・(￣∀￣)・:*:')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"char_length valid cases{in:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\",result:(success 16)}",
-    statement:"char_length('ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\",result:(success 16)}",
+    statement: "char_length('ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:16
+      output: 16
     }
   },
   {
-    name:"char_length valid cases{in:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\",result:(success 26)}",
-    statement:"char_length(',。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\",result:(success 26)}",
+    statement: "char_length(',。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:26
+      output: 26
     }
   },
   {
-    name:"char_length valid cases{in:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\",result:(success 13)}",
-    statement:"char_length('(╯°□°）╯︵ ┻━┻)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\",result:(success 13)}",
+    statement: "char_length('(╯°□°）╯︵ ┻━┻)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:13
+      output: 13
     }
   },
   {
-    name:"char_length valid cases{in:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\",result:(success 12)}",
-    statement:"char_length('(ﾉಥ益ಥ）ﾉ﻿ ┻━┻')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\",result:(success 12)}",
+    statement: "char_length('(ﾉಥ益ಥ）ﾉ﻿ ┻━┻')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:(success 13)}",
-    statement:"char_length('┬─┬ノ( º _ ºノ)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:(success 13)}",
+    statement: "char_length('┬─┬ノ( º _ ºノ)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:13
+      output: 13
     }
   },
   {
-    name:"char_length valid cases{in:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\",result:(success 11)}",
-    statement:"char_length('( ͡° ͜ʖ ͡°)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\",result:(success 11)}",
+    statement: "char_length('( ͡° ͜ʖ ͡°)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001f60d\",result:(success 1)}",
-    statement:"char_length('😍')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001f60d\",result:(success 1)}",
+    statement: "char_length('😍')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001f469\\U0001f3fd\",result:(success 2)}",
-    statement:"char_length('👩🏽')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001f469\\U0001f3fd\",result:(success 2)}",
+    statement: "char_length('👩🏽')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\",result:(success 15)}",
-    statement:"char_length('👾 🙇 💁 🙅 🙆 🙋 🙎 🙍')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\",result:(success 15)}",
+    statement: "char_length('👾 🙇 💁 🙅 🙆 🙋 🙎 🙍')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:15
+      output: 15
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\",result:(success 7)}",
-    statement:"char_length('🐵 🙈 🙉 🙊')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\",result:(success 7)}",
+    statement: "char_length('🐵 🙈 🙉 🙊')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\",result:(success 30)}",
-    statement:"char_length('❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\",result:(success 30)}",
+    statement: "char_length('❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:30
+      output: 30
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\",result:(success 17)}",
-    statement:"char_length('✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\",result:(success 17)}",
+    statement: "char_length('✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:17
+      output: 17
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\",result:(success 15)}",
-    statement:"char_length('🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\",result:(success 15)}",
+    statement: "char_length('🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:15
+      output: 15
     }
   },
   {
-    name:"char_length valid cases{in:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\",result:(success 41)}",
-    statement:"char_length('0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\",result:(success 41)}",
+    statement: "char_length('0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:41
+      output: 41
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\",result:(success 11)}",
-    statement:"char_length('🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\",result:(success 11)}",
+    statement: "char_length('🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\",result:(success 9)}",
-    statement:"char_length('🇺🇸🇷🇺🇸🇦🇫🇦🇲')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\",result:(success 9)}",
+    statement: "char_length('🇺🇸🇷🇺🇸🇦🇫🇦🇲')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\",result:(success 6)}",
-    statement:"char_length('🇺🇸🇷🇺🇸🇦')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\",result:(success 6)}",
+    statement: "char_length('🇺🇸🇷🇺🇸🇦')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"char_length valid cases{in:\"\\uff34\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff4f\\uff56\\uff45\\uff52 \\uff54\\uff48\\uff45 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\",result:(success 43)}",
-    statement:"char_length('Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\uff34\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff4f\\uff56\\uff45\\uff52 \\uff54\\uff48\\uff45 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\",result:(success 43)}",
+    statement: "char_length('Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001d413\\U0001d421\\U0001d41e \\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b \\U0001d42d\\U0001d421\\U0001d41e \\U0001d425\\U0001d41a\\U0001d433\\U0001d432 \\U0001d41d\\U0001d428\\U0001d420\",result:(success 43)}",
-    statement:"char_length('𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001d413\\U0001d421\\U0001d41e \\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b \\U0001d42d\\U0001d421\\U0001d41e \\U0001d425\\U0001d41a\\U0001d433\\U0001d432 \\U0001d41d\\U0001d428\\U0001d420\",result:(success 43)}",
+    statement: "char_length('𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001d57f\\U0001d58d\\U0001d58a \\U0001d596\\U0001d59a\\U0001d58e\\U0001d588\\U0001d590 \\U0001d587\\U0001d597\\U0001d594\\U0001d59c\\U0001d593 \\U0001d58b\\U0001d594\\U0001d59d \\U0001d58f\\U0001d59a\\U0001d592\\U0001d595\\U0001d598 \\U0001d594\\U0001d59b\\U0001d58a\\U0001d597 \\U0001d599\\U0001d58d\\U0001d58a \\U0001d591\\U0001d586\\U0001d59f\\U0001d59e \\U0001d589\\U0001d594\\U0001d58c\",result:(success 43)}",
-    statement:"char_length('𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001d57f\\U0001d58d\\U0001d58a \\U0001d596\\U0001d59a\\U0001d58e\\U0001d588\\U0001d590 \\U0001d587\\U0001d597\\U0001d594\\U0001d59c\\U0001d593 \\U0001d58b\\U0001d594\\U0001d59d \\U0001d58f\\U0001d59a\\U0001d592\\U0001d595\\U0001d598 \\U0001d594\\U0001d59b\\U0001d58a\\U0001d597 \\U0001d599\\U0001d58d\\U0001d58a \\U0001d591\\U0001d586\\U0001d59f\\U0001d59e \\U0001d589\\U0001d594\\U0001d58c\",result:(success 43)}",
+    statement: "char_length('𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001d47b\\U0001d489\\U0001d486 \\U0001d492\\U0001d496\\U0001d48a\\U0001d484\\U0001d48c \\U0001d483\\U0001d493\\U0001d490\\U0001d498\\U0001d48f \\U0001d487\\U0001d490\\U0001d499 \\U0001d48b\\U0001d496\\U0001d48e\\U0001d491\\U0001d494 \\U0001d490\\U0001d497\\U0001d486\\U0001d493 \\U0001d495\\U0001d489\\U0001d486 \\U0001d48d\\U0001d482\\U0001d49b\\U0001d49a \\U0001d485\\U0001d490\\U0001d488\",result:(success 43)}",
-    statement:"char_length('𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001d47b\\U0001d489\\U0001d486 \\U0001d492\\U0001d496\\U0001d48a\\U0001d484\\U0001d48c \\U0001d483\\U0001d493\\U0001d490\\U0001d498\\U0001d48f \\U0001d487\\U0001d490\\U0001d499 \\U0001d48b\\U0001d496\\U0001d48e\\U0001d491\\U0001d494 \\U0001d490\\U0001d497\\U0001d486\\U0001d493 \\U0001d495\\U0001d489\\U0001d486 \\U0001d48d\\U0001d482\\U0001d49b\\U0001d49a \\U0001d485\\U0001d490\\U0001d488\",result:(success 43)}",
+    statement: "char_length('𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001d4e3\\U0001d4f1\\U0001d4ee \\U0001d4fa\\U0001d4fe\\U0001d4f2\\U0001d4ec\\U0001d4f4 \\U0001d4eb\\U0001d4fb\\U0001d4f8\\U0001d500\\U0001d4f7 \\U0001d4ef\\U0001d4f8\\U0001d501 \\U0001d4f3\\U0001d4fe\\U0001d4f6\\U0001d4f9\\U0001d4fc \\U0001d4f8\\U0001d4ff\\U0001d4ee\\U0001d4fb \\U0001d4fd\\U0001d4f1\\U0001d4ee \\U0001d4f5\\U0001d4ea\\U0001d503\\U0001d502 \\U0001d4ed\\U0001d4f8\\U0001d4f0\",result:(success 43)}",
-    statement:"char_length('𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001d4e3\\U0001d4f1\\U0001d4ee \\U0001d4fa\\U0001d4fe\\U0001d4f2\\U0001d4ec\\U0001d4f4 \\U0001d4eb\\U0001d4fb\\U0001d4f8\\U0001d500\\U0001d4f7 \\U0001d4ef\\U0001d4f8\\U0001d501 \\U0001d4f3\\U0001d4fe\\U0001d4f6\\U0001d4f9\\U0001d4fc \\U0001d4f8\\U0001d4ff\\U0001d4ee\\U0001d4fb \\U0001d4fd\\U0001d4f1\\U0001d4ee \\U0001d4f5\\U0001d4ea\\U0001d503\\U0001d502 \\U0001d4ed\\U0001d4f8\\U0001d4f0\",result:(success 43)}",
+    statement: "char_length('𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001d54b\\U0001d559\\U0001d556 \\U0001d562\\U0001d566\\U0001d55a\\U0001d554\\U0001d55c \\U0001d553\\U0001d563\\U0001d560\\U0001d568\\U0001d55f \\U0001d557\\U0001d560\\U0001d569 \\U0001d55b\\U0001d566\\U0001d55e\\U0001d561\\U0001d564 \\U0001d560\\U0001d567\\U0001d556\\U0001d563 \\U0001d565\\U0001d559\\U0001d556 \\U0001d55d\\U0001d552\\U0001d56b\\U0001d56a \\U0001d555\\U0001d560\\U0001d558\",result:(success 43)}",
-    statement:"char_length('𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001d54b\\U0001d559\\U0001d556 \\U0001d562\\U0001d566\\U0001d55a\\U0001d554\\U0001d55c \\U0001d553\\U0001d563\\U0001d560\\U0001d568\\U0001d55f \\U0001d557\\U0001d560\\U0001d569 \\U0001d55b\\U0001d566\\U0001d55e\\U0001d561\\U0001d564 \\U0001d560\\U0001d567\\U0001d556\\U0001d563 \\U0001d565\\U0001d559\\U0001d556 \\U0001d55d\\U0001d552\\U0001d56b\\U0001d56a \\U0001d555\\U0001d560\\U0001d558\",result:(success 43)}",
+    statement: "char_length('𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"char_length valid cases{in:\"\\U0001d683\\U0001d691\\U0001d68e \\U0001d69a\\U0001d69e\\U0001d692\\U0001d68c\\U0001d694 \\U0001d68b\\U0001d69b\\U0001d698\\U0001d6a0\\U0001d697 \\U0001d68f\\U0001d698\\U0001d6a1 \\U0001d693\\U0001d69e\\U0001d696\\U0001d699\\U0001d69c \\U0001d698\\U0001d69f\\U0001d68e\\U0001d69b \\U0001d69d\\U0001d691\\U0001d68e \\U0001d695\\U0001d68a\\U0001d6a3\\U0001d6a2 \\U0001d68d\\U0001d698\\U0001d690\",result:(success 43)}",
-    statement:"char_length('𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\U0001d683\\U0001d691\\U0001d68e \\U0001d69a\\U0001d69e\\U0001d692\\U0001d68c\\U0001d694 \\U0001d68b\\U0001d69b\\U0001d698\\U0001d6a0\\U0001d697 \\U0001d68f\\U0001d698\\U0001d6a1 \\U0001d693\\U0001d69e\\U0001d696\\U0001d699\\U0001d69c \\U0001d698\\U0001d69f\\U0001d68e\\U0001d69b \\U0001d69d\\U0001d691\\U0001d68e \\U0001d695\\U0001d68a\\U0001d6a3\\U0001d6a2 \\U0001d68d\\U0001d698\\U0001d690\",result:(success 43)}",
+    statement: "char_length('𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"char_length valid cases{in:\"\\u24af\\u24a3\\u24a0 \\u24ac\\u24b0\\u24a4\\u249e\\u24a6 \\u249d\\u24ad\\u24aa\\u24b2\\u24a9 \\u24a1\\u24aa\\u24b3 \\u24a5\\u24b0\\u24a8\\u24ab\\u24ae \\u24aa\\u24b1\\u24a0\\u24ad \\u24af\\u24a3\\u24a0 \\u24a7\\u249c\\u24b5\\u24b4 \\u249f\\u24aa\\u24a2\",result:(success 43)}",
-    statement:"char_length('⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length valid cases{in:\"\\u24af\\u24a3\\u24a0 \\u24ac\\u24b0\\u24a4\\u249e\\u24a6 \\u249d\\u24ad\\u24aa\\u24b2\\u24a9 \\u24a1\\u24aa\\u24b3 \\u24a5\\u24b0\\u24a8\\u24ab\\u24ae \\u24aa\\u24b1\\u24a0\\u24ad \\u24af\\u24a3\\u24a0 \\u24a7\\u249c\\u24b5\\u24b4 \\u249f\\u24aa\\u24a2\",result:(success 43)}",
+    statement: "char_length('⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"character_length valid cases{in:\"\",result:(success 0)}",
-    statement:"character_length('')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\",result:(success 0)}",
+    statement: "character_length('')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"character_length valid cases{in:\"a\",result:(success 1)}",
-    statement:"character_length('a')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"a\",result:(success 1)}",
+    statement: "character_length('a')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"character_length valid cases{in:\"123456789\",result:(success 9)}",
-    statement:"character_length('123456789')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"123456789\",result:(success 9)}",
+    statement: "character_length('123456789')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"character_length valid cases{in:\"avi\\xe3o\",result:(success 5)}",
-    statement:"character_length('avião')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"avi\\xe3o\",result:(success 5)}",
+    statement: "character_length('avião')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"e\\u082b\",result:(success 2)}",
-    statement:"character_length('eࠫ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"e\\u082b\",result:(success 2)}",
+    statement: "character_length('eࠫ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",result:(success 4)}",
-    statement:"character_length('😁😞😸😸')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",result:(success 4)}",
+    statement: "character_length('😁😞😸😸')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",result:(success 12)}",
-    statement:"character_length('話家身圧費谷料村能計税金')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",result:(success 12)}",
+    statement: "character_length('話家身圧費谷料村能計税金')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"undefined\",result:(success 9)}",
-    statement:"character_length('undefined')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"undefined\",result:(success 9)}",
+    statement: "character_length('undefined')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"character_length valid cases{in:\"undef\",result:(success 5)}",
-    statement:"character_length('undef')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"undef\",result:(success 5)}",
+    statement: "character_length('undef')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"null\",result:(success 4)}",
-    statement:"character_length('null')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"null\",result:(success 4)}",
+    statement: "character_length('null')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"NULL\",result:(success 4)}",
-    statement:"character_length('NULL')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"NULL\",result:(success 4)}",
+    statement: "character_length('NULL')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"(null)\",result:(success 6)}",
-    statement:"character_length('(null)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"(null)\",result:(success 6)}",
+    statement: "character_length('(null)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"character_length valid cases{in:\"nil\",result:(success 3)}",
-    statement:"character_length('nil')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"nil\",result:(success 3)}",
+    statement: "character_length('nil')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"NIL\",result:(success 3)}",
-    statement:"character_length('NIL')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"NIL\",result:(success 3)}",
+    statement: "character_length('NIL')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"true\",result:(success 4)}",
-    statement:"character_length('true')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"true\",result:(success 4)}",
+    statement: "character_length('true')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"false\",result:(success 5)}",
-    statement:"character_length('false')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"false\",result:(success 5)}",
+    statement: "character_length('false')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"True\",result:(success 4)}",
-    statement:"character_length('True')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"True\",result:(success 4)}",
+    statement: "character_length('True')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"False\",result:(success 5)}",
-    statement:"character_length('False')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"False\",result:(success 5)}",
+    statement: "character_length('False')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"TRUE\",result:(success 4)}",
-    statement:"character_length('TRUE')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"TRUE\",result:(success 4)}",
+    statement: "character_length('TRUE')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"FALSE\",result:(success 5)}",
-    statement:"character_length('FALSE')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"FALSE\",result:(success 5)}",
+    statement: "character_length('FALSE')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"None\",result:(success 4)}",
-    statement:"character_length('None')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"None\",result:(success 4)}",
+    statement: "character_length('None')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"hasOwnProperty\",result:(success 14)}",
-    statement:"character_length('hasOwnProperty')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"hasOwnProperty\",result:(success 14)}",
+    statement: "character_length('hasOwnProperty')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:14
+      output: 14
     }
   },
   {
-    name:"character_length valid cases{in:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\",result:(success 96)}",
-    statement:"character_length('999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\",result:(success 96)}",
+    statement: "character_length('999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:96
+      output: 96
     }
   },
   {
-    name:"character_length valid cases{in:\"123456789012345678901234567890123456789\",result:(success 39)}",
-    statement:"character_length('123456789012345678901234567890123456789')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"123456789012345678901234567890123456789\",result:(success 39)}",
+    statement: "character_length('123456789012345678901234567890123456789')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:39
+      output: 39
     }
   },
   {
-    name:"character_length valid cases{in:\"0\",result:(success 1)}",
-    statement:"character_length('0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0\",result:(success 1)}",
+    statement: "character_length('0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"character_length valid cases{in:\"1\",result:(success 1)}",
-    statement:"character_length('1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1\",result:(success 1)}",
+    statement: "character_length('1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"character_length valid cases{in:\"1.00\",result:(success 4)}",
-    statement:"character_length('1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1.00\",result:(success 4)}",
+    statement: "character_length('1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"1.00\",result:(success 5)}",
-    statement:"character_length('$1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1.00\",result:(success 5)}",
+    statement: "character_length('$1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"1/2\",result:(success 3)}",
-    statement:"character_length('1/2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1/2\",result:(success 3)}",
+    statement: "character_length('1/2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"1E2\",result:(success 3)}",
-    statement:"character_length('1E2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1E2\",result:(success 3)}",
+    statement: "character_length('1E2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"1E02\",result:(success 4)}",
-    statement:"character_length('1E02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1E02\",result:(success 4)}",
+    statement: "character_length('1E02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"1E+02\",result:(success 5)}",
-    statement:"character_length('1E+02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1E+02\",result:(success 5)}",
+    statement: "character_length('1E+02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"-1\",result:(success 2)}",
-    statement:"character_length('-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-1\",result:(success 2)}",
+    statement: "character_length('-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"character_length valid cases{in:\"-1.00\",result:(success 5)}",
-    statement:"character_length('-1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-1.00\",result:(success 5)}",
+    statement: "character_length('-1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"-1.00\",result:(success 6)}",
-    statement:"character_length('-$1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-1.00\",result:(success 6)}",
+    statement: "character_length('-$1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"character_length valid cases{in:\"-1/2\",result:(success 4)}",
-    statement:"character_length('-1/2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-1/2\",result:(success 4)}",
+    statement: "character_length('-1/2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"-1E2\",result:(success 4)}",
-    statement:"character_length('-1E2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-1E2\",result:(success 4)}",
+    statement: "character_length('-1E2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"-1E02\",result:(success 5)}",
-    statement:"character_length('-1E02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-1E02\",result:(success 5)}",
+    statement: "character_length('-1E02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"-1E+02\",result:(success 6)}",
-    statement:"character_length('-1E+02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-1E+02\",result:(success 6)}",
+    statement: "character_length('-1E+02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"character_length valid cases{in:\"1/0\",result:(success 3)}",
-    statement:"character_length('1/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1/0\",result:(success 3)}",
+    statement: "character_length('1/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"0/0\",result:(success 3)}",
-    statement:"character_length('0/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0/0\",result:(success 3)}",
+    statement: "character_length('0/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"-2147483648/-1\",result:(success 14)}",
-    statement:"character_length('-2147483648/-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-2147483648/-1\",result:(success 14)}",
+    statement: "character_length('-2147483648/-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:14
+      output: 14
     }
   },
   {
-    name:"character_length valid cases{in:\"-9223372036854775808/-1\",result:(success 23)}",
-    statement:"character_length('-9223372036854775808/-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-9223372036854775808/-1\",result:(success 23)}",
+    statement: "character_length('-9223372036854775808/-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:23
+      output: 23
     }
   },
   {
-    name:"character_length valid cases{in:\"-0\",result:(success 2)}",
-    statement:"character_length('-0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-0\",result:(success 2)}",
+    statement: "character_length('-0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"character_length valid cases{in:\"-0.0\",result:(success 4)}",
-    statement:"character_length('-0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-0.0\",result:(success 4)}",
+    statement: "character_length('-0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"+0\",result:(success 2)}",
-    statement:"character_length('+0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"+0\",result:(success 2)}",
+    statement: "character_length('+0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"character_length valid cases{in:\"+0.0\",result:(success 4)}",
-    statement:"character_length('+0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"+0.0\",result:(success 4)}",
+    statement: "character_length('+0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"0.00\",result:(success 4)}",
-    statement:"character_length('0.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0.00\",result:(success 4)}",
+    statement: "character_length('0.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"0..0\",result:(success 4)}",
-    statement:"character_length('0..0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0..0\",result:(success 4)}",
+    statement: "character_length('0..0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\".\",result:(success 1)}",
-    statement:"character_length('.')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\".\",result:(success 1)}",
+    statement: "character_length('.')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"character_length valid cases{in:\"0.0.0\",result:(success 5)}",
-    statement:"character_length('0.0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0.0.0\",result:(success 5)}",
+    statement: "character_length('0.0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"0,00\",result:(success 4)}",
-    statement:"character_length('0,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0,00\",result:(success 4)}",
+    statement: "character_length('0,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"0,,0\",result:(success 4)}",
-    statement:"character_length('0,,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0,,0\",result:(success 4)}",
+    statement: "character_length('0,,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\",\",result:(success 1)}",
-    statement:"character_length(',')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\",\",result:(success 1)}",
+    statement: "character_length(',')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"character_length valid cases{in:\"0,0,0\",result:(success 5)}",
-    statement:"character_length('0,0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0,0,0\",result:(success 5)}",
+    statement: "character_length('0,0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"0.0/0\",result:(success 5)}",
-    statement:"character_length('0.0/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0.0/0\",result:(success 5)}",
+    statement: "character_length('0.0/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"1.0/0.0\",result:(success 7)}",
-    statement:"character_length('1.0/0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1.0/0.0\",result:(success 7)}",
+    statement: "character_length('1.0/0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"character_length valid cases{in:\"0.0/0.0\",result:(success 7)}",
-    statement:"character_length('0.0/0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0.0/0.0\",result:(success 7)}",
+    statement: "character_length('0.0/0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"character_length valid cases{in:\"1,0/0,0\",result:(success 7)}",
-    statement:"character_length('1,0/0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1,0/0,0\",result:(success 7)}",
+    statement: "character_length('1,0/0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"character_length valid cases{in:\"0,0/0,0\",result:(success 7)}",
-    statement:"character_length('0,0/0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0,0/0,0\",result:(success 7)}",
+    statement: "character_length('0,0/0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"character_length valid cases{in:\"--1\",result:(success 3)}",
-    statement:"character_length('--1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"--1\",result:(success 3)}",
+    statement: "character_length('--1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"-\",result:(success 1)}",
-    statement:"character_length('-')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-\",result:(success 1)}",
+    statement: "character_length('-')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"character_length valid cases{in:\"-.\",result:(success 2)}",
-    statement:"character_length('-.')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-.\",result:(success 2)}",
+    statement: "character_length('-.')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"character_length valid cases{in:\"-,\",result:(success 2)}",
-    statement:"character_length('-,')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-,\",result:(success 2)}",
+    statement: "character_length('-,')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"character_length valid cases{in:\"NaN\",result:(success 3)}",
-    statement:"character_length('NaN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"NaN\",result:(success 3)}",
+    statement: "character_length('NaN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"Infinity\",result:(success 8)}",
-    statement:"character_length('Infinity')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"Infinity\",result:(success 8)}",
+    statement: "character_length('Infinity')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
   {
-    name:"character_length valid cases{in:\"-Infinity\",result:(success 9)}",
-    statement:"character_length('-Infinity')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-Infinity\",result:(success 9)}",
+    statement: "character_length('-Infinity')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"character_length valid cases{in:\"INF\",result:(success 3)}",
-    statement:"character_length('INF')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"INF\",result:(success 3)}",
+    statement: "character_length('INF')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"1#INF\",result:(success 5)}",
-    statement:"character_length('1#INF')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1#INF\",result:(success 5)}",
+    statement: "character_length('1#INF')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"-1#IND\",result:(success 6)}",
-    statement:"character_length('-1#IND')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"-1#IND\",result:(success 6)}",
+    statement: "character_length('-1#IND')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"character_length valid cases{in:\"1#QNAN\",result:(success 6)}",
-    statement:"character_length('1#QNAN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1#QNAN\",result:(success 6)}",
+    statement: "character_length('1#QNAN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"character_length valid cases{in:\"1#SNAN\",result:(success 6)}",
-    statement:"character_length('1#SNAN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1#SNAN\",result:(success 6)}",
+    statement: "character_length('1#SNAN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"character_length valid cases{in:\"1#IND\",result:(success 5)}",
-    statement:"character_length('1#IND')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1#IND\",result:(success 5)}",
+    statement: "character_length('1#IND')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"0x0\",result:(success 3)}",
-    statement:"character_length('0x0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0x0\",result:(success 3)}",
+    statement: "character_length('0x0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"0xffffffff\",result:(success 10)}",
-    statement:"character_length('0xffffffff')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0xffffffff\",result:(success 10)}",
+    statement: "character_length('0xffffffff')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"character_length valid cases{in:\"0xffffffffffffffff\",result:(success 18)}",
-    statement:"character_length('0xffffffffffffffff')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0xffffffffffffffff\",result:(success 18)}",
+    statement: "character_length('0xffffffffffffffff')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:18
+      output: 18
     }
   },
   {
-    name:"character_length valid cases{in:\"0xabad1dea\",result:(success 10)}",
-    statement:"character_length('0xabad1dea')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0xabad1dea\",result:(success 10)}",
+    statement: "character_length('0xabad1dea')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"character_length valid cases{in:\"1,000.00\",result:(success 8)}",
-    statement:"character_length('1,000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1,000.00\",result:(success 8)}",
+    statement: "character_length('1,000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
   {
-    name:"character_length valid cases{in:\"1 000.00\",result:(success 8)}",
-    statement:"character_length('1 000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1 000.00\",result:(success 8)}",
+    statement: "character_length('1 000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
   {
-    name:"character_length valid cases{in:\"1,000,000.00\",result:(success 12)}",
-    statement:"character_length('1,000,000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1,000,000.00\",result:(success 12)}",
+    statement: "character_length('1,000,000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"1 000 000.00\",result:(success 12)}",
-    statement:"character_length('1 000 000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1 000 000.00\",result:(success 12)}",
+    statement: "character_length('1 000 000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"1.000,00\",result:(success 8)}",
-    statement:"character_length('1.000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1.000,00\",result:(success 8)}",
+    statement: "character_length('1.000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
   {
-    name:"character_length valid cases{in:\"1 000,00\",result:(success 8)}",
-    statement:"character_length('1 000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1 000,00\",result:(success 8)}",
+    statement: "character_length('1 000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
   {
-    name:"character_length valid cases{in:\"1.000.000,00\",result:(success 12)}",
-    statement:"character_length('1.000.000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1.000.000,00\",result:(success 12)}",
+    statement: "character_length('1.000.000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"1 000 000,00\",result:(success 12)}",
-    statement:"character_length('1 000 000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"1 000 000,00\",result:(success 12)}",
+    statement: "character_length('1 000 000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"01000\",result:(success 5)}",
-    statement:"character_length('01000')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"01000\",result:(success 5)}",
+    statement: "character_length('01000')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"08\",result:(success 2)}",
-    statement:"character_length('08')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"08\",result:(success 2)}",
+    statement: "character_length('08')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"character_length valid cases{in:\"09\",result:(success 2)}",
-    statement:"character_length('09')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"09\",result:(success 2)}",
+    statement: "character_length('09')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"character_length valid cases{in:\"2.2250738585072011e-308\",result:(success 23)}",
-    statement:"character_length('2.2250738585072011e-308')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"2.2250738585072011e-308\",result:(success 23)}",
+    statement: "character_length('2.2250738585072011e-308')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:23
+      output: 23
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:(success 79)}",
-    statement:"character_length('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:(success 79)}",
+    statement: "character_length('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:79
+      output: 79
     }
   },
   {
-    name:"character_length valid cases{in:\"<>?:\\\"{}|_+\",result:(success 10)}",
-    statement:"character_length('<>?:\"{}|_+')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"<>?:\\\"{}|_+\",result:(success 10)}",
+    statement: "character_length('<>?:\"{}|_+')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"character_length valid cases{in:\"!@#%^&*()`~\",result:(success 12)}",
-    statement:"character_length('!@#$%^&*()`~')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"!@#%^&*()`~\",result:(success 12)}",
+    statement: "character_length('!@#$%^&*()`~')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u03a9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\",result:(success 10)}",
-    statement:"character_length('Ω≈ç√∫˜µ≤≥÷')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u03a9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\",result:(success 10)}",
+    statement: "character_length('Ω≈ç√∫˜µ≤≥÷')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"character_length valid cases{in:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\",result:(success 11)}",
-    statement:"character_length('åß∂ƒ©˙∆˚¬…æ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\",result:(success 11)}",
+    statement: "character_length('åß∂ƒ©˙∆˚¬…æ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\",result:(success 12)}",
-    statement:"character_length('œ∑´®†¥¨ˆøπ“‘')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\",result:(success 12)}",
+    statement: "character_length('œ∑´®†¥¨ˆøπ“‘')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\",result:(success 12)}",
-    statement:"character_length('¡™£¢∞§¶•ªº–≠')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\",result:(success 12)}",
+    statement: "character_length('¡™£¢∞§¶•ªº–≠')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"\\xb8\\u02db\\xc7\\u25ca\\u0131\\u02dc\\xc2\\xaf\\u02d8\\xbf\",result:(success 10)}",
-    statement:"character_length('¸˛Ç◊ı˜Â¯˘¿')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\xb8\\u02db\\xc7\\u25ca\\u0131\\u02dc\\xc2\\xaf\\u02d8\\xbf\",result:(success 10)}",
+    statement: "character_length('¸˛Ç◊ı˜Â¯˘¿')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"character_length valid cases{in:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\",result:(success 12)}",
-    statement:"character_length('ÅÍÎÏ˝ÓÔÒÚÆ☃')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\",result:(success 12)}",
+    statement: "character_length('ÅÍÎÏ˝ÓÔÒÚÆ☃')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\",result:(success 12)}",
-    statement:"character_length('Œ„´‰ˇÁ¨ˆØ∏”’')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\",result:(success 12)}",
+    statement: "character_length('Œ„´‰ˇÁ¨ˆØ∏”’')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\",result:(success 13)}",
-    statement:"character_length('`⁄€‹›ﬁﬂ‡°·‚—±')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\",result:(success 13)}",
+    statement: "character_length('`⁄€‹›ﬁﬂ‡°·‚—±')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:13
+      output: 13
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u215b\\u215c\\u215d\\u215e\",result:(success 4)}",
-    statement:"character_length('⅛⅜⅝⅞')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u215b\\u215c\\u215d\\u215e\",result:(success 4)}",
+    statement: "character_length('⅛⅜⅝⅞')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\",result:(success 10)}",
-    statement:"character_length('٠١٢٣٤٥٦٧٨٩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\",result:(success 10)}",
+    statement: "character_length('٠١٢٣٤٥٦٧٨٩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\",result:(success 11)}",
-    statement:"character_length('田中さんにあげて下さい')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\",result:(success 11)}",
+    statement: "character_length('田中さんにあげて下さい')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\",result:(success 11)}",
-    statement:"character_length('パーティーへ行かないか')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\",result:(success 11)}",
+    statement: "character_length('パーティーへ行かないか')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u548c\\u88fd\\u6f22\\u8a9e\",result:(success 4)}",
-    statement:"character_length('和製漢語')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u548c\\u88fd\\u6f22\\u8a9e\",result:(success 4)}",
+    statement: "character_length('和製漢語')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:4
+      output: 4
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u90e8\\u843d\\u683c\",result:(success 3)}",
-    statement:"character_length('部落格')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u90e8\\u843d\\u683c\",result:(success 3)}",
+    statement: "character_length('部落格')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"character_length valid cases{in:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\",result:(success 11)}",
-    statement:"character_length('사회과학원 어학연구소')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\",result:(success 11)}",
+    statement: "character_length('사회과학원 어학연구소')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"character_length valid cases{in:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\",result:(success 22)}",
-    statement:"character_length('찦차를 타고 온 펲시맨과 쑛다리 똠방각하')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\",result:(success 22)}",
+    statement: "character_length('찦차를 타고 온 펲시맨과 쑛다리 똠방각하')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:22
+      output: 22
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\",result:(success 10)}",
-    statement:"character_length('社會科學院語學研究所')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\",result:(success 10)}",
+    statement: "character_length('社會科學院語學研究所')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"character_length valid cases{in:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\",result:(success 5)}",
-    statement:"character_length('울란바토르')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\",result:(success 5)}",
+    statement: "character_length('울란바토르')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\",result:(success 7)}",
-    statement:"character_length('𠜎𠜱𠝹𠱓𠱸𠲖𠳏')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\",result:(success 7)}",
+    statement: "character_length('𠜎𠜱𠝹𠱓𠱸𠲖𠳏')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u023a\",result:(success 1)}",
-    statement:"character_length('Ⱥ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u023a\",result:(success 1)}",
+    statement: "character_length('Ⱥ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u023e\",result:(success 1)}",
-    statement:"character_length('Ⱦ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u023e\",result:(success 1)}",
+    statement: "character_length('Ⱦ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\",result:(success 17)}",
-    statement:"character_length('ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\",result:(success 17)}",
+    statement: "character_length('ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:17
+      output: 17
     }
   },
   {
-    name:"character_length valid cases{in:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\",result:(success 9)}",
-    statement:"character_length('(｡◕ ∀ ◕｡)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\",result:(success 9)}",
+    statement: "character_length('(｡◕ ∀ ◕｡)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"character_length valid cases{in:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\",result:(success 7)}",
-    statement:"character_length('｀ｨ(´∀｀∩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\",result:(success 7)}",
+    statement: "character_length('｀ｨ(´∀｀∩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"character_length valid cases{in:\"__\\uff9b(,_,*)\",result:(success 9)}",
-    statement:"character_length('__ﾛ(,_,*)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"__\\uff9b(,_,*)\",result:(success 9)}",
+    statement: "character_length('__ﾛ(,_,*)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\",result:(success 10)}",
-    statement:"character_length('・(￣∀￣)・:*:')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\",result:(success 10)}",
+    statement: "character_length('・(￣∀￣)・:*:')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:10
+      output: 10
     }
   },
   {
-    name:"character_length valid cases{in:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\",result:(success 16)}",
-    statement:"character_length('ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\",result:(success 16)}",
+    statement: "character_length('ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:16
+      output: 16
     }
   },
   {
-    name:"character_length valid cases{in:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\",result:(success 26)}",
-    statement:"character_length(',。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\",result:(success 26)}",
+    statement: "character_length(',。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:26
+      output: 26
     }
   },
   {
-    name:"character_length valid cases{in:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\",result:(success 13)}",
-    statement:"character_length('(╯°□°）╯︵ ┻━┻)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\",result:(success 13)}",
+    statement: "character_length('(╯°□°）╯︵ ┻━┻)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:13
+      output: 13
     }
   },
   {
-    name:"character_length valid cases{in:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\",result:(success 12)}",
-    statement:"character_length('(ﾉಥ益ಥ）ﾉ﻿ ┻━┻')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\",result:(success 12)}",
+    statement: "character_length('(ﾉಥ益ಥ）ﾉ﻿ ┻━┻')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:12
+      output: 12
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:(success 13)}",
-    statement:"character_length('┬─┬ノ( º _ ºノ)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:(success 13)}",
+    statement: "character_length('┬─┬ノ( º _ ºノ)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:13
+      output: 13
     }
   },
   {
-    name:"character_length valid cases{in:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\",result:(success 11)}",
-    statement:"character_length('( ͡° ͜ʖ ͡°)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\",result:(success 11)}",
+    statement: "character_length('( ͡° ͜ʖ ͡°)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001f60d\",result:(success 1)}",
-    statement:"character_length('😍')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001f60d\",result:(success 1)}",
+    statement: "character_length('😍')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001f469\\U0001f3fd\",result:(success 2)}",
-    statement:"character_length('👩🏽')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001f469\\U0001f3fd\",result:(success 2)}",
+    statement: "character_length('👩🏽')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\",result:(success 15)}",
-    statement:"character_length('👾 🙇 💁 🙅 🙆 🙋 🙎 🙍')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\",result:(success 15)}",
+    statement: "character_length('👾 🙇 💁 🙅 🙆 🙋 🙎 🙍')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:15
+      output: 15
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\",result:(success 7)}",
-    statement:"character_length('🐵 🙈 🙉 🙊')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\",result:(success 7)}",
+    statement: "character_length('🐵 🙈 🙉 🙊')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:7
+      output: 7
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\",result:(success 30)}",
-    statement:"character_length('❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\",result:(success 30)}",
+    statement: "character_length('❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:30
+      output: 30
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\",result:(success 17)}",
-    statement:"character_length('✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\",result:(success 17)}",
+    statement: "character_length('✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:17
+      output: 17
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\",result:(success 15)}",
-    statement:"character_length('🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\",result:(success 15)}",
+    statement: "character_length('🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:15
+      output: 15
     }
   },
   {
-    name:"character_length valid cases{in:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\",result:(success 41)}",
-    statement:"character_length('0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\",result:(success 41)}",
+    statement: "character_length('0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:41
+      output: 41
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\",result:(success 11)}",
-    statement:"character_length('🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\",result:(success 11)}",
+    statement: "character_length('🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:11
+      output: 11
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\",result:(success 9)}",
-    statement:"character_length('🇺🇸🇷🇺🇸🇦🇫🇦🇲')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\",result:(success 9)}",
+    statement: "character_length('🇺🇸🇷🇺🇸🇦🇫🇦🇲')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\",result:(success 6)}",
-    statement:"character_length('🇺🇸🇷🇺🇸🇦')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\",result:(success 6)}",
+    statement: "character_length('🇺🇸🇷🇺🇸🇦')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:6
+      output: 6
     }
   },
   {
-    name:"character_length valid cases{in:\"\\uff34\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff4f\\uff56\\uff45\\uff52 \\uff54\\uff48\\uff45 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\",result:(success 43)}",
-    statement:"character_length('Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\uff34\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff4f\\uff56\\uff45\\uff52 \\uff54\\uff48\\uff45 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\",result:(success 43)}",
+    statement: "character_length('Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001d413\\U0001d421\\U0001d41e \\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b \\U0001d42d\\U0001d421\\U0001d41e \\U0001d425\\U0001d41a\\U0001d433\\U0001d432 \\U0001d41d\\U0001d428\\U0001d420\",result:(success 43)}",
-    statement:"character_length('𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001d413\\U0001d421\\U0001d41e \\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b \\U0001d42d\\U0001d421\\U0001d41e \\U0001d425\\U0001d41a\\U0001d433\\U0001d432 \\U0001d41d\\U0001d428\\U0001d420\",result:(success 43)}",
+    statement: "character_length('𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001d57f\\U0001d58d\\U0001d58a \\U0001d596\\U0001d59a\\U0001d58e\\U0001d588\\U0001d590 \\U0001d587\\U0001d597\\U0001d594\\U0001d59c\\U0001d593 \\U0001d58b\\U0001d594\\U0001d59d \\U0001d58f\\U0001d59a\\U0001d592\\U0001d595\\U0001d598 \\U0001d594\\U0001d59b\\U0001d58a\\U0001d597 \\U0001d599\\U0001d58d\\U0001d58a \\U0001d591\\U0001d586\\U0001d59f\\U0001d59e \\U0001d589\\U0001d594\\U0001d58c\",result:(success 43)}",
-    statement:"character_length('𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001d57f\\U0001d58d\\U0001d58a \\U0001d596\\U0001d59a\\U0001d58e\\U0001d588\\U0001d590 \\U0001d587\\U0001d597\\U0001d594\\U0001d59c\\U0001d593 \\U0001d58b\\U0001d594\\U0001d59d \\U0001d58f\\U0001d59a\\U0001d592\\U0001d595\\U0001d598 \\U0001d594\\U0001d59b\\U0001d58a\\U0001d597 \\U0001d599\\U0001d58d\\U0001d58a \\U0001d591\\U0001d586\\U0001d59f\\U0001d59e \\U0001d589\\U0001d594\\U0001d58c\",result:(success 43)}",
+    statement: "character_length('𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001d47b\\U0001d489\\U0001d486 \\U0001d492\\U0001d496\\U0001d48a\\U0001d484\\U0001d48c \\U0001d483\\U0001d493\\U0001d490\\U0001d498\\U0001d48f \\U0001d487\\U0001d490\\U0001d499 \\U0001d48b\\U0001d496\\U0001d48e\\U0001d491\\U0001d494 \\U0001d490\\U0001d497\\U0001d486\\U0001d493 \\U0001d495\\U0001d489\\U0001d486 \\U0001d48d\\U0001d482\\U0001d49b\\U0001d49a \\U0001d485\\U0001d490\\U0001d488\",result:(success 43)}",
-    statement:"character_length('𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001d47b\\U0001d489\\U0001d486 \\U0001d492\\U0001d496\\U0001d48a\\U0001d484\\U0001d48c \\U0001d483\\U0001d493\\U0001d490\\U0001d498\\U0001d48f \\U0001d487\\U0001d490\\U0001d499 \\U0001d48b\\U0001d496\\U0001d48e\\U0001d491\\U0001d494 \\U0001d490\\U0001d497\\U0001d486\\U0001d493 \\U0001d495\\U0001d489\\U0001d486 \\U0001d48d\\U0001d482\\U0001d49b\\U0001d49a \\U0001d485\\U0001d490\\U0001d488\",result:(success 43)}",
+    statement: "character_length('𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001d4e3\\U0001d4f1\\U0001d4ee \\U0001d4fa\\U0001d4fe\\U0001d4f2\\U0001d4ec\\U0001d4f4 \\U0001d4eb\\U0001d4fb\\U0001d4f8\\U0001d500\\U0001d4f7 \\U0001d4ef\\U0001d4f8\\U0001d501 \\U0001d4f3\\U0001d4fe\\U0001d4f6\\U0001d4f9\\U0001d4fc \\U0001d4f8\\U0001d4ff\\U0001d4ee\\U0001d4fb \\U0001d4fd\\U0001d4f1\\U0001d4ee \\U0001d4f5\\U0001d4ea\\U0001d503\\U0001d502 \\U0001d4ed\\U0001d4f8\\U0001d4f0\",result:(success 43)}",
-    statement:"character_length('𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001d4e3\\U0001d4f1\\U0001d4ee \\U0001d4fa\\U0001d4fe\\U0001d4f2\\U0001d4ec\\U0001d4f4 \\U0001d4eb\\U0001d4fb\\U0001d4f8\\U0001d500\\U0001d4f7 \\U0001d4ef\\U0001d4f8\\U0001d501 \\U0001d4f3\\U0001d4fe\\U0001d4f6\\U0001d4f9\\U0001d4fc \\U0001d4f8\\U0001d4ff\\U0001d4ee\\U0001d4fb \\U0001d4fd\\U0001d4f1\\U0001d4ee \\U0001d4f5\\U0001d4ea\\U0001d503\\U0001d502 \\U0001d4ed\\U0001d4f8\\U0001d4f0\",result:(success 43)}",
+    statement: "character_length('𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001d54b\\U0001d559\\U0001d556 \\U0001d562\\U0001d566\\U0001d55a\\U0001d554\\U0001d55c \\U0001d553\\U0001d563\\U0001d560\\U0001d568\\U0001d55f \\U0001d557\\U0001d560\\U0001d569 \\U0001d55b\\U0001d566\\U0001d55e\\U0001d561\\U0001d564 \\U0001d560\\U0001d567\\U0001d556\\U0001d563 \\U0001d565\\U0001d559\\U0001d556 \\U0001d55d\\U0001d552\\U0001d56b\\U0001d56a \\U0001d555\\U0001d560\\U0001d558\",result:(success 43)}",
-    statement:"character_length('𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001d54b\\U0001d559\\U0001d556 \\U0001d562\\U0001d566\\U0001d55a\\U0001d554\\U0001d55c \\U0001d553\\U0001d563\\U0001d560\\U0001d568\\U0001d55f \\U0001d557\\U0001d560\\U0001d569 \\U0001d55b\\U0001d566\\U0001d55e\\U0001d561\\U0001d564 \\U0001d560\\U0001d567\\U0001d556\\U0001d563 \\U0001d565\\U0001d559\\U0001d556 \\U0001d55d\\U0001d552\\U0001d56b\\U0001d56a \\U0001d555\\U0001d560\\U0001d558\",result:(success 43)}",
+    statement: "character_length('𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"character_length valid cases{in:\"\\U0001d683\\U0001d691\\U0001d68e \\U0001d69a\\U0001d69e\\U0001d692\\U0001d68c\\U0001d694 \\U0001d68b\\U0001d69b\\U0001d698\\U0001d6a0\\U0001d697 \\U0001d68f\\U0001d698\\U0001d6a1 \\U0001d693\\U0001d69e\\U0001d696\\U0001d699\\U0001d69c \\U0001d698\\U0001d69f\\U0001d68e\\U0001d69b \\U0001d69d\\U0001d691\\U0001d68e \\U0001d695\\U0001d68a\\U0001d6a3\\U0001d6a2 \\U0001d68d\\U0001d698\\U0001d690\",result:(success 43)}",
-    statement:"character_length('𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\U0001d683\\U0001d691\\U0001d68e \\U0001d69a\\U0001d69e\\U0001d692\\U0001d68c\\U0001d694 \\U0001d68b\\U0001d69b\\U0001d698\\U0001d6a0\\U0001d697 \\U0001d68f\\U0001d698\\U0001d6a1 \\U0001d693\\U0001d69e\\U0001d696\\U0001d699\\U0001d69c \\U0001d698\\U0001d69f\\U0001d68e\\U0001d69b \\U0001d69d\\U0001d691\\U0001d68e \\U0001d695\\U0001d68a\\U0001d6a3\\U0001d6a2 \\U0001d68d\\U0001d698\\U0001d690\",result:(success 43)}",
+    statement: "character_length('𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"character_length valid cases{in:\"\\u24af\\u24a3\\u24a0 \\u24ac\\u24b0\\u24a4\\u249e\\u24a6 \\u249d\\u24ad\\u24aa\\u24b2\\u24a9 \\u24a1\\u24aa\\u24b3 \\u24a5\\u24b0\\u24a8\\u24ab\\u24ae \\u24aa\\u24b1\\u24a0\\u24ad \\u24af\\u24a3\\u24a0 \\u24a7\\u249c\\u24b5\\u24b4 \\u249f\\u24aa\\u24a2\",result:(success 43)}",
-    statement:"character_length('⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "character_length valid cases{in:\"\\u24af\\u24a3\\u24a0 \\u24ac\\u24b0\\u24a4\\u249e\\u24a6 \\u249d\\u24ad\\u24aa\\u24b2\\u24a9 \\u24a1\\u24aa\\u24b3 \\u24a5\\u24b0\\u24a8\\u24ab\\u24ae \\u24aa\\u24b1\\u24a0\\u24ad \\u24af\\u24a3\\u24a0 \\u24a7\\u249c\\u24b5\\u24b4 \\u249f\\u24aa\\u24a2\",result:(success 43)}",
+    statement: "character_length('⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:43
+      output: 43
     }
   },
   {
-    name:"char_length null and missing propagation{in:\"null\",result:(success null)}",
-    statement:"char_length(null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "char_length null and missing propagation{in:\"null\",result:(success null)}",
+    statement: "char_length(null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"char_length null and missing propagation{in:\"missing\",result:(success missing::null)}",
-    statement:"char_length(missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"character_length null and missing propagation{in:\"null\",result:(success null)}",
-    statement:"character_length(null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"character_length null and missing propagation{in:\"missing\",result:(success missing::null)}",
-    statement:"character_length(missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"CHARACTER_LENGTH invalid type",
-    statement:"CHARACTER_LENGTH(1)",
-    assert:[
+    name: "char_length null and missing propagation{in:\"missing\",result:(success missing::null)}",
+    statement: "char_length(missing)",
+    assert: [
       {
-        evalMode:EvalModeError,
-        result:EvaluationFail
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "character_length null and missing propagation{in:\"null\",result:(success null)}",
+    statement: "character_length(null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "character_length null and missing propagation{in:\"missing\",result:(success missing::null)}",
+    statement: "character_length(missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
+        EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "CHARACTER_LENGTH invalid type",
+    statement: "CHARACTER_LENGTH(1)",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ],
   },
   {
-    name:"CHARACTER_LENGTH special character",
-    statement:"CHARACTER_LENGTH('français')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "CHARACTER_LENGTH special character",
+    statement: "CHARACTER_LENGTH('français')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:8
+      output: 8
     }
   },
 ]

--- a/partiql-tests-data/eval/primitives/functions/extract.ion
+++ b/partiql-tests-data/eval/primitives/functions/extract.ion
@@ -1,631 +1,662 @@
 extract::[
   extract_null_propagation::[
     {
-      name:"EXTRACT(YEAR FROM NULL)",
-      statement:"EXTRACT(YEAR FROM NULL)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(YEAR FROM NULL)",
+      statement: "EXTRACT(YEAR FROM NULL)",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:null
+        output: null
       }
     },
     {
-      name:"EXTRACT(MONTH FROM NULL)",
-      statement:"EXTRACT(MONTH FROM NULL)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MONTH FROM NULL)",
+      statement: "EXTRACT(MONTH FROM NULL)",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:null
+        output: null
       }
     },
     {
-      name:"EXTRACT(DAY FROM NULL)",
-      statement:"EXTRACT(DAY FROM NULL)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(DAY FROM NULL)",
+      statement: "EXTRACT(DAY FROM NULL)",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:null
+        output: null
       }
     },
     {
-      name:"EXTRACT(HOUR FROM NULL)",
-      statement:"EXTRACT(HOUR FROM NULL)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(HOUR FROM NULL)",
+      statement: "EXTRACT(HOUR FROM NULL)",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:null
+        output: null
       }
     },
     {
-      name:"EXTRACT(MINUTE FROM NULL)",
-      statement:"EXTRACT(MINUTE FROM NULL)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MINUTE FROM NULL)",
+      statement: "EXTRACT(MINUTE FROM NULL)",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:null
+        output: null
       }
     },
     {
-      name:"EXTRACT(SECOND FROM NULL)",
-      statement:"EXTRACT(SECOND FROM NULL)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(SECOND FROM NULL)",
+      statement: "EXTRACT(SECOND FROM NULL)",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:null
+        output: null
       }
     },
     {
-      name:"EXTRACT(TIMEZONE_HOUR FROM NULL)",
-      statement:"EXTRACT(TIMEZONE_HOUR FROM NULL)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_HOUR FROM NULL)",
+      statement: "EXTRACT(TIMEZONE_HOUR FROM NULL)",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:null
+        output: null
       }
     },
     {
-      name:"EXTRACT(TIMEZONE_MINUTE FROM NULL)",
-      statement:"EXTRACT(TIMEZONE_MINUTE FROM NULL)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_MINUTE FROM NULL)",
+      statement: "EXTRACT(TIMEZONE_MINUTE FROM NULL)",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:null
+        output: null
       }
     },
   ],
   missing_propagation::[
     {
-      name:"EXTRACT(YEAR FROM MISSING)",
-      statement:"EXTRACT(YEAR FROM MISSING)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
-          EvalModeCoerce,
-          EvalModeError
-        ],
-        output:$missing::null
-      }
+      name: "EXTRACT(YEAR FROM MISSING)",
+      statement: "EXTRACT(YEAR FROM MISSING)",
+      assert: [
+        {
+          result: EvaluationSuccess,
+          evalMode: EvalModeCoerce,
+          output: $missing::null
+        },
+        {
+          result: EvaluationFail,
+          evalMode: EvalModeError
+        }
+      ]
     },
     {
-      name:"EXTRACT(MONTH FROM MISSING)",
-      statement:"EXTRACT(MONTH FROM MISSING)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MONTH FROM MISSING)",
+      statement: "EXTRACT(MONTH FROM MISSING)",
+      assert: [
+        {
+          result: EvaluationSuccess,
+          evalMode:
           EvalModeCoerce,
-          EvalModeError
-        ],
-        output:$missing::null
-      }
+          output: $missing::null
+        },
+        {
+          evalMode: EvalModeError,
+          result: EvaluationFail,
+        }
+      ]
     },
     {
-      name:"EXTRACT(DAY FROM MISSING)",
-      statement:"EXTRACT(DAY FROM MISSING)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(DAY FROM MISSING)",
+      statement: "EXTRACT(DAY FROM MISSING)",
+      assert: [
+        {
+          result: EvaluationSuccess,
+          evalMode:
           EvalModeCoerce,
-          EvalModeError
-        ],
-        output:$missing::null
-      }
+          output: $missing::null
+        },
+        {
+          evalMode: EvalModeError,
+          result: EvaluationFail,
+        }
+      ]
     },
     {
-      name:"EXTRACT(HOUR FROM MISSING)",
-      statement:"EXTRACT(HOUR FROM MISSING)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(HOUR FROM MISSING)",
+      statement: "EXTRACT(HOUR FROM MISSING)",
+      assert: [
+        {
+          result: EvaluationSuccess,
+          evalMode:
           EvalModeCoerce,
-          EvalModeError
-        ],
-        output:$missing::null
-      }
+          output: $missing::null
+        },
+        {
+          evalMode: EvalModeError,
+          result: EvaluationFail,
+        }
+      ]
     },
     {
-      name:"EXTRACT(MINUTE FROM MISSING)",
-      statement:"EXTRACT(MINUTE FROM MISSING)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MINUTE FROM MISSING)",
+      statement: "EXTRACT(MINUTE FROM MISSING)",
+      assert: [
+        {
+          result: EvaluationSuccess,
+          evalMode:
           EvalModeCoerce,
-          EvalModeError
-        ],
-        output:$missing::null
-      }
+          output: $missing::null
+        },
+        {
+          evalMode: EvalModeError,
+          result: EvaluationFail,
+        }
+      ]
     },
     {
-      name:"EXTRACT(SECOND FROM MISSING)",
-      statement:"EXTRACT(SECOND FROM MISSING)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(SECOND FROM MISSING)",
+      statement: "EXTRACT(SECOND FROM MISSING)",
+      assert: [
+        {
+          result: EvaluationSuccess,
+          evalMode:
           EvalModeCoerce,
-          EvalModeError
-        ],
-        output:$missing::null
-      }
+          output: $missing::null
+        },
+        {
+          evalMode: EvalModeError,
+          result: EvaluationFail,
+        }
+      ]
     },
     {
-      name:"EXTRACT(TIMEZONE_HOUR FROM MISSING)",
-      statement:"EXTRACT(TIMEZONE_HOUR FROM MISSING)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_HOUR FROM MISSING)",
+      statement: "EXTRACT(TIMEZONE_HOUR FROM MISSING)",
+      assert: [
+        {
+          result: EvaluationSuccess,
+          evalMode:
           EvalModeCoerce,
-          EvalModeError
-        ],
-        output:$missing::null
-      }
+          output: $missing::null
+        },
+        {
+          evalMode: EvalModeError,
+          result: EvaluationFail,
+        }
+      ]
     },
     {
-      name:"EXTRACT(TIMEZONE_MINUTE FROM MISSING)",
-      statement:"EXTRACT(TIMEZONE_MINUTE FROM MISSING)",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_MINUTE FROM MISSING)",
+      statement: "EXTRACT(TIMEZONE_MINUTE FROM MISSING)",
+      assert: [
+        {
+          result: EvaluationSuccess,
+          evalMode:
           EvalModeCoerce,
-          EvalModeError
-        ],
-        output:$missing::null
-      }
+          output: $missing::null
+        },
+        {
+          evalMode: EvalModeError,
+          result: EvaluationFail,
+        }
+      ]
     },
   ],
   extract_date::[
     {
-      name:"EXTRACT(YEAR FROM DATE '2000-01-02')",
-      statement:"EXTRACT(YEAR FROM DATE '2000-01-02') = 2000",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(YEAR FROM DATE '2000-01-02')",
+      statement: "EXTRACT(YEAR FROM DATE '2000-01-02') = 2000",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(MONTH FROM DATE '2000-01-02')",
-      statement:"EXTRACT(MONTH FROM DATE '2000-01-02') = 1",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MONTH FROM DATE '2000-01-02')",
+      statement: "EXTRACT(MONTH FROM DATE '2000-01-02') = 1",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(DAY FROM DATE '2000-01-02')",
-      statement:"EXTRACT(DAY FROM DATE '2000-01-02') = 2",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(DAY FROM DATE '2000-01-02')",
+      statement: "EXTRACT(DAY FROM DATE '2000-01-02') = 2",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
   ],
   extract_time::[
     {
-      name:"EXTRACT(HOUR FROM TIME '01:23:45.678')",
-      statement:"EXTRACT(HOUR FROM TIME '01:23:45.678') = 1",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(HOUR FROM TIME '01:23:45.678')",
+      statement: "EXTRACT(HOUR FROM TIME '01:23:45.678') = 1",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(MINUTE FROM TIME '01:23:45.678')",
-      statement:"EXTRACT(MINUTE FROM TIME '01:23:45.678') = 23",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MINUTE FROM TIME '01:23:45.678')",
+      statement: "EXTRACT(MINUTE FROM TIME '01:23:45.678') = 23",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(SECOND FROM TIME '01:23:45.678')",
-      statement:"EXTRACT(SECOND FROM TIME '01:23:45.678') = 45.678",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(SECOND FROM TIME '01:23:45.678')",
+      statement: "EXTRACT(SECOND FROM TIME '01:23:45.678') = 45.678",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
   ],
   extract_time_precision::[
     {
-      name:"EXTRACT(HOUR FROM TIME (2) '01:23:45.678')",
-      statement:"EXTRACT(HOUR FROM TIME (2) '01:23:45.678') = 1",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(HOUR FROM TIME (2) '01:23:45.678')",
+      statement: "EXTRACT(HOUR FROM TIME (2) '01:23:45.678') = 1",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(MINUTE FROM TIME (2) '01:23:45.678')",
-      statement:"EXTRACT(MINUTE FROM TIME (2) '01:23:45.678') = 23",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MINUTE FROM TIME (2) '01:23:45.678')",
+      statement: "EXTRACT(MINUTE FROM TIME (2) '01:23:45.678') = 23",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(SECOND FROM TIME (2) '01:23:45.678')",
-      statement:"EXTRACT(SECOND FROM TIME (2) '01:23:45.678') = 45.68",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(SECOND FROM TIME (2) '01:23:45.678')",
+      statement: "EXTRACT(SECOND FROM TIME (2) '01:23:45.678') = 45.68",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
   ],
   extract_time_with_time_zone::[
     {
-      name:"EXTRACT(HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = 1",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+      statement: "EXTRACT(HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = 1",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = 23",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+      statement: "EXTRACT(MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = 23",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(SECOND FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(SECOND FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = 45.678",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(SECOND FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+      statement: "EXTRACT(SECOND FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = 45.678",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(TIMEZONE_HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(TIMEZONE_HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = -6",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+      statement: "EXTRACT(TIMEZONE_HOUR FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = -6",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(TIMEZONE_MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(TIMEZONE_MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = -30",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+      statement: "EXTRACT(TIMEZONE_MINUTE FROM TIME WITH TIME ZONE '01:23:45.678-06:30') = -30",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
   ],
   extract_time_precision_with_time_zone::[
     {
-      name:"EXTRACT(HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678') = 1",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
+      statement: "EXTRACT(HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678') = 1",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = 23",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
+      statement: "EXTRACT(MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = 23",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(SECOND FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(SECOND FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = 45.68",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(SECOND FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
+      statement: "EXTRACT(SECOND FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = 45.68",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(TIMEZONE_HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(TIMEZONE_HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = -6",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
+      statement: "EXTRACT(TIMEZONE_HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = -6",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(TIMEZONE_MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
-      statement:"EXTRACT(TIMEZONE_MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = -30",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')",
+      statement: "EXTRACT(TIMEZONE_MINUTE FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30') = -30",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
   ],
   extract_timestamp::[
     {
-      name:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67Z`) = 2000",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(YEAR FROM `2000-01-02T03:04:05.67Z`)",
+      statement: "EXTRACT(YEAR FROM `2000-01-02T03:04:05.67Z`) = 2000",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(MONTH FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(MONTH FROM `2000-01-02T03:04:05.67Z`) = 1",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MONTH FROM `2000-01-02T03:04:05.67Z`)",
+      statement: "EXTRACT(MONTH FROM `2000-01-02T03:04:05.67Z`) = 1",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(DAY FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(DAY FROM `2000-01-02T03:04:05.67Z`) = 2",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(DAY FROM `2000-01-02T03:04:05.67Z`)",
+      statement: "EXTRACT(DAY FROM `2000-01-02T03:04:05.67Z`) = 2",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(HOUR FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(HOUR FROM `2000-01-02T03:04:05.67Z`) = 3",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(HOUR FROM `2000-01-02T03:04:05.67Z`)",
+      statement: "EXTRACT(HOUR FROM `2000-01-02T03:04:05.67Z`) = 3",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67Z`) = 4",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67Z`)",
+      statement: "EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67Z`) = 4",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(SECOND FROM `2000-01-02T03:04:05.67Z`)",
-      statement:"EXTRACT(SECOND FROM `2000-01-02T03:04:05.67Z`) = 5.67",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(SECOND FROM `2000-01-02T03:04:05.67Z`)",
+      statement: "EXTRACT(SECOND FROM `2000-01-02T03:04:05.67Z`) = 5.67",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
   ],
   extract_timestamp_offset::[
     {
-      name:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67+08:09`)",
-      statement:"EXTRACT(YEAR FROM `2000-01-02T03:04:05.67+08:09`) = 2000",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(YEAR FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement: "EXTRACT(YEAR FROM `2000-01-02T03:04:05.67+08:09`) = 2000",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(MONTH FROM `2000-01-02T03:04:05.67+08:09`)",
-      statement:"EXTRACT(MONTH FROM `2000-01-02T03:04:05.67+08:09`) = 1",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MONTH FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement: "EXTRACT(MONTH FROM `2000-01-02T03:04:05.67+08:09`) = 1",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(DAY FROM `2000-01-02T03:04:05.67+08:09`)",
-      statement:"EXTRACT(DAY FROM `2000-01-02T03:04:05.67+08:09`) = 2",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(DAY FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement: "EXTRACT(DAY FROM `2000-01-02T03:04:05.67+08:09`) = 2",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(HOUR FROM `2000-01-02T03:04:05.67+08:09`)",
-      statement:"EXTRACT(HOUR FROM `2000-01-02T03:04:05.67+08:09`) = 3",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(HOUR FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement: "EXTRACT(HOUR FROM `2000-01-02T03:04:05.67+08:09`) = 3",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67+08:09`)",
-      statement:"EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67+08:09`) = 4",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement: "EXTRACT(MINUTE FROM `2000-01-02T03:04:05.67+08:09`) = 4",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(SECOND FROM `2000-01-02T03:04:05.67+08:09`)",
-      statement:"EXTRACT(SECOND FROM `2000-01-02T03:04:05.67+08:09`) = 5.67",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(SECOND FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement: "EXTRACT(SECOND FROM `2000-01-02T03:04:05.67+08:09`) = 5.67",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67+08:09`)",
-      statement:"EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67+08:09`) = 8",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement: "EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67+08:09`) = 8",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67+08:09`)",
-      statement:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67+08:09`) = 9",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67+08:09`)",
+      statement: "EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67+08:09`) = 9",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67-08:09`)",
-      statement:"EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67-08:09`) = -8",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67-08:09`)",
+      statement: "EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67-08:09`) = -8",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
     {
-      name:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67-08:09`)",
-      statement:"EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67-08:09`) = -9",
-      assert:{
-        result:EvaluationSuccess,
-        evalMode:[
+      name: "EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67-08:09`)",
+      statement: "EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67-08:09`) = -9",
+      assert: {
+        result: EvaluationSuccess,
+        evalMode: [
           EvalModeCoerce,
           EvalModeError
         ],
-        output:true
+        output: true
       }
     },
   ]
@@ -633,92 +664,92 @@ extract::[
 
 extract_invalid::[
   {
-    name:"invalid extract year from time",
-    statement:"EXTRACT(YEAR FROM TIME '01:23:45.678')",
-    assert:[
+    name: "invalid extract year from time",
+    statement: "EXTRACT(YEAR FROM TIME '01:23:45.678')",
+    assert: [
       {
-        result:EvaluationFail,
-        evalMode:EvalModeError
+        result: EvaluationFail,
+        evalMode: EvalModeError
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"invalid extract month from time",
-    statement:"EXTRACT(MONTH FROM TIME '01:23:45.678')",
-    assert:[
+    name: "invalid extract month from time",
+    statement: "EXTRACT(MONTH FROM TIME '01:23:45.678')",
+    assert: [
       {
-        result:EvaluationFail,
-        evalMode:EvalModeError
+        result: EvaluationFail,
+        evalMode: EvalModeError
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"invalid extract day from time",
-    statement:"EXTRACT(DAY FROM TIME '01:23:45.678')",
-    assert:[
+    name: "invalid extract day from time",
+    statement: "EXTRACT(DAY FROM TIME '01:23:45.678')",
+    assert: [
       {
-        result:EvaluationFail,
-        evalMode:EvalModeError
+        result: EvaluationFail,
+        evalMode: EvalModeError
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"invalid extract year from time",
-    statement:"EXTRACT(YEAR FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
-    assert:[
+    name: "invalid extract year from time",
+    statement: "EXTRACT(YEAR FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+    assert: [
       {
-        result:EvaluationFail,
-        evalMode:EvalModeError
+        result: EvaluationFail,
+        evalMode: EvalModeError
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"invalid extract month from time with time zone",
-    statement:"EXTRACT(MONTH FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
-    assert:[
+    name: "invalid extract month from time with time zone",
+    statement: "EXTRACT(MONTH FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+    assert: [
       {
-        result:EvaluationFail,
-        evalMode:EvalModeError
+        result: EvaluationFail,
+        evalMode: EvalModeError
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ]
   },
   {
-    name:"invalid extract day from time with time zone",
-    statement:"EXTRACT(DAY FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
-    assert:[
+    name: "invalid extract day from time with time zone",
+    statement: "EXTRACT(DAY FROM TIME WITH TIME ZONE '01:23:45.678-06:30')",
+    assert: [
       {
-        result:EvaluationFail,
-        evalMode:EvalModeError
+        result: EvaluationFail,
+        evalMode: EvalModeError
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ]
   },

--- a/partiql-tests-data/eval/primitives/functions/lower.ion
+++ b/partiql-tests-data/eval/primitives/functions/lower.ion
@@ -1,1646 +1,1649 @@
 lower::[
   {
-    name:"lower valid cases{in:\" !\\\"#%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\",result:\" !\\\"#%&()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\"}",
-    statement:"lower(' !\"#$%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\" !\\\"#%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\",result:\" !\\\"#%&()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\"}",
+    statement: "lower(' !\"#$%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:" !\"#$%&()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+      output: " !\"#$%&()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
     }
   },
   {
-    name:"lower valid cases{in:\"\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xff\",result:\"\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xd7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xff\"}",
-    statement:"lower('¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xff\",result:\"\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xd7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xff\"}",
+    statement: "lower('¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿àáâãäåæçèéêëìíîïðñòóôõö×øùúûüýþàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ"
+      output: "¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿àáâãäåæçèéêëìíîïðñòóôõö×øùúûüýþàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u0100\\u0101\\u0102\\u0103\\u0104\\u0105\\u0106\\u0107\\u0108\\u0109\\u010a\\u010b\\u010c\\u010d\\u010e\\u010f\\u0110\\u0111\\u0112\\u0113\\u0114\\u0115\\u0116\\u0117\\u0118\\u0119\\u011a\\u011b\\u011c\\u011d\\u011e\\u011f\\u0120\\u0121\\u0122\\u0123\\u0124\\u0125\\u0126\\u0127\\u0128\\u0129\\u012a\\u012b\\u012c\\u012d\\u012e\\u012f\\u0130\\u0131\\u0132\\u0133\\u0134\\u0135\\u0136\\u0137\\u0138\\u0139\\u013a\\u013b\\u013c\\u013d\\u013e\\u013f\\u0140\\u0141\\u0142\\u0143\\u0144\\u0145\\u0146\\u0147\\u0148\\u014a\\u014b\\u014c\\u014d\\u014e\\u014f\\u0150\\u0151\\u0152\\u0153\\u0154\\u0155\\u0156\\u0157\\u0158\\u0159\\u015a\\u015b\\u015c\\u015d\\u015e\\u015f\\u0160\\u0161\\u0162\\u0163\\u0164\\u0165\\u0166\\u0167\\u0168\\u0169\\u016a\\u016b\\u016c\\u016d\\u016e\\u016f\\u0170\\u0171\\u0172\\u0173\\u0174\\u0175\\u0176\\u0177\\u0178\\u0179\\u017a\\u017b\\u017c\\u017d\\u017e\",result:\"\\u0101\\u0101\\u0103\\u0103\\u0105\\u0105\\u0107\\u0107\\u0109\\u0109\\u010b\\u010b\\u010d\\u010d\\u010f\\u010f\\u0111\\u0111\\u0113\\u0113\\u0115\\u0115\\u0117\\u0117\\u0119\\u0119\\u011b\\u011b\\u011d\\u011d\\u011f\\u011f\\u0121\\u0121\\u0123\\u0123\\u0125\\u0125\\u0127\\u0127\\u0129\\u0129\\u012b\\u012b\\u012d\\u012d\\u012f\\u012fi\\u0307\\u0131\\u0133\\u0133\\u0135\\u0135\\u0137\\u0137\\u0138\\u013a\\u013a\\u013c\\u013c\\u013e\\u013e\\u0140\\u0140\\u0142\\u0142\\u0144\\u0144\\u0146\\u0146\\u0148\\u0148\\u014b\\u014b\\u014d\\u014d\\u014f\\u014f\\u0151\\u0151\\u0153\\u0153\\u0155\\u0155\\u0157\\u0157\\u0159\\u0159\\u015b\\u015b\\u015d\\u015d\\u015f\\u015f\\u0161\\u0161\\u0163\\u0163\\u0165\\u0165\\u0167\\u0167\\u0169\\u0169\\u016b\\u016b\\u016d\\u016d\\u016f\\u016f\\u0171\\u0171\\u0173\\u0173\\u0175\\u0175\\u0177\\u0177\\xff\\u017a\\u017a\\u017c\\u017c\\u017e\\u017e\"}",
-    statement:"lower('ĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽž')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u0100\\u0101\\u0102\\u0103\\u0104\\u0105\\u0106\\u0107\\u0108\\u0109\\u010a\\u010b\\u010c\\u010d\\u010e\\u010f\\u0110\\u0111\\u0112\\u0113\\u0114\\u0115\\u0116\\u0117\\u0118\\u0119\\u011a\\u011b\\u011c\\u011d\\u011e\\u011f\\u0120\\u0121\\u0122\\u0123\\u0124\\u0125\\u0126\\u0127\\u0128\\u0129\\u012a\\u012b\\u012c\\u012d\\u012e\\u012f\\u0130\\u0131\\u0132\\u0133\\u0134\\u0135\\u0136\\u0137\\u0138\\u0139\\u013a\\u013b\\u013c\\u013d\\u013e\\u013f\\u0140\\u0141\\u0142\\u0143\\u0144\\u0145\\u0146\\u0147\\u0148\\u014a\\u014b\\u014c\\u014d\\u014e\\u014f\\u0150\\u0151\\u0152\\u0153\\u0154\\u0155\\u0156\\u0157\\u0158\\u0159\\u015a\\u015b\\u015c\\u015d\\u015e\\u015f\\u0160\\u0161\\u0162\\u0163\\u0164\\u0165\\u0166\\u0167\\u0168\\u0169\\u016a\\u016b\\u016c\\u016d\\u016e\\u016f\\u0170\\u0171\\u0172\\u0173\\u0174\\u0175\\u0176\\u0177\\u0178\\u0179\\u017a\\u017b\\u017c\\u017d\\u017e\",result:\"\\u0101\\u0101\\u0103\\u0103\\u0105\\u0105\\u0107\\u0107\\u0109\\u0109\\u010b\\u010b\\u010d\\u010d\\u010f\\u010f\\u0111\\u0111\\u0113\\u0113\\u0115\\u0115\\u0117\\u0117\\u0119\\u0119\\u011b\\u011b\\u011d\\u011d\\u011f\\u011f\\u0121\\u0121\\u0123\\u0123\\u0125\\u0125\\u0127\\u0127\\u0129\\u0129\\u012b\\u012b\\u012d\\u012d\\u012f\\u012fi\\u0307\\u0131\\u0133\\u0133\\u0135\\u0135\\u0137\\u0137\\u0138\\u013a\\u013a\\u013c\\u013c\\u013e\\u013e\\u0140\\u0140\\u0142\\u0142\\u0144\\u0144\\u0146\\u0146\\u0148\\u0148\\u014b\\u014b\\u014d\\u014d\\u014f\\u014f\\u0151\\u0151\\u0153\\u0153\\u0155\\u0155\\u0157\\u0157\\u0159\\u0159\\u015b\\u015b\\u015d\\u015d\\u015f\\u015f\\u0161\\u0161\\u0163\\u0163\\u0165\\u0165\\u0167\\u0167\\u0169\\u0169\\u016b\\u016b\\u016d\\u016d\\u016f\\u016f\\u0171\\u0171\\u0173\\u0173\\u0175\\u0175\\u0177\\u0177\\xff\\u017a\\u017a\\u017c\\u017c\\u017e\\u017e\"}",
+    statement: "lower('ĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽž')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"āāăăąąććĉĉċċččďďđđēēĕĕėėęęěěĝĝğğġġģģĥĥħħĩĩīīĭĭįįi̇ıĳĳĵĵķķĸĺĺļļľľŀŀłłńńņņňňŋŋōōŏŏőőœœŕŕŗŗřřśśŝŝşşššţţťťŧŧũũūūŭŭůůűűųųŵŵŷŷÿźźżżžž"
+      output: "āāăăąąććĉĉċċččďďđđēēĕĕėėęęěěĝĝğğġġģģĥĥħħĩĩīīĭĭįįi̇ıĳĳĵĵķķĸĺĺļļľľŀŀłłńńņņňňŋŋōōŏŏőőœœŕŕŗŗřřśśŝŝşşššţţťťŧŧũũūūŭŭůůűűųųŵŵŷŷÿźźżżžž"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u0180\\u0181\\u0182\\u0183\\u0184\\u0185\\u0186\\u0187\\u0188\\u0189\\u018a\\u018b\\u018c\\u018d\\u018e\\u018f\\u0190\\u0191\\u0192\\u0193\\u0194\\u0195\\u0196\\u0197\\u0198\\u0199\\u019a\\u019b\\u019c\\u019d\\u019e\\u019f\\u01a0\\u01a1\\u01a2\\u01a3\\u01a4\\u01a5\\u01a6\\u01a7\\u01a8\\u01a9\\u01aa\\u01ab\\u01ac\\u01ad\\u01ae\\u01af\\u01b0\\u01b1\\u01b2\\u01b3\\u01b4\\u01b5\\u01b6\\u01b7\\u01b8\\u01b9\\u01ba\\u01bb\\u01bc\\u01bd\\u01be\\u01bf\\u01c0\\u01c1\\u01c2\\u01c3\\u01c4\\u01c5\\u01c6\\u01c7\\u01c8\\u01c9\\u01ca\\u01cb\\u01cc\\u01cd\\u01ce\\u01cf\\u01d0\\u01d1\\u01d2\\u01d3\\u01d4\\u01d5\\u01d6\\u01d7\\u01d8\\u01d9\\u01da\\u01db\\u01dc\\u01dd\\u01de\\u01df\\u01e0\\u01e1\\u01e2\\u01e3\\u01e4\\u01e5\\u01e6\\u01e7\\u01e8\\u01e9\\u01ea\\u01eb\\u01ec\\u01ed\\u01ee\\u01ef\\u01f0\\u01f1\\u01f2\\u01f3\\u01f4\\u01f5\\u01f6\\u01f7\\u01f8\\u01f9\\u01fa\\u01fb\\u01fc\\u01fd\\u01fe\\u01ff\\u0200\\u0201\\u0202\\u0203\\u0204\\u0205\\u0206\\u0207\\u0208\\u0209\\u020a\\u020b\\u020c\\u020d\\u020e\\u020f\\u0210\\u0211\\u0212\\u0213\\u0214\\u0215\\u0216\\u0217\\u0218\\u0219\\u021a\\u021b\\u021c\\u021d\\u021e\\u021f\\u0220\\u0221\\u0222\\u0223\\u0224\\u0225\\u0226\\u0227\\u0228\\u0229\\u022a\\u022b\\u022c\\u022d\\u022e\\u022f\\u0230\\u0231\\u0232\\u0233\\u0234\\u0235\\u0236\\u0237\\u0238\\u0239\\u023a\\u023b\\u023c\\u023d\\u023e\\u023f\\u0240\\u0241\\u0242\\u0243\\u0244\\u0245\\u0246\\u0247\\u0248\\u0249\\u024a\\u024b\\u024c\\u024d\\u024e\\u024f\",result:\"\\u0180\\u0253\\u0183\\u0183\\u0185\\u0185\\u0254\\u0188\\u0188\\u0256\\u0257\\u018c\\u018c\\u018d\\u01dd\\u0259\\u025b\\u0192\\u0192\\u0260\\u0263\\u0195\\u0269\\u0268\\u0199\\u0199\\u019a\\u019b\\u026f\\u0272\\u019e\\u0275\\u01a1\\u01a1\\u01a3\\u01a3\\u01a5\\u01a5\\u0280\\u01a8\\u01a8\\u0283\\u01aa\\u01ab\\u01ad\\u01ad\\u0288\\u01b0\\u01b0\\u028a\\u028b\\u01b4\\u01b4\\u01b6\\u01b6\\u0292\\u01b9\\u01b9\\u01ba\\u01bb\\u01bd\\u01bd\\u01be\\u01bf\\u01c0\\u01c1\\u01c2\\u01c3\\u01c6\\u01c6\\u01c6\\u01c9\\u01c9\\u01c9\\u01cc\\u01cc\\u01cc\\u01ce\\u01ce\\u01d0\\u01d0\\u01d2\\u01d2\\u01d4\\u01d4\\u01d6\\u01d6\\u01d8\\u01d8\\u01da\\u01da\\u01dc\\u01dc\\u01dd\\u01df\\u01df\\u01e1\\u01e1\\u01e3\\u01e3\\u01e5\\u01e5\\u01e7\\u01e7\\u01e9\\u01e9\\u01eb\\u01eb\\u01ed\\u01ed\\u01ef\\u01ef\\u01f0\\u01f3\\u01f3\\u01f3\\u01f5\\u01f5\\u0195\\u01bf\\u01f9\\u01f9\\u01fb\\u01fb\\u01fd\\u01fd\\u01ff\\u01ff\\u0201\\u0201\\u0203\\u0203\\u0205\\u0205\\u0207\\u0207\\u0209\\u0209\\u020b\\u020b\\u020d\\u020d\\u020f\\u020f\\u0211\\u0211\\u0213\\u0213\\u0215\\u0215\\u0217\\u0217\\u0219\\u0219\\u021b\\u021b\\u021d\\u021d\\u021f\\u021f\\u019e\\u0221\\u0223\\u0223\\u0225\\u0225\\u0227\\u0227\\u0229\\u0229\\u022b\\u022b\\u022d\\u022d\\u022f\\u022f\\u0231\\u0231\\u0233\\u0233\\u0234\\u0235\\u0236\\u0237\\u0238\\u0239\\u2c65\\u023c\\u023c\\u019a\\u2c66\\u023f\\u0240\\u0242\\u0242\\u0180\\u0289\\u028c\\u0247\\u0247\\u0249\\u0249\\u024b\\u024b\\u024d\\u024d\\u024f\\u024f\"}",
-    statement:"lower('ƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴǵǶǷǸǹǺǻǼǽǾǿȀȁȂȃȄȅȆȇȈȉȊȋȌȍȎȏȐȑȒȓȔȕȖȗȘșȚțȜȝȞȟȠȡȢȣȤȥȦȧȨȩȪȫȬȭȮȯȰȱȲȳȴȵȶȷȸȹȺȻȼȽȾȿɀɁɂɃɄɅɆɇɈɉɊɋɌɍɎɏ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u0180\\u0181\\u0182\\u0183\\u0184\\u0185\\u0186\\u0187\\u0188\\u0189\\u018a\\u018b\\u018c\\u018d\\u018e\\u018f\\u0190\\u0191\\u0192\\u0193\\u0194\\u0195\\u0196\\u0197\\u0198\\u0199\\u019a\\u019b\\u019c\\u019d\\u019e\\u019f\\u01a0\\u01a1\\u01a2\\u01a3\\u01a4\\u01a5\\u01a6\\u01a7\\u01a8\\u01a9\\u01aa\\u01ab\\u01ac\\u01ad\\u01ae\\u01af\\u01b0\\u01b1\\u01b2\\u01b3\\u01b4\\u01b5\\u01b6\\u01b7\\u01b8\\u01b9\\u01ba\\u01bb\\u01bc\\u01bd\\u01be\\u01bf\\u01c0\\u01c1\\u01c2\\u01c3\\u01c4\\u01c5\\u01c6\\u01c7\\u01c8\\u01c9\\u01ca\\u01cb\\u01cc\\u01cd\\u01ce\\u01cf\\u01d0\\u01d1\\u01d2\\u01d3\\u01d4\\u01d5\\u01d6\\u01d7\\u01d8\\u01d9\\u01da\\u01db\\u01dc\\u01dd\\u01de\\u01df\\u01e0\\u01e1\\u01e2\\u01e3\\u01e4\\u01e5\\u01e6\\u01e7\\u01e8\\u01e9\\u01ea\\u01eb\\u01ec\\u01ed\\u01ee\\u01ef\\u01f0\\u01f1\\u01f2\\u01f3\\u01f4\\u01f5\\u01f6\\u01f7\\u01f8\\u01f9\\u01fa\\u01fb\\u01fc\\u01fd\\u01fe\\u01ff\\u0200\\u0201\\u0202\\u0203\\u0204\\u0205\\u0206\\u0207\\u0208\\u0209\\u020a\\u020b\\u020c\\u020d\\u020e\\u020f\\u0210\\u0211\\u0212\\u0213\\u0214\\u0215\\u0216\\u0217\\u0218\\u0219\\u021a\\u021b\\u021c\\u021d\\u021e\\u021f\\u0220\\u0221\\u0222\\u0223\\u0224\\u0225\\u0226\\u0227\\u0228\\u0229\\u022a\\u022b\\u022c\\u022d\\u022e\\u022f\\u0230\\u0231\\u0232\\u0233\\u0234\\u0235\\u0236\\u0237\\u0238\\u0239\\u023a\\u023b\\u023c\\u023d\\u023e\\u023f\\u0240\\u0241\\u0242\\u0243\\u0244\\u0245\\u0246\\u0247\\u0248\\u0249\\u024a\\u024b\\u024c\\u024d\\u024e\\u024f\",result:\"\\u0180\\u0253\\u0183\\u0183\\u0185\\u0185\\u0254\\u0188\\u0188\\u0256\\u0257\\u018c\\u018c\\u018d\\u01dd\\u0259\\u025b\\u0192\\u0192\\u0260\\u0263\\u0195\\u0269\\u0268\\u0199\\u0199\\u019a\\u019b\\u026f\\u0272\\u019e\\u0275\\u01a1\\u01a1\\u01a3\\u01a3\\u01a5\\u01a5\\u0280\\u01a8\\u01a8\\u0283\\u01aa\\u01ab\\u01ad\\u01ad\\u0288\\u01b0\\u01b0\\u028a\\u028b\\u01b4\\u01b4\\u01b6\\u01b6\\u0292\\u01b9\\u01b9\\u01ba\\u01bb\\u01bd\\u01bd\\u01be\\u01bf\\u01c0\\u01c1\\u01c2\\u01c3\\u01c6\\u01c6\\u01c6\\u01c9\\u01c9\\u01c9\\u01cc\\u01cc\\u01cc\\u01ce\\u01ce\\u01d0\\u01d0\\u01d2\\u01d2\\u01d4\\u01d4\\u01d6\\u01d6\\u01d8\\u01d8\\u01da\\u01da\\u01dc\\u01dc\\u01dd\\u01df\\u01df\\u01e1\\u01e1\\u01e3\\u01e3\\u01e5\\u01e5\\u01e7\\u01e7\\u01e9\\u01e9\\u01eb\\u01eb\\u01ed\\u01ed\\u01ef\\u01ef\\u01f0\\u01f3\\u01f3\\u01f3\\u01f5\\u01f5\\u0195\\u01bf\\u01f9\\u01f9\\u01fb\\u01fb\\u01fd\\u01fd\\u01ff\\u01ff\\u0201\\u0201\\u0203\\u0203\\u0205\\u0205\\u0207\\u0207\\u0209\\u0209\\u020b\\u020b\\u020d\\u020d\\u020f\\u020f\\u0211\\u0211\\u0213\\u0213\\u0215\\u0215\\u0217\\u0217\\u0219\\u0219\\u021b\\u021b\\u021d\\u021d\\u021f\\u021f\\u019e\\u0221\\u0223\\u0223\\u0225\\u0225\\u0227\\u0227\\u0229\\u0229\\u022b\\u022b\\u022d\\u022d\\u022f\\u022f\\u0231\\u0231\\u0233\\u0233\\u0234\\u0235\\u0236\\u0237\\u0238\\u0239\\u2c65\\u023c\\u023c\\u019a\\u2c66\\u023f\\u0240\\u0242\\u0242\\u0180\\u0289\\u028c\\u0247\\u0247\\u0249\\u0249\\u024b\\u024b\\u024d\\u024d\\u024f\\u024f\"}",
+    statement: "lower('ƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴǵǶǷǸǹǺǻǼǽǾǿȀȁȂȃȄȅȆȇȈȉȊȋȌȍȎȏȐȑȒȓȔȕȖȗȘșȚțȜȝȞȟȠȡȢȣȤȥȦȧȨȩȪȫȬȭȮȯȰȱȲȳȴȵȶȷȸȹȺȻȼȽȾȿɀɁɂɃɄɅɆɇɈɉɊɋɌɍɎɏ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ƀɓƃƃƅƅɔƈƈɖɗƌƌƍǝəɛƒƒɠɣƕɩɨƙƙƚƛɯɲƞɵơơƣƣƥƥʀƨƨʃƪƫƭƭʈưưʊʋƴƴƶƶʒƹƹƺƻƽƽƾƿǀǁǂǃǆǆǆǉǉǉǌǌǌǎǎǐǐǒǒǔǔǖǖǘǘǚǚǜǜǝǟǟǡǡǣǣǥǥǧǧǩǩǫǫǭǭǯǯǰǳǳǳǵǵƕƿǹǹǻǻǽǽǿǿȁȁȃȃȅȅȇȇȉȉȋȋȍȍȏȏȑȑȓȓȕȕȗȗșșțțȝȝȟȟƞȡȣȣȥȥȧȧȩȩȫȫȭȭȯȯȱȱȳȳȴȵȶȷȸȹⱥȼȼƚⱦȿɀɂɂƀʉʌɇɇɉɉɋɋɍɍɏɏ"
+      output: "ƀɓƃƃƅƅɔƈƈɖɗƌƌƍǝəɛƒƒɠɣƕɩɨƙƙƚƛɯɲƞɵơơƣƣƥƥʀƨƨʃƪƫƭƭʈưưʊʋƴƴƶƶʒƹƹƺƻƽƽƾƿǀǁǂǃǆǆǆǉǉǉǌǌǌǎǎǐǐǒǒǔǔǖǖǘǘǚǚǜǜǝǟǟǡǡǣǣǥǥǧǧǩǩǫǫǭǭǯǯǰǳǳǳǵǵƕƿǹǹǻǻǽǽǿǿȁȁȃȃȅȅȇȇȉȉȋȋȍȍȏȏȑȑȓȓȕȕȗȗșșțțȝȝȟȟƞȡȣȣȥȥȧȧȩȩȫȫȭȭȯȯȱȱȳȳȴȵȶȷȸȹⱥȼȼƚⱦȿɀɂɂƀʉʌɇɇɉɉɋɋɍɍɏɏ"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u2c60\\u2c61\\u2c62\\u2c63\\u2c64\\u2c65\\u2c66\\u2c67\\u2c68\\u2c69\\u2c6a\\u2c6b\\u2c6c\\u2c6d\\u2c6e\\u2c6f\\u2c70\\u2c71\\u2c72\\u2c73\\u2c74\\u2c75\\u2c76\\u2c77\\u2c78\\u2c79\\u2c7a\\u2c7b\\u2c7c\\u2c7d\\u2c7e\\u2c7f\",result:\"\\u2c61\\u2c61\\u026b\\u1d7d\\u027d\\u2c65\\u2c66\\u2c68\\u2c68\\u2c6a\\u2c6a\\u2c6c\\u2c6c\\u0251\\u0271\\u0250\\u0252\\u2c71\\u2c73\\u2c73\\u2c74\\u2c76\\u2c76\\u2c77\\u2c78\\u2c79\\u2c7a\\u2c7b\\u2c7c\\u2c7d\\u023f\\u0240\"}",
-    statement:"lower('ⱠⱡⱢⱣⱤⱥⱦⱧⱨⱩⱪⱫⱬⱭⱮⱯⱰⱱⱲⱳⱴⱵⱶⱷⱸⱹⱺⱻⱼⱽⱾⱿ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u2c60\\u2c61\\u2c62\\u2c63\\u2c64\\u2c65\\u2c66\\u2c67\\u2c68\\u2c69\\u2c6a\\u2c6b\\u2c6c\\u2c6d\\u2c6e\\u2c6f\\u2c70\\u2c71\\u2c72\\u2c73\\u2c74\\u2c75\\u2c76\\u2c77\\u2c78\\u2c79\\u2c7a\\u2c7b\\u2c7c\\u2c7d\\u2c7e\\u2c7f\",result:\"\\u2c61\\u2c61\\u026b\\u1d7d\\u027d\\u2c65\\u2c66\\u2c68\\u2c68\\u2c6a\\u2c6a\\u2c6c\\u2c6c\\u0251\\u0271\\u0250\\u0252\\u2c71\\u2c73\\u2c73\\u2c74\\u2c76\\u2c76\\u2c77\\u2c78\\u2c79\\u2c7a\\u2c7b\\u2c7c\\u2c7d\\u023f\\u0240\"}",
+    statement: "lower('ⱠⱡⱢⱣⱤⱥⱦⱧⱨⱩⱪⱫⱬⱭⱮⱯⱰⱱⱲⱳⱴⱵⱶⱷⱸⱹⱺⱻⱼⱽⱾⱿ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ⱡⱡɫᵽɽⱥⱦⱨⱨⱪⱪⱬⱬɑɱɐɒⱱⱳⱳⱴⱶⱶⱷⱸⱹⱺⱻⱼⱽȿɀ"
+      output: "ⱡⱡɫᵽɽⱥⱦⱨⱨⱪⱪⱬⱬɑɱɐɒⱱⱳⱳⱴⱶⱶⱷⱸⱹⱺⱻⱼⱽȿɀ"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\\u3041\\u3066\\u30c8\\u30ad\\u307b\\u30c3\\u0394\\u03d5\\u03be\\u0391\",result:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\\u3041\\u3066\\u30c8\\u30ad\\u307b\\u30c3\\u03b4\\u03d5\\u03be\\u03b1\"}",
-    statement:"lower('話家身圧費谷料村能計税金ぁてトキほッΔϕξΑ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\\u3041\\u3066\\u30c8\\u30ad\\u307b\\u30c3\\u0394\\u03d5\\u03be\\u0391\",result:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\\u3041\\u3066\\u30c8\\u30ad\\u307b\\u30c3\\u03b4\\u03d5\\u03be\\u03b1\"}",
+    statement: "lower('話家身圧費谷料村能計税金ぁてトキほッΔϕξΑ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"話家身圧費谷料村能計税金ぁてトキほッδϕξα"
+      output: "話家身圧費谷料村能計税金ぁてトキほッδϕξα"
     }
   },
   {
-    name:"lower valid cases{in:\"undefined\",result:\"undefined\"}",
-    statement:"lower('undefined')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"undefined\",result:\"undefined\"}",
+    statement: "lower('undefined')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"undefined"
+      output: "undefined"
     }
   },
   {
-    name:"lower valid cases{in:\"undef\",result:\"undef\"}",
-    statement:"lower('undef')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"undef\",result:\"undef\"}",
+    statement: "lower('undef')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"undef"
+      output: "undef"
     }
   },
   {
-    name:"lower valid cases{in:\"null\",result:\"null\"}",
-    statement:"lower('null')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"null\",result:\"null\"}",
+    statement: "lower('null')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"null"
+      output: "null"
     }
   },
   {
-    name:"lower valid cases{in:\"NULL\",result:\"null\"}",
-    statement:"lower('NULL')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"NULL\",result:\"null\"}",
+    statement: "lower('NULL')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"null"
+      output: "null"
     }
   },
   {
-    name:"lower valid cases{in:\"(null)\",result:\"(null)\"}",
-    statement:"lower('(null)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"(null)\",result:\"(null)\"}",
+    statement: "lower('(null)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"(null)"
+      output: "(null)"
     }
   },
   {
-    name:"lower valid cases{in:\"nil\",result:\"nil\"}",
-    statement:"lower('nil')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"nil\",result:\"nil\"}",
+    statement: "lower('nil')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"nil"
+      output: "nil"
     }
   },
   {
-    name:"lower valid cases{in:\"NIL\",result:\"nil\"}",
-    statement:"lower('NIL')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"NIL\",result:\"nil\"}",
+    statement: "lower('NIL')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"nil"
+      output: "nil"
     }
   },
   {
-    name:"lower valid cases{in:\"true\",result:\"true\"}",
-    statement:"lower('true')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"true\",result:\"true\"}",
+    statement: "lower('true')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"true"
+      output: "true"
     }
   },
   {
-    name:"lower valid cases{in:\"false\",result:\"false\"}",
-    statement:"lower('false')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"false\",result:\"false\"}",
+    statement: "lower('false')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"false"
+      output: "false"
     }
   },
   {
-    name:"lower valid cases{in:\"True\",result:\"true\"}",
-    statement:"lower('True')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"True\",result:\"true\"}",
+    statement: "lower('True')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"true"
+      output: "true"
     }
   },
   {
-    name:"lower valid cases{in:\"False\",result:\"false\"}",
-    statement:"lower('False')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"False\",result:\"false\"}",
+    statement: "lower('False')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"false"
+      output: "false"
     }
   },
   {
-    name:"lower valid cases{in:\"TRUE\",result:\"true\"}",
-    statement:"lower('TRUE')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"TRUE\",result:\"true\"}",
+    statement: "lower('TRUE')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"true"
+      output: "true"
     }
   },
   {
-    name:"lower valid cases{in:\"FALSE\",result:\"false\"}",
-    statement:"lower('FALSE')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"FALSE\",result:\"false\"}",
+    statement: "lower('FALSE')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"false"
+      output: "false"
     }
   },
   {
-    name:"lower valid cases{in:\"None\",result:\"none\"}",
-    statement:"lower('None')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"None\",result:\"none\"}",
+    statement: "lower('None')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"none"
+      output: "none"
     }
   },
   {
-    name:"lower valid cases{in:\"hasOwnProperty\",result:\"hasownproperty\"}",
-    statement:"lower('hasOwnProperty')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"hasOwnProperty\",result:\"hasownproperty\"}",
+    statement: "lower('hasOwnProperty')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"hasownproperty"
+      output: "hasownproperty"
     }
   },
   {
-    name:"lower valid cases{in:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\",result:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\"}",
-    statement:"lower('999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\",result:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\"}",
+    statement: "lower('999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"
+      output: "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"
     }
   },
   {
-    name:"lower valid cases{in:\"123456789012345678901234567890123456789\",result:\"123456789012345678901234567890123456789\"}",
-    statement:"lower('123456789012345678901234567890123456789')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"123456789012345678901234567890123456789\",result:\"123456789012345678901234567890123456789\"}",
+    statement: "lower('123456789012345678901234567890123456789')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789012345678901234567890123456789"
+      output: "123456789012345678901234567890123456789"
     }
   },
   {
-    name:"lower valid cases{in:\"0\",result:\"0\"}",
-    statement:"lower('0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0\",result:\"0\"}",
+    statement: "lower('0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0"
+      output: "0"
     }
   },
   {
-    name:"lower valid cases{in:\"1\",result:\"1\"}",
-    statement:"lower('1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1\",result:\"1\"}",
+    statement: "lower('1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1"
+      output: "1"
     }
   },
   {
-    name:"lower valid cases{in:\"1.00\",result:\"1.00\"}",
-    statement:"lower('1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1.00\",result:\"1.00\"}",
+    statement: "lower('1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1.00"
+      output: "1.00"
     }
   },
   {
-    name:"lower valid cases{in:\"1.00\",result:\"1.00\"}",
-    statement:"lower('$1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1.00\",result:\"1.00\"}",
+    statement: "lower('$1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"$1.00"
+      output: "$1.00"
     }
   },
   {
-    name:"lower valid cases{in:\"1/2\",result:\"1/2\"}",
-    statement:"lower('1/2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1/2\",result:\"1/2\"}",
+    statement: "lower('1/2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1/2"
+      output: "1/2"
     }
   },
   {
-    name:"lower valid cases{in:\"1E2\",result:\"1e2\"}",
-    statement:"lower('1E2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1E2\",result:\"1e2\"}",
+    statement: "lower('1E2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1e2"
+      output: "1e2"
     }
   },
   {
-    name:"lower valid cases{in:\"1E02\",result:\"1e02\"}",
-    statement:"lower('1E02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1E02\",result:\"1e02\"}",
+    statement: "lower('1E02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1e02"
+      output: "1e02"
     }
   },
   {
-    name:"lower valid cases{in:\"1E+02\",result:\"1e+02\"}",
-    statement:"lower('1E+02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1E+02\",result:\"1e+02\"}",
+    statement: "lower('1E+02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1e+02"
+      output: "1e+02"
     }
   },
   {
-    name:"lower valid cases{in:\"-1\",result:\"-1\"}",
-    statement:"lower('-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-1\",result:\"-1\"}",
+    statement: "lower('-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1"
+      output: "-1"
     }
   },
   {
-    name:"lower valid cases{in:\"-1.00\",result:\"-1.00\"}",
-    statement:"lower('-1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-1.00\",result:\"-1.00\"}",
+    statement: "lower('-1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1.00"
+      output: "-1.00"
     }
   },
   {
-    name:"lower valid cases{in:\"-1.00\",result:\"-1.00\"}",
-    statement:"lower('-$1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-1.00\",result:\"-1.00\"}",
+    statement: "lower('-$1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-$1.00"
+      output: "-$1.00"
     }
   },
   {
-    name:"lower valid cases{in:\"-1/2\",result:\"-1/2\"}",
-    statement:"lower('-1/2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-1/2\",result:\"-1/2\"}",
+    statement: "lower('-1/2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1/2"
+      output: "-1/2"
     }
   },
   {
-    name:"lower valid cases{in:\"-1E2\",result:\"-1e2\"}",
-    statement:"lower('-1E2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-1E2\",result:\"-1e2\"}",
+    statement: "lower('-1E2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1e2"
+      output: "-1e2"
     }
   },
   {
-    name:"lower valid cases{in:\"-1E02\",result:\"-1e02\"}",
-    statement:"lower('-1E02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-1E02\",result:\"-1e02\"}",
+    statement: "lower('-1E02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1e02"
+      output: "-1e02"
     }
   },
   {
-    name:"lower valid cases{in:\"-1E+02\",result:\"-1e+02\"}",
-    statement:"lower('-1E+02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-1E+02\",result:\"-1e+02\"}",
+    statement: "lower('-1E+02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1e+02"
+      output: "-1e+02"
     }
   },
   {
-    name:"lower valid cases{in:\"1/0\",result:\"1/0\"}",
-    statement:"lower('1/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1/0\",result:\"1/0\"}",
+    statement: "lower('1/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1/0"
+      output: "1/0"
     }
   },
   {
-    name:"lower valid cases{in:\"0/0\",result:\"0/0\"}",
-    statement:"lower('0/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0/0\",result:\"0/0\"}",
+    statement: "lower('0/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0/0"
+      output: "0/0"
     }
   },
   {
-    name:"lower valid cases{in:\"-2147483648/-1\",result:\"-2147483648/-1\"}",
-    statement:"lower('-2147483648/-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-2147483648/-1\",result:\"-2147483648/-1\"}",
+    statement: "lower('-2147483648/-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-2147483648/-1"
+      output: "-2147483648/-1"
     }
   },
   {
-    name:"lower valid cases{in:\"-9223372036854775808/-1\",result:\"-9223372036854775808/-1\"}",
-    statement:"lower('-9223372036854775808/-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-9223372036854775808/-1\",result:\"-9223372036854775808/-1\"}",
+    statement: "lower('-9223372036854775808/-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-9223372036854775808/-1"
+      output: "-9223372036854775808/-1"
     }
   },
   {
-    name:"lower valid cases{in:\"-0\",result:\"-0\"}",
-    statement:"lower('-0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-0\",result:\"-0\"}",
+    statement: "lower('-0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-0"
+      output: "-0"
     }
   },
   {
-    name:"lower valid cases{in:\"-0.0\",result:\"-0.0\"}",
-    statement:"lower('-0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-0.0\",result:\"-0.0\"}",
+    statement: "lower('-0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-0.0"
+      output: "-0.0"
     }
   },
   {
-    name:"lower valid cases{in:\"+0\",result:\"+0\"}",
-    statement:"lower('+0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"+0\",result:\"+0\"}",
+    statement: "lower('+0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"+0"
+      output: "+0"
     }
   },
   {
-    name:"lower valid cases{in:\"+0.0\",result:\"+0.0\"}",
-    statement:"lower('+0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"+0.0\",result:\"+0.0\"}",
+    statement: "lower('+0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"+0.0"
+      output: "+0.0"
     }
   },
   {
-    name:"lower valid cases{in:\"0.00\",result:\"0.00\"}",
-    statement:"lower('0.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0.00\",result:\"0.00\"}",
+    statement: "lower('0.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0.00"
+      output: "0.00"
     }
   },
   {
-    name:"lower valid cases{in:\"0..0\",result:\"0..0\"}",
-    statement:"lower('0..0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0..0\",result:\"0..0\"}",
+    statement: "lower('0..0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0..0"
+      output: "0..0"
     }
   },
   {
-    name:"lower valid cases{in:\".\",result:\".\"}",
-    statement:"lower('.')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\".\",result:\".\"}",
+    statement: "lower('.')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"."
+      output: "."
     }
   },
   {
-    name:"lower valid cases{in:\"0.0.0\",result:\"0.0.0\"}",
-    statement:"lower('0.0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0.0.0\",result:\"0.0.0\"}",
+    statement: "lower('0.0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0.0.0"
+      output: "0.0.0"
     }
   },
   {
-    name:"lower valid cases{in:\"0,00\",result:\"0,00\"}",
-    statement:"lower('0,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0,00\",result:\"0,00\"}",
+    statement: "lower('0,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0,00"
+      output: "0,00"
     }
   },
   {
-    name:"lower valid cases{in:\"0,,0\",result:\"0,,0\"}",
-    statement:"lower('0,,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0,,0\",result:\"0,,0\"}",
+    statement: "lower('0,,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0,,0"
+      output: "0,,0"
     }
   },
   {
-    name:"lower valid cases{in:\",\",result:\",\"}",
-    statement:"lower(',')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\",\",result:\",\"}",
+    statement: "lower(',')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:","
+      output: ","
     }
   },
   {
-    name:"lower valid cases{in:\"0,0,0\",result:\"0,0,0\"}",
-    statement:"lower('0,0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0,0,0\",result:\"0,0,0\"}",
+    statement: "lower('0,0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0,0,0"
+      output: "0,0,0"
     }
   },
   {
-    name:"lower valid cases{in:\"0.0/0\",result:\"0.0/0\"}",
-    statement:"lower('0.0/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0.0/0\",result:\"0.0/0\"}",
+    statement: "lower('0.0/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0.0/0"
+      output: "0.0/0"
     }
   },
   {
-    name:"lower valid cases{in:\"1.0/0.0\",result:\"1.0/0.0\"}",
-    statement:"lower('1.0/0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1.0/0.0\",result:\"1.0/0.0\"}",
+    statement: "lower('1.0/0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1.0/0.0"
+      output: "1.0/0.0"
     }
   },
   {
-    name:"lower valid cases{in:\"0.0/0.0\",result:\"0.0/0.0\"}",
-    statement:"lower('0.0/0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0.0/0.0\",result:\"0.0/0.0\"}",
+    statement: "lower('0.0/0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0.0/0.0"
+      output: "0.0/0.0"
     }
   },
   {
-    name:"lower valid cases{in:\"1,0/0,0\",result:\"1,0/0,0\"}",
-    statement:"lower('1,0/0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1,0/0,0\",result:\"1,0/0,0\"}",
+    statement: "lower('1,0/0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1,0/0,0"
+      output: "1,0/0,0"
     }
   },
   {
-    name:"lower valid cases{in:\"0,0/0,0\",result:\"0,0/0,0\"}",
-    statement:"lower('0,0/0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0,0/0,0\",result:\"0,0/0,0\"}",
+    statement: "lower('0,0/0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0,0/0,0"
+      output: "0,0/0,0"
     }
   },
   {
-    name:"lower valid cases{in:\"--1\",result:\"--1\"}",
-    statement:"lower('--1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"--1\",result:\"--1\"}",
+    statement: "lower('--1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"--1"
+      output: "--1"
     }
   },
   {
-    name:"lower valid cases{in:\"-\",result:\"-\"}",
-    statement:"lower('-')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-\",result:\"-\"}",
+    statement: "lower('-')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-"
+      output: "-"
     }
   },
   {
-    name:"lower valid cases{in:\"-.\",result:\"-.\"}",
-    statement:"lower('-.')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-.\",result:\"-.\"}",
+    statement: "lower('-.')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-."
+      output: "-."
     }
   },
   {
-    name:"lower valid cases{in:\"-,\",result:\"-,\"}",
-    statement:"lower('-,')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-,\",result:\"-,\"}",
+    statement: "lower('-,')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-,"
+      output: "-,"
     }
   },
   {
-    name:"lower valid cases{in:\"NaN\",result:\"nan\"}",
-    statement:"lower('NaN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"NaN\",result:\"nan\"}",
+    statement: "lower('NaN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"nan"
+      output: "nan"
     }
   },
   {
-    name:"lower valid cases{in:\"Infinity\",result:\"infinity\"}",
-    statement:"lower('Infinity')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"Infinity\",result:\"infinity\"}",
+    statement: "lower('Infinity')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"infinity"
+      output: "infinity"
     }
   },
   {
-    name:"lower valid cases{in:\"-Infinity\",result:\"-infinity\"}",
-    statement:"lower('-Infinity')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-Infinity\",result:\"-infinity\"}",
+    statement: "lower('-Infinity')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-infinity"
+      output: "-infinity"
     }
   },
   {
-    name:"lower valid cases{in:\"INF\",result:\"inf\"}",
-    statement:"lower('INF')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"INF\",result:\"inf\"}",
+    statement: "lower('INF')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"inf"
+      output: "inf"
     }
   },
   {
-    name:"lower valid cases{in:\"1#INF\",result:\"1#inf\"}",
-    statement:"lower('1#INF')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1#INF\",result:\"1#inf\"}",
+    statement: "lower('1#INF')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1#inf"
+      output: "1#inf"
     }
   },
   {
-    name:"lower valid cases{in:\"-1#IND\",result:\"-1#ind\"}",
-    statement:"lower('-1#IND')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"-1#IND\",result:\"-1#ind\"}",
+    statement: "lower('-1#IND')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1#ind"
+      output: "-1#ind"
     }
   },
   {
-    name:"lower valid cases{in:\"1#QNAN\",result:\"1#qnan\"}",
-    statement:"lower('1#QNAN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1#QNAN\",result:\"1#qnan\"}",
+    statement: "lower('1#QNAN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1#qnan"
+      output: "1#qnan"
     }
   },
   {
-    name:"lower valid cases{in:\"1#SNAN\",result:\"1#snan\"}",
-    statement:"lower('1#SNAN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1#SNAN\",result:\"1#snan\"}",
+    statement: "lower('1#SNAN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1#snan"
+      output: "1#snan"
     }
   },
   {
-    name:"lower valid cases{in:\"1#IND\",result:\"1#ind\"}",
-    statement:"lower('1#IND')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1#IND\",result:\"1#ind\"}",
+    statement: "lower('1#IND')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1#ind"
+      output: "1#ind"
     }
   },
   {
-    name:"lower valid cases{in:\"0x0\",result:\"0x0\"}",
-    statement:"lower('0x0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0x0\",result:\"0x0\"}",
+    statement: "lower('0x0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0x0"
+      output: "0x0"
     }
   },
   {
-    name:"lower valid cases{in:\"0xffffffff\",result:\"0xffffffff\"}",
-    statement:"lower('0xffffffff')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0xffffffff\",result:\"0xffffffff\"}",
+    statement: "lower('0xffffffff')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0xffffffff"
+      output: "0xffffffff"
     }
   },
   {
-    name:"lower valid cases{in:\"0xffffffffffffffff\",result:\"0xffffffffffffffff\"}",
-    statement:"lower('0xffffffffffffffff')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0xffffffffffffffff\",result:\"0xffffffffffffffff\"}",
+    statement: "lower('0xffffffffffffffff')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0xffffffffffffffff"
+      output: "0xffffffffffffffff"
     }
   },
   {
-    name:"lower valid cases{in:\"0xabad1dea\",result:\"0xabad1dea\"}",
-    statement:"lower('0xabad1dea')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0xabad1dea\",result:\"0xabad1dea\"}",
+    statement: "lower('0xabad1dea')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0xabad1dea"
+      output: "0xabad1dea"
     }
   },
   {
-    name:"lower valid cases{in:\"1,000.00\",result:\"1,000.00\"}",
-    statement:"lower('1,000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1,000.00\",result:\"1,000.00\"}",
+    statement: "lower('1,000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1,000.00"
+      output: "1,000.00"
     }
   },
   {
-    name:"lower valid cases{in:\"1 000.00\",result:\"1 000.00\"}",
-    statement:"lower('1 000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1 000.00\",result:\"1 000.00\"}",
+    statement: "lower('1 000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1 000.00"
+      output: "1 000.00"
     }
   },
   {
-    name:"lower valid cases{in:\"1,000,000.00\",result:\"1,000,000.00\"}",
-    statement:"lower('1,000,000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1,000,000.00\",result:\"1,000,000.00\"}",
+    statement: "lower('1,000,000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1,000,000.00"
+      output: "1,000,000.00"
     }
   },
   {
-    name:"lower valid cases{in:\"1 000 000.00\",result:\"1 000 000.00\"}",
-    statement:"lower('1 000 000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1 000 000.00\",result:\"1 000 000.00\"}",
+    statement: "lower('1 000 000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1 000 000.00"
+      output: "1 000 000.00"
     }
   },
   {
-    name:"lower valid cases{in:\"1.000,00\",result:\"1.000,00\"}",
-    statement:"lower('1.000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1.000,00\",result:\"1.000,00\"}",
+    statement: "lower('1.000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1.000,00"
+      output: "1.000,00"
     }
   },
   {
-    name:"lower valid cases{in:\"1 000,00\",result:\"1 000,00\"}",
-    statement:"lower('1 000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1 000,00\",result:\"1 000,00\"}",
+    statement: "lower('1 000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1 000,00"
+      output: "1 000,00"
     }
   },
   {
-    name:"lower valid cases{in:\"1.000.000,00\",result:\"1.000.000,00\"}",
-    statement:"lower('1.000.000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1.000.000,00\",result:\"1.000.000,00\"}",
+    statement: "lower('1.000.000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1.000.000,00"
+      output: "1.000.000,00"
     }
   },
   {
-    name:"lower valid cases{in:\"1 000 000,00\",result:\"1 000 000,00\"}",
-    statement:"lower('1 000 000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"1 000 000,00\",result:\"1 000 000,00\"}",
+    statement: "lower('1 000 000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1 000 000,00"
+      output: "1 000 000,00"
     }
   },
   {
-    name:"lower valid cases{in:\"01000\",result:\"01000\"}",
-    statement:"lower('01000')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"01000\",result:\"01000\"}",
+    statement: "lower('01000')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"01000"
+      output: "01000"
     }
   },
   {
-    name:"lower valid cases{in:\"08\",result:\"08\"}",
-    statement:"lower('08')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"08\",result:\"08\"}",
+    statement: "lower('08')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"08"
+      output: "08"
     }
   },
   {
-    name:"lower valid cases{in:\"09\",result:\"09\"}",
-    statement:"lower('09')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"09\",result:\"09\"}",
+    statement: "lower('09')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"09"
+      output: "09"
     }
   },
   {
-    name:"lower valid cases{in:\"2.2250738585072011e-308\",result:\"2.2250738585072011e-308\"}",
-    statement:"lower('2.2250738585072011e-308')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"2.2250738585072011e-308\",result:\"2.2250738585072011e-308\"}",
+    statement: "lower('2.2250738585072011e-308')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"2.2250738585072011e-308"
+      output: "2.2250738585072011e-308"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:\"\\u0451\\u0452\\u0453\\u0454\\u0455\\u0456\\u0457\\u0458\\u0459\\u045a\\u045b\\u045c\\u045d\\u045e\\u045f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
-    statement:"lower('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:\"\\u0451\\u0452\\u0453\\u0454\\u0455\\u0456\\u0457\\u0458\\u0459\\u045a\\u045b\\u045c\\u045d\\u045e\\u045f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
+    statement: "lower('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ёђѓєѕіїјљњћќѝўџабвгдежзийклмнопрстуфхцчшщъыьэюяабвгдежзийклмнопрстуфхцчшщъыьэюя"
+      output: "ёђѓєѕіїјљњћќѝўџабвгдежзийклмнопрстуфхцчшщъыьэюяабвгдежзийклмнопрстуфхцчшщъыьэюя"
     }
   },
   {
-    name:"lower valid cases{in:\"<>?:\\\"{}|_+\",result:\"<>?:\\\"{}|_+\"}",
-    statement:"lower('<>?:\"{}|_+')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"<>?:\\\"{}|_+\",result:\"<>?:\\\"{}|_+\"}",
+    statement: "lower('<>?:\"{}|_+')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"<>?:\"{}|_+"
+      output: "<>?:\"{}|_+"
     }
   },
   {
-    name:"lower valid cases{in:\"!@#%^&*()`~\",result:\"!@#%^&*()`~\"}",
-    statement:"lower('!@#$%^&*()`~')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"!@#%^&*()`~\",result:\"!@#%^&*()`~\"}",
+    statement: "lower('!@#$%^&*()`~')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"!@#$%^&*()`~"
+      output: "!@#$%^&*()`~"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u03a9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\",result:\"\\u03c9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\"}",
-    statement:"lower('Ω≈ç√∫˜µ≤≥÷')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u03a9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\",result:\"\\u03c9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\"}",
+    statement: "lower('Ω≈ç√∫˜µ≤≥÷')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ω≈ç√∫˜µ≤≥÷"
+      output: "ω≈ç√∫˜µ≤≥÷"
     }
   },
   {
-    name:"lower valid cases{in:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\",result:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\"}",
-    statement:"lower('åß∂ƒ©˙∆˚¬…æ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\",result:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\"}",
+    statement: "lower('åß∂ƒ©˙∆˚¬…æ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"åß∂ƒ©˙∆˚¬…æ"
+      output: "åß∂ƒ©˙∆˚¬…æ"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\",result:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\"}",
-    statement:"lower('œ∑´®†¥¨ˆøπ“‘')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\",result:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\"}",
+    statement: "lower('œ∑´®†¥¨ˆøπ“‘')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"œ∑´®†¥¨ˆøπ“‘"
+      output: "œ∑´®†¥¨ˆøπ“‘"
     }
   },
   {
-    name:"lower valid cases{in:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\",result:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\"}",
-    statement:"lower('¡™£¢∞§¶•ªº–≠')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\",result:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\"}",
+    statement: "lower('¡™£¢∞§¶•ªº–≠')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"¡™£¢∞§¶•ªº–≠"
+      output: "¡™£¢∞§¶•ªº–≠"
     }
   },
   {
-    name:"lower valid cases{in:\"\\xb8\\u02db\\xc7\\u25ca\\u0131\\u02dc\\xc2\\xaf\\u02d8\\xbf\",result:\"\\xb8\\u02db\\xe7\\u25ca\\u0131\\u02dc\\xe2\\xaf\\u02d8\\xbf\"}",
-    statement:"lower('¸˛Ç◊ı˜Â¯˘¿')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\xb8\\u02db\\xc7\\u25ca\\u0131\\u02dc\\xc2\\xaf\\u02d8\\xbf\",result:\"\\xb8\\u02db\\xe7\\u25ca\\u0131\\u02dc\\xe2\\xaf\\u02d8\\xbf\"}",
+    statement: "lower('¸˛Ç◊ı˜Â¯˘¿')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"¸˛ç◊ı˜â¯˘¿"
+      output: "¸˛ç◊ı˜â¯˘¿"
     }
   },
   {
-    name:"lower valid cases{in:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\",result:\"\\xe5\\xed\\xee\\xef\\u02dd\\xf3\\xf4\\uf8ff\\xf2\\xfa\\xe6\\u2603\"}",
-    statement:"lower('ÅÍÎÏ˝ÓÔÒÚÆ☃')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\",result:\"\\xe5\\xed\\xee\\xef\\u02dd\\xf3\\xf4\\uf8ff\\xf2\\xfa\\xe6\\u2603\"}",
+    statement: "lower('ÅÍÎÏ˝ÓÔÒÚÆ☃')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"åíîï˝óôòúæ☃"
+      output: "åíîï˝óôòúæ☃"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\",result:\"\\u0153\\u201e\\xb4\\u2030\\u02c7\\xe1\\xa8\\u02c6\\xf8\\u220f\\u201d\\u2019\"}",
-    statement:"lower('Œ„´‰ˇÁ¨ˆØ∏”’')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\",result:\"\\u0153\\u201e\\xb4\\u2030\\u02c7\\xe1\\xa8\\u02c6\\xf8\\u220f\\u201d\\u2019\"}",
+    statement: "lower('Œ„´‰ˇÁ¨ˆØ∏”’')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"œ„´‰ˇá¨ˆø∏”’"
+      output: "œ„´‰ˇá¨ˆø∏”’"
     }
   },
   {
-    name:"lower valid cases{in:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\",result:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\"}",
-    statement:"lower('`⁄€‹›ﬁﬂ‡°·‚—±')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\",result:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\"}",
+    statement: "lower('`⁄€‹›ﬁﬂ‡°·‚—±')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"`⁄€‹›ﬁﬂ‡°·‚—±"
+      output: "`⁄€‹›ﬁﬂ‡°·‚—±"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u215b\\u215c\\u215d\\u215e\",result:\"\\u215b\\u215c\\u215d\\u215e\"}",
-    statement:"lower('⅛⅜⅝⅞')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u215b\\u215c\\u215d\\u215e\",result:\"\\u215b\\u215c\\u215d\\u215e\"}",
+    statement: "lower('⅛⅜⅝⅞')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"⅛⅜⅝⅞"
+      output: "⅛⅜⅝⅞"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\",result:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\"}",
-    statement:"lower('٠١٢٣٤٥٦٧٨٩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\",result:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\"}",
+    statement: "lower('٠١٢٣٤٥٦٧٨٩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"٠١٢٣٤٥٦٧٨٩"
+      output: "٠١٢٣٤٥٦٧٨٩"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\",result:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\"}",
-    statement:"lower('田中さんにあげて下さい')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\",result:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\"}",
+    statement: "lower('田中さんにあげて下さい')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"田中さんにあげて下さい"
+      output: "田中さんにあげて下さい"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\",result:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\"}",
-    statement:"lower('パーティーへ行かないか')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\",result:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\"}",
+    statement: "lower('パーティーへ行かないか')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"パーティーへ行かないか"
+      output: "パーティーへ行かないか"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u548c\\u88fd\\u6f22\\u8a9e\",result:\"\\u548c\\u88fd\\u6f22\\u8a9e\"}",
-    statement:"lower('和製漢語')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u548c\\u88fd\\u6f22\\u8a9e\",result:\"\\u548c\\u88fd\\u6f22\\u8a9e\"}",
+    statement: "lower('和製漢語')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"和製漢語"
+      output: "和製漢語"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u90e8\\u843d\\u683c\",result:\"\\u90e8\\u843d\\u683c\"}",
-    statement:"lower('部落格')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u90e8\\u843d\\u683c\",result:\"\\u90e8\\u843d\\u683c\"}",
+    statement: "lower('部落格')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"部落格"
+      output: "部落格"
     }
   },
   {
-    name:"lower valid cases{in:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\",result:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\"}",
-    statement:"lower('사회과학원 어학연구소')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\",result:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\"}",
+    statement: "lower('사회과학원 어학연구소')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"사회과학원 어학연구소"
+      output: "사회과학원 어학연구소"
     }
   },
   {
-    name:"lower valid cases{in:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\",result:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\"}",
-    statement:"lower('찦차를 타고 온 펲시맨과 쑛다리 똠방각하')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\",result:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\"}",
+    statement: "lower('찦차를 타고 온 펲시맨과 쑛다리 똠방각하')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"찦차를 타고 온 펲시맨과 쑛다리 똠방각하"
+      output: "찦차를 타고 온 펲시맨과 쑛다리 똠방각하"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\",result:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\"}",
-    statement:"lower('社會科學院語學研究所')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\",result:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\"}",
+    statement: "lower('社會科學院語學研究所')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"社會科學院語學研究所"
+      output: "社會科學院語學研究所"
     }
   },
   {
-    name:"lower valid cases{in:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\",result:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\"}",
-    statement:"lower('울란바토르')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\",result:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\"}",
+    statement: "lower('울란바토르')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"울란바토르"
+      output: "울란바토르"
     }
   },
   {
-    name:"lower valid cases{in:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\",result:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\"}",
-    statement:"lower('𠜎𠜱𠝹𠱓𠱸𠲖𠳏')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\",result:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\"}",
+    statement: "lower('𠜎𠜱𠝹𠱓𠱸𠲖𠳏')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"𠜎𠜱𠝹𠱓𠱸𠲖𠳏"
+      output: "𠜎𠜱𠝹𠱓𠱸𠲖𠳏"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u023a\",result:\"\\u2c65\"}",
-    statement:"lower('Ⱥ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u023a\",result:\"\\u2c65\"}",
+    statement: "lower('Ⱥ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ⱥ"
+      output: "ⱥ"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u023e\",result:\"\\u2c66\"}",
-    statement:"lower('Ⱦ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u023e\",result:\"\\u2c66\"}",
+    statement: "lower('Ⱦ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ⱦ"
+      output: "ⱦ"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\",result:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\"}",
-    statement:"lower('ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\",result:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\"}",
+    statement: "lower('ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ"
+      output: "ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ"
     }
   },
   {
-    name:"lower valid cases{in:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\",result:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\"}",
-    statement:"lower('(｡◕ ∀ ◕｡)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\",result:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\"}",
+    statement: "lower('(｡◕ ∀ ◕｡)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"(｡◕ ∀ ◕｡)"
+      output: "(｡◕ ∀ ◕｡)"
     }
   },
   {
-    name:"lower valid cases{in:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\",result:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\"}",
-    statement:"lower('｀ｨ(´∀｀∩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\",result:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\"}",
+    statement: "lower('｀ｨ(´∀｀∩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"｀ｨ(´∀｀∩"
+      output: "｀ｨ(´∀｀∩"
     }
   },
   {
-    name:"lower valid cases{in:\"__\\uff9b(,_,*)\",result:\"__\\uff9b(,_,*)\"}",
-    statement:"lower('__ﾛ(,_,*)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"__\\uff9b(,_,*)\",result:\"__\\uff9b(,_,*)\"}",
+    statement: "lower('__ﾛ(,_,*)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"__ﾛ(,_,*)"
+      output: "__ﾛ(,_,*)"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\",result:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\"}",
-    statement:"lower('・(￣∀￣)・:*:')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\",result:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\"}",
+    statement: "lower('・(￣∀￣)・:*:')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"・(￣∀￣)・:*:"
+      output: "・(￣∀￣)・:*:"
     }
   },
   {
-    name:"lower valid cases{in:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\",result:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\"}",
-    statement:"lower('ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\",result:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\"}",
+    statement: "lower('ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ"
+      output: "ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ"
     }
   },
   {
-    name:"lower valid cases{in:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\",result:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\"}",
-    statement:"lower(',。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\",result:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\"}",
+    statement: "lower(',。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:",。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’"
+      output: ",。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’"
     }
   },
   {
-    name:"lower valid cases{in:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\",result:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\"}",
-    statement:"lower('(╯°□°）╯︵ ┻━┻)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\",result:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\"}",
+    statement: "lower('(╯°□°）╯︵ ┻━┻)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"(╯°□°）╯︵ ┻━┻)"
+      output: "(╯°□°）╯︵ ┻━┻)"
     }
   },
   {
-    name:"lower valid cases{in:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\",result:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\"}",
-    statement:"lower('(ﾉಥ益ಥ）ﾉ﻿ ┻━┻')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\",result:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\"}",
+    statement: "lower('(ﾉಥ益ಥ）ﾉ﻿ ┻━┻')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"(ﾉಥ益ಥ）ﾉ﻿ ┻━┻"
+      output: "(ﾉಥ益ಥ）ﾉ﻿ ┻━┻"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\"}",
-    statement:"lower('┬─┬ノ( º _ ºノ)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\"}",
+    statement: "lower('┬─┬ノ( º _ ºノ)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"┬─┬ノ( º _ ºノ)"
+      output: "┬─┬ノ( º _ ºノ)"
     }
   },
   {
-    name:"lower valid cases{in:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\",result:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\"}",
-    statement:"lower('( ͡° ͜ʖ ͡°)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\",result:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\"}",
+    statement: "lower('( ͡° ͜ʖ ͡°)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"( ͡° ͜ʖ ͡°)"
+      output: "( ͡° ͜ʖ ͡°)"
     }
   },
   {
-    name:"lower valid cases{in:\"\\U0001f60d\",result:\"\\U0001f60d\"}",
-    statement:"lower('😍')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\U0001f60d\",result:\"\\U0001f60d\"}",
+    statement: "lower('😍')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"😍"
+      output: "😍"
     }
   },
   {
-    name:"lower valid cases{in:\"\\U0001f469\\U0001f3fd\",result:\"\\U0001f469\\U0001f3fd\"}",
-    statement:"lower('👩🏽')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\U0001f469\\U0001f3fd\",result:\"\\U0001f469\\U0001f3fd\"}",
+    statement: "lower('👩🏽')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"👩🏽"
+      output: "👩🏽"
     }
   },
   {
-    name:"lower valid cases{in:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\",result:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\"}",
-    statement:"lower('👾 🙇 💁 🙅 🙆 🙋 🙎 🙍')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\",result:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\"}",
+    statement: "lower('👾 🙇 💁 🙅 🙆 🙋 🙎 🙍')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"👾 🙇 💁 🙅 🙆 🙋 🙎 🙍"
+      output: "👾 🙇 💁 🙅 🙆 🙋 🙎 🙍"
     }
   },
   {
-    name:"lower valid cases{in:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\",result:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\"}",
-    statement:"lower('🐵 🙈 🙉 🙊')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\",result:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\"}",
+    statement: "lower('🐵 🙈 🙉 🙊')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🐵 🙈 🙉 🙊"
+      output: "🐵 🙈 🙉 🙊"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\",result:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\"}",
-    statement:"lower('❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\",result:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\"}",
+    statement: "lower('❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙"
+      output: "❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙"
     }
   },
   {
-    name:"lower valid cases{in:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\",result:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\"}",
-    statement:"lower('✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\",result:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\"}",
+    statement: "lower('✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿"
+      output: "✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿"
     }
   },
   {
-    name:"lower valid cases{in:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\",result:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\"}",
-    statement:"lower('🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\",result:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\"}",
+    statement: "lower('🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧"
+      output: "🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧"
     }
   },
   {
-    name:"lower valid cases{in:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\",result:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\"}",
-    statement:"lower('0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\",result:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\"}",
+    statement: "lower('0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟"
+      output: "0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟"
     }
   },
   {
-    name:"lower valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\"}",
-    statement:"lower('🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\"}",
+    statement: "lower('🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
+      output: "🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
     }
   },
   {
-    name:"lower valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\"}",
-    statement:"lower('🇺🇸🇷🇺🇸🇦🇫🇦🇲')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\"}",
+    statement: "lower('🇺🇸🇷🇺🇸🇦🇫🇦🇲')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🇺🇸🇷🇺🇸🇦🇫🇦🇲"
+      output: "🇺🇸🇷🇺🇸🇦🇫🇦🇲"
     }
   },
   {
-    name:"lower valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\"}",
-    statement:"lower('🇺🇸🇷🇺🇸🇦')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\"}",
+    statement: "lower('🇺🇸🇷🇺🇸🇦')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🇺🇸🇷🇺🇸🇦"
+      output: "🇺🇸🇷🇺🇸🇦"
     }
   },
   {
-    name:"lower valid cases{in:\"\\uff34\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff2f\\uff36\\uff25\\uff32 \\uff34\\uff28\\uff25 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\",result:\"\\uff54\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff4f\\uff56\\uff45\\uff52 \\uff54\\uff48\\uff45 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\"}",
-    statement:"lower('Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ＯＶＥＲ ＴＨＥ ｌａｚｙ ｄｏｇ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower valid cases{in:\"\\uff34\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff2f\\uff36\\uff25\\uff32 \\uff34\\uff28\\uff25 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\",result:\"\\uff54\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff4f\\uff56\\uff45\\uff52 \\uff54\\uff48\\uff45 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\"}",
+    statement: "lower('Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ＯＶＥＲ ＴＨＥ ｌａｚｙ ｄｏｇ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ"
+      output: "ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ"
     }
   },
   {
-    name:"lower null and missing propagation{param:\"null\"}",
-    statement:"lower(null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "lower null and missing propagation{param:\"null\"}",
+    statement: "lower(null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"lower null and missing propagation{param:\"missing\"}",
-    statement:"lower(missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+    name: "lower null and missing propagation{param:\"missing\"}",
+    statement: "lower(missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
 ]

--- a/partiql-tests-data/eval/primitives/functions/mod.ion
+++ b/partiql-tests-data/eval/primitives/functions/mod.ion
@@ -1,260 +1,272 @@
 mod::[
   {
-    name:"MOD(1, 1)",
-    statement:"MOD(1, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "MOD(1, 1)",
+    statement: "MOD(1, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"MOD(10, 1)",
-    statement:"MOD(10, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "MOD(10, 1)",
+    statement: "MOD(10, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"MOD(17, 1)",
-    statement:"MOD(17, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "MOD(17, 1)",
+    statement: "MOD(17, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"MOD(-17, 4)",
-    statement:"MOD(-17, 4)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "MOD(-17, 4)",
+    statement: "MOD(-17, 4)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:-1
+      output: -1
     }
   },
   {
-    name:"MOD(17, -4)",
-    statement:"MOD(17, -4)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "MOD(17, -4)",
+    statement: "MOD(17, -4)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"MOD(10, 3)",
-    statement:"MOD(10, 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "MOD(10, 3)",
+    statement: "MOD(10, 3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"MOD(17, 1)",
-    statement:"MOD(17, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "MOD(17, 1)",
+    statement: "MOD(17, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"MOD(17, 3)",
-    statement:"MOD(17, 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "MOD(17, 3)",
+    statement: "MOD(17, 3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:2
+      output: 2
     }
   },
   {
-    name:"MOD(MISSING, 3)",
-    statement:"MOD(MISSING, 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "MOD(MISSING, 3)",
+    statement: "MOD(MISSING, 3)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "MOD(3, MISSING)",
+    statement: "MOD(3, MISSING)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "MOD(NULL, 3)",
+    statement: "MOD(NULL, 3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output: null
     }
   },
   {
-    name:"MOD(3, MISSING)",
-    statement:"MOD(3, MISSING)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "MOD(3, NULL)",
+    statement: "MOD(3, NULL)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output: null
     }
   },
   {
-    name:"MOD(NULL, 3)",
-    statement:"MOD(NULL, 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
+    name: "MOD(MISSING, NULL)",
+    statement: "MOD(MISSING, NULL)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
-    name:"MOD(3, NULL)",
-    statement:"MOD(3, NULL)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"MOD(MISSING, NULL)",
-    statement:"MOD(MISSING, NULL)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"MOD(NULL, MISSING)",
-    statement:"MOD(NULL, MISSING)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+    name: "MOD(NULL, MISSING)",
+    statement: "MOD(NULL, MISSING)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   // data type mismatch tests below
   {
-    name:"MOD(MISSING, 'some string')",
-    statement:"MOD(MISSING, 'some string')",
-    assert:[
-      {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
-      },
-      {
-        result:EvaluationSuccess,
-        evalMode: EvalModeCoerce,
-        output:$missing::null
-      }
-    ]
-  },
-  {
-    name:"MOD('some string', MISSING)",
-    statement:"MOD('some string', MISSING)",
-    assert:[
-      {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
-      },
-      {
-        result:EvaluationSuccess,
-        evalMode: EvalModeCoerce,
-        output:$missing::null
-      }
-    ]
-  },
-  {
-    name:"MOD(NULL, 'some string')",
-    statement:"MOD(NULL, 'some string')",
-    assert:[
-      {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
-      },
-      {
-        result:EvaluationSuccess,
-        evalMode: EvalModeCoerce,
-        output:$missing::null
-      }
-    ]
-  },
-  {
-    name:"MOD('some string', NULL)",
-    statement:"MOD('some string', NULL)",
-    assert:[
-      {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
-      },
-      {
-        result:EvaluationSuccess,
-        evalMode: EvalModeCoerce,
-        output:$missing::null
-      }
-    ]
-  },
-  {
-    name:"MOD(3, 'some string')",
-    statement:"MOD(3, 'some string')",
+    name: "MOD(MISSING, 'some string')",
+    statement: "MOD(MISSING, 'some string')",
     assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        result:EvaluationSuccess,
+        result: EvaluationSuccess,
         evalMode: EvalModeCoerce,
-        output:$missing::null
+        output: $missing::null
       }
     ]
   },
   {
-    name:"MOD('some string', 3)",
-    statement:"MOD('some string', 3)",
+    name: "MOD('some string', MISSING)",
+    statement: "MOD('some string', MISSING)",
     assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        result:EvaluationSuccess,
+        result: EvaluationSuccess,
         evalMode: EvalModeCoerce,
-        output:$missing::null
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "MOD(NULL, 'some string')",
+    statement: "MOD(NULL, 'some string')",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "MOD('some string', NULL)",
+    statement: "MOD('some string', NULL)",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "MOD(3, 'some string')",
+    statement: "MOD(3, 'some string')",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "MOD('some string', 3)",
+    statement: "MOD('some string', 3)",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ]
   }

--- a/partiql-tests-data/eval/primitives/functions/octet_length.ion
+++ b/partiql-tests-data/eval/primitives/functions/octet_length.ion
@@ -1,77 +1,80 @@
 octet_length::[
   {
-    name:"OCTET_LENGTH empty string",
-    statement:"OCTET_LENGTH('')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OCTET_LENGTH empty string",
+    statement: "OCTET_LENGTH('')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"OCTET_LENGTH string",
-    statement:"OCTET_LENGTH('abc')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OCTET_LENGTH string",
+    statement: "OCTET_LENGTH('abc')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"OCTET_LENGTH NULL",
-    statement:"OCTET_LENGTH(NULL)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OCTET_LENGTH NULL",
+    statement: "OCTET_LENGTH(NULL)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"OCTET_LENGTH MISSING",
-    statement:"OCTET_LENGTH(MISSING)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"OCTET_LENGTH invalid type",
-    statement:"OCTET_LENGTH(1)",
-    assert:[
+    name: "OCTET_LENGTH MISSING",
+    statement: "OCTET_LENGTH(MISSING)",
+    assert: [
       {
-        evalMode:EvalModeError,
-        result:EvaluationFail
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "OCTET_LENGTH invalid type",
+    statement: "OCTET_LENGTH(1)",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ],
   },
   {
-    name:"OCTET_LENGTH special character",
-    statement:"OCTET_LENGTH('français')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OCTET_LENGTH special character",
+    statement: "OCTET_LENGTH('français')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:9
+      output: 9
     }
   },
 ]

--- a/partiql-tests-data/eval/primitives/functions/overlay.ion
+++ b/partiql-tests-data/eval/primitives/functions/overlay.ion
@@ -1,301 +1,313 @@
 overlay::[
   {
-    name:"OVERLAY 'hello' PLACING '' FROM 1",
-    statement:"OVERLAY('hello' PLACING '' FROM 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING '' FROM 1",
+    statement: "OVERLAY('hello' PLACING '' FROM 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"hello"
+      output: "hello"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING '' FROM 2 FOR 3",
-    statement:"OVERLAY('hello' PLACING '' FROM 2 FOR 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING '' FROM 2 FOR 3",
+    statement: "OVERLAY('hello' PLACING '' FROM 2 FOR 3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ho"
+      output: "ho"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING '' FROM 2 FOR 4",
-    statement:"OVERLAY('hello' PLACING '' FROM 2 FOR 4)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING '' FROM 2 FOR 4",
+    statement: "OVERLAY('hello' PLACING '' FROM 2 FOR 4)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"h"
+      output: "h"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING 'XX' FROM 1",
-    statement:"OVERLAY('hello' PLACING 'XX' FROM 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING 'XX' FROM 1",
+    statement: "OVERLAY('hello' PLACING 'XX' FROM 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"XXllo"
+      output: "XXllo"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING 'XX' FROM 1 FOR 3",
-    statement:"OVERLAY('hello' PLACING 'XX' FROM 1 FOR 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING 'XX' FROM 1 FOR 3",
+    statement: "OVERLAY('hello' PLACING 'XX' FROM 1 FOR 3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"XXlo"
+      output: "XXlo"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING 'XX' FROM 1 FOR 1",
-    statement:"OVERLAY('hello' PLACING 'XX' FROM 1 FOR 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING 'XX' FROM 1 FOR 1",
+    statement: "OVERLAY('hello' PLACING 'XX' FROM 1 FOR 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"XXello"
+      output: "XXello"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING 'XX' FROM 1 FOR 100",
-    statement:"OVERLAY('hello' PLACING 'XX' FROM 1 FOR 100)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING 'XX' FROM 1 FOR 100",
+    statement: "OVERLAY('hello' PLACING 'XX' FROM 1 FOR 100)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"XX"
+      output: "XX"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING 'XX' FROM 1 FOR 0",
-    statement:"OVERLAY('hello' PLACING 'XX' FROM 1 FOR 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING 'XX' FROM 1 FOR 0",
+    statement: "OVERLAY('hello' PLACING 'XX' FROM 1 FOR 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"XXhello"
+      output: "XXhello"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING 'XX' FROM 7",
-    statement:"OVERLAY('hello' PLACING 'XX' FROM 7)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING 'XX' FROM 7",
+    statement: "OVERLAY('hello' PLACING 'XX' FROM 7)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"helloXX"
+      output: "helloXX"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING 'XX' FROM 100 FOR 100",
-    statement:"OVERLAY('hello' PLACING 'XX' FROM 100 FOR 100)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING 'XX' FROM 100 FOR 100",
+    statement: "OVERLAY('hello' PLACING 'XX' FROM 100 FOR 100)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"helloXX"
+      output: "helloXX"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING 'XX' FROM 2 FOR 1",
-    statement:"OVERLAY('hello' PLACING 'XX' FROM 2 FOR 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING 'XX' FROM 2 FOR 1",
+    statement: "OVERLAY('hello' PLACING 'XX' FROM 2 FOR 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"hXXllo"
+      output: "hXXllo"
     }
   },
   {
-    name:"OVERLAY 'hello' PLACING 'XX' FROM 2 FOR 3",
-    statement:"OVERLAY('hello' PLACING 'XX' FROM 2 FOR 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "OVERLAY 'hello' PLACING 'XX' FROM 2 FOR 3",
+    statement: "OVERLAY('hello' PLACING 'XX' FROM 2 FOR 3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"hXXo"
+      output: "hXXo"
     }
   },
   {
-    name:"OVERLAY MISSING",
-    statement:"OVERLAY(MISSING PLACING 'XX' FROM 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"OVERLAY PLACING MISSING",
-    statement:"OVERLAY('foo' PLACING MISSING FROM 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"OVERLAY FROM MISSING",
-    statement:"OVERLAY('foo' PLACING 'bar' FROM MISSING)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"OVERLAY FOR MISSING",
-    statement:"OVERLAY('foo' PLACING 'bar' FROM 1 FOR MISSING)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"OVERLAY NULL",
-    statement:"OVERLAY(NULL PLACING 'XX' FROM 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"OVERLAY PLACING NULL",
-    statement:"OVERLAY('foo' PLACING NULL FROM 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"OVERLAY FROM NULL",
-    statement:"OVERLAY('foo' PLACING 'bar' FROM NULL)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"OVERLAY FOR NULL",
-    statement:"OVERLAY('foo' PLACING 'bar' FROM 1 FOR NULL)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"OVERLAY mismatched type",
-    statement:"OVERLAY(1 PLACING 'XX' FROM 1)",
+    name: "OVERLAY MISSING",
+    statement: "OVERLAY(MISSING PLACING 'XX' FROM 1)",
     assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       },
       {
-        result:EvaluationSuccess,
-        evalMode: EvalModeCoerce,
-        output:$missing::null
+        evalMode: EvalModeError,
+        result: EvaluationFail,
       }
     ]
   },
   {
-    name:"OVERLAY PLACING mismatched type",
-    statement:"OVERLAY('foo' PLACING 1 FROM 1)",
+    name: "OVERLAY PLACING MISSING",
+    statement: "OVERLAY('foo' PLACING MISSING FROM 1)",
     assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       },
       {
-        result:EvaluationSuccess,
-        evalMode: EvalModeCoerce,
-        output:$missing::null
+        evalMode: EvalModeError,
+        result: EvaluationFail,
       }
     ]
   },
   {
-    name:"OVERLAY FROM mismatched type",
-    statement:"OVERLAY('foo' PLACING 'bar' FROM 'string')",
+    name: "OVERLAY FROM MISSING",
+    statement: "OVERLAY('foo' PLACING 'bar' FROM MISSING)",
     assert: [
       {
-        evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       },
       {
-        result:EvaluationSuccess,
-        evalMode: EvalModeCoerce,
-        output:$missing::null
+        evalMode: EvalModeError,
+        result: EvaluationFail,
       }
     ]
   },
   {
-    name:"OVERLAY FOR mismatched type",
-    statement:"OVERLAY('foo' PLACING 'bar' FROM 1 FOR 'string')",
+    name: "OVERLAY FOR MISSING",
+    statement: "OVERLAY('foo' PLACING 'bar' FROM 1 FOR MISSING)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "OVERLAY NULL",
+    statement: "OVERLAY(NULL PLACING 'XX' FROM 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "OVERLAY PLACING NULL",
+    statement: "OVERLAY('foo' PLACING NULL FROM 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "OVERLAY FROM NULL",
+    statement: "OVERLAY('foo' PLACING 'bar' FROM NULL)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "OVERLAY FOR NULL",
+    statement: "OVERLAY('foo' PLACING 'bar' FROM 1 FOR NULL)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "OVERLAY mismatched type",
+    statement: "OVERLAY(1 PLACING 'XX' FROM 1)",
     assert: [
       {
         evalMode: EvalModeError,
-        result:EvaluationFail,
+        result: EvaluationFail,
       },
       {
-        result:EvaluationSuccess,
+        result: EvaluationSuccess,
         evalMode: EvalModeCoerce,
-        output:$missing::null
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "OVERLAY PLACING mismatched type",
+    statement: "OVERLAY('foo' PLACING 1 FROM 1)",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "OVERLAY FROM mismatched type",
+    statement: "OVERLAY('foo' PLACING 'bar' FROM 'string')",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "OVERLAY FOR mismatched type",
+    statement: "OVERLAY('foo' PLACING 'bar' FROM 1 FOR 'string')",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ]
   }

--- a/partiql-tests-data/eval/primitives/functions/position.ion
+++ b/partiql-tests-data/eval/primitives/functions/position.ion
@@ -1,187 +1,207 @@
 position::[
   {
-    name:"POSITION empty string in string",
-    statement:"POSITION('' IN 'abcdefg')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "POSITION empty string in string",
+    statement: "POSITION('' IN 'abcdefg')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"POSITION string at start",
-    statement:"POSITION('abc' IN 'abcdefg')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "POSITION string at start",
+    statement: "POSITION('abc' IN 'abcdefg')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:1
+      output: 1
     }
   },
   {
-    name:"POSITION string in middle",
-    statement:"POSITION('cde' IN 'abcdefg')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "POSITION string in middle",
+    statement: "POSITION('cde' IN 'abcdefg')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:3
+      output: 3
     }
   },
   {
-    name:"POSITION string at end",
-    statement:"POSITION('efg' IN 'abcdefg')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "POSITION string at end",
+    statement: "POSITION('efg' IN 'abcdefg')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:5
+      output: 5
     }
   },
   {
-    name:"POSITION string not in string",
-    statement:"POSITION('ghi' IN 'abcdefg')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "POSITION string not in string",
+    statement: "POSITION('ghi' IN 'abcdefg')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:0
+      output: 0
     }
   },
   {
-    name:"POSITION NULL in string",
-    statement:"POSITION(NULL IN 'abcdefg')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "POSITION NULL in string",
+    statement: "POSITION(NULL IN 'abcdefg')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"POSITION MISSING in string",
-    statement:"POSITION(MISSING IN 'abcdefg')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"POSITION string in NULL",
-    statement:"POSITION('abc' IN NULL)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"POSITION string in MISSING",
-    statement:"POSITION('abc' IN MISSING)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"POSITION NULL in MISSING",
-    statement:"POSITION(NULL IN MISSING)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"POSITION MISSING in NULL",
-    statement:"POSITION(MISSING IN NULL)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"POSITION NULL in NULL",
-    statement:"POSITION(NULL IN NULL)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"POSITION MISSING in MISSING",
-    statement:"POSITION(MISSING IN MISSING)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"POSITION invalid type in string",
-    statement:"POSITION(1 IN 'abcdefg')",
-    assert:[
+    name: "POSITION MISSING in string",
+    statement: "POSITION(MISSING IN 'abcdefg')",
+    assert: [
       {
-        evalMode:EvalModeError,
-        result:EvaluationFail
+        result: EvaluationSuccess,
+        evalMode:
+        EvalModeCoerce,
+        output: $missing::null
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "POSITION string in NULL",
+    statement: "POSITION('abc' IN NULL)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "POSITION string in MISSING",
+    statement: "POSITION('abc' IN MISSING)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
+        EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "POSITION NULL in MISSING",
+    statement: "POSITION(NULL IN MISSING)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
+        EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "POSITION MISSING in NULL",
+    statement: "POSITION(MISSING IN NULL)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
+        EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "POSITION NULL in NULL",
+    statement: "POSITION(NULL IN NULL)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "POSITION MISSING in MISSING",
+    statement: "POSITION(MISSING IN MISSING)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
+        EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "POSITION invalid type in string",
+    statement: "POSITION(1 IN 'abcdefg')",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ],
   },
   {
-    name:"POSITION string in invalid type",
-    statement:"POSITION('abc' IN 1)",
-    assert:[
+    name: "POSITION string in invalid type",
+    statement: "POSITION('abc' IN 1)",
+    assert: [
       {
-        evalMode:EvalModeError,
-        result:EvaluationFail
+        evalMode: EvalModeError,
+        result: EvaluationFail
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ],
   },

--- a/partiql-tests-data/eval/primitives/functions/substring.ion
+++ b/partiql-tests-data/eval/primitives/functions/substring.ion
@@ -1,1312 +1,1385 @@
 substring::[
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"123456789\",start:\"0\",result:\"123456789\"}",
-    statement:"substring('123456789' FROM 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"123456789\",start:\"0\",result:\"123456789\"}",
+    statement: "substring('123456789' FROM 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"123456789\",start:\"1\",result:\"123456789\"}",
-    statement:"substring('123456789' FROM 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"123456789\",start:\"1\",result:\"123456789\"}",
+    statement: "substring('123456789' FROM 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"123456789\",start:\"2\",result:\"23456789\"}",
-    statement:"substring('123456789' FROM 2)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"123456789\",start:\"2\",result:\"23456789\"}",
+    statement: "substring('123456789' FROM 2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"23456789"
+      output: "23456789"
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"123456789\",start:\"-4\",result:\"123456789\"}",
-    statement:"substring('123456789' FROM -4)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"123456789\",start:\"-4\",result:\"123456789\"}",
+    statement: "substring('123456789' FROM -4)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"\",start:\"-1\",result:\"\"}",
-    statement:"substring('' FROM -1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"\",start:\"-1\",result:\"\"}",
+    statement: "substring('' FROM -1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"\",start:\"0\",result:\"\"}",
-    statement:"substring('' FROM 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"\",start:\"0\",result:\"\"}",
+    statement: "substring('' FROM 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",result:\"\\U0001f638\\U0001f638\"}",
-    statement:"substring('😁😞😸😸' FROM 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",result:\"\\U0001f638\\U0001f638\"}",
+    statement: "substring('😁😞😸😸' FROM 3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"😸😸"
+      output: "😸😸"
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",result:\"\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
-    statement:"substring('話家身圧費谷料村能計税金' FROM 6)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",result:\"\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
+    statement: "substring('話家身圧費谷料村能計税金' FROM 6)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"谷料村能計税金"
+      output: "谷料村能計税金"
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",result:\"\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
-    statement:"substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя' FROM 40)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",result:\"\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
+    statement: "substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя' FROM 40)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
+      output: "ШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"16\",result:\"( \\xba _ \\xba\\u30ce)\"}",
-    statement:"substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)' FROM 16)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"16\",result:\"( \\xba _ \\xba\\u30ce)\"}",
+    statement: "substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)' FROM 16)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"( º _ ºノ)"
+      output: "( º _ ºノ)"
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
-    statement:"substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫' FROM 17)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
+    statement: "substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫' FROM 17)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
+      output: "𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
     }
   },
   {
-    name:"substring valid cases 2 arguments with FROM syntax{target:\"\\U0001f469\\U0001f3fd\",start:\"2\",result:\"\\U0001f3fd\"}",
-    statement:"substring('👩🏽' FROM 2)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments with FROM syntax{target:\"\\U0001f469\\U0001f3fd\",start:\"2\",result:\"\\U0001f3fd\"}",
+    statement: "substring('👩🏽' FROM 2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🏽"
+      output: "🏽"
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"123456789\",start:\"0\",result:\"123456789\"}",
-    statement:"substring('123456789', 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"123456789\",start:\"0\",result:\"123456789\"}",
+    statement: "substring('123456789', 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"123456789\",start:\"1\",result:\"123456789\"}",
-    statement:"substring('123456789', 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"123456789\",start:\"1\",result:\"123456789\"}",
+    statement: "substring('123456789', 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"123456789\",start:\"2\",result:\"23456789\"}",
-    statement:"substring('123456789', 2)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"123456789\",start:\"2\",result:\"23456789\"}",
+    statement: "substring('123456789', 2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"23456789"
+      output: "23456789"
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"123456789\",start:\"-4\",result:\"123456789\"}",
-    statement:"substring('123456789', -4)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"123456789\",start:\"-4\",result:\"123456789\"}",
+    statement: "substring('123456789', -4)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"\",start:\"-1\",result:\"\"}",
-    statement:"substring('', -1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"\",start:\"-1\",result:\"\"}",
+    statement: "substring('', -1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"\",start:\"0\",result:\"\"}",
-    statement:"substring('', 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"\",start:\"0\",result:\"\"}",
+    statement: "substring('', 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",result:\"\\U0001f638\\U0001f638\"}",
-    statement:"substring('😁😞😸😸', 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",result:\"\\U0001f638\\U0001f638\"}",
+    statement: "substring('😁😞😸😸', 3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"😸😸"
+      output: "😸😸"
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",result:\"\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
-    statement:"substring('話家身圧費谷料村能計税金', 6)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",result:\"\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
+    statement: "substring('話家身圧費谷料村能計税金', 6)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"谷料村能計税金"
+      output: "谷料村能計税金"
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",result:\"\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
-    statement:"substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', 40)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",result:\"\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
+    statement: "substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', 40)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
+      output: "ШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"16\",result:\"( \\xba _ \\xba\\u30ce)\"}",
-    statement:"substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)', 16)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"16\",result:\"( \\xba _ \\xba\\u30ce)\"}",
+    statement: "substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)', 16)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"( º _ ºノ)"
+      output: "( º _ ºノ)"
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
-    statement:"substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫', 17)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
+    statement: "substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫', 17)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
+      output: "𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
     }
   },
   {
-    name:"substring valid cases 2 arguments{target:\"\\U0001f469\\U0001f3fd\",start:\"2\",result:\"\\U0001f3fd\"}",
-    statement:"substring('👩🏽', 2)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 2 arguments{target:\"\\U0001f469\\U0001f3fd\",start:\"2\",result:\"\\U0001f3fd\"}",
+    statement: "substring('👩🏽', 2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🏽"
+      output: "🏽"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"0\",quantity:\"999\",result:\"123456789\"}",
-    statement:"substring('123456789' FROM 0 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"0\",quantity:\"999\",result:\"123456789\"}",
+    statement: "substring('123456789' FROM 0 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"0\",quantity:\"2\",result:\"1\"}",
-    statement:"substring('123456789' FROM 0 FOR 2)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"0\",quantity:\"2\",result:\"1\"}",
+    statement: "substring('123456789' FROM 0 FOR 2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1"
+      output: "1"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"1\",quantity:\"999\",result:\"123456789\"}",
-    statement:"substring('123456789' FROM 1 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"1\",quantity:\"999\",result:\"123456789\"}",
+    statement: "substring('123456789' FROM 1 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"1\",quantity:\"2\",result:\"12\"}",
-    statement:"substring('123456789' FROM 1 FOR 2)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"1\",quantity:\"2\",result:\"12\"}",
+    statement: "substring('123456789' FROM 1 FOR 2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"12"
+      output: "12"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"2\",quantity:\"999\",result:\"23456789\"}",
-    statement:"substring('123456789' FROM 2 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"2\",quantity:\"999\",result:\"23456789\"}",
+    statement: "substring('123456789' FROM 2 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"23456789"
+      output: "23456789"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"2\",quantity:\"3\",result:\"234\"}",
-    statement:"substring('123456789' FROM 2 FOR 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"2\",quantity:\"3\",result:\"234\"}",
+    statement: "substring('123456789' FROM 2 FOR 3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"234"
+      output: "234"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"-4\",quantity:\"999\",result:\"123456789\"}",
-    statement:"substring('123456789' FROM -4 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"-4\",quantity:\"999\",result:\"123456789\"}",
+    statement: "substring('123456789' FROM -4 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"-4\",quantity:\"6\",result:\"1\"}",
-    statement:"substring('123456789' FROM -4 FOR 6)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"123456789\",start:\"-4\",quantity:\"6\",result:\"1\"}",
+    statement: "substring('123456789' FROM -4 FOR 6)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1"
+      output: "1"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\",start:\"-1\",quantity:\"999\",result:\"\"}",
-    statement:"substring('' FROM -1 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\",start:\"-1\",quantity:\"999\",result:\"\"}",
+    statement: "substring('' FROM -1 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\",start:\"0\",quantity:\"999\",result:\"\"}",
-    statement:"substring('' FROM 0 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\",start:\"0\",quantity:\"999\",result:\"\"}",
+    statement: "substring('' FROM 0 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"1\",start:\"-4\",quantity:\"1\",result:\"\"}",
-    statement:"substring('1' FROM -4 FOR 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"1\",start:\"-4\",quantity:\"1\",result:\"\"}",
+    statement: "substring('1' FROM -4 FOR 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"1\",start:\"-4\",quantity:\"0\",result:\"\"}",
-    statement:"substring('1' FROM -4 FOR 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"1\",start:\"-4\",quantity:\"0\",result:\"\"}",
+    statement: "substring('1' FROM -4 FOR 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"1\",start:\"1\",quantity:\"0\",result:\"\"}",
-    statement:"substring('1' FROM 1 FOR 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"1\",start:\"1\",quantity:\"0\",result:\"\"}",
+    statement: "substring('1' FROM 1 FOR 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"1\",start:\"0\",quantity:\"0\",result:\"\"}",
-    statement:"substring('1' FROM 0 FOR 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"1\",start:\"0\",quantity:\"0\",result:\"\"}",
+    statement: "substring('1' FROM 0 FOR 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",quantity:\"999\",result:\"\\U0001f638\\U0001f638\"}",
-    statement:"substring('😁😞😸😸' FROM 3 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",quantity:\"999\",result:\"\\U0001f638\\U0001f638\"}",
+    statement: "substring('😁😞😸😸' FROM 3 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"😸😸"
+      output: "😸😸"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",quantity:\"1\",result:\"\\U0001f638\"}",
-    statement:"substring('😁😞😸😸' FROM 3 FOR 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",quantity:\"1\",result:\"\\U0001f638\"}",
+    statement: "substring('😁😞😸😸' FROM 3 FOR 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"😸"
+      output: "😸"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",quantity:\"999\",result:\"\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
-    statement:"substring('話家身圧費谷料村能計税金' FROM 6 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",quantity:\"999\",result:\"\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
+    statement: "substring('話家身圧費谷料村能計税金' FROM 6 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"谷料村能計税金"
+      output: "谷料村能計税金"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",quantity:\"2\",result:\"\\u8c37\\u6599\"}",
-    statement:"substring('話家身圧費谷料村能計税金' FROM 6 FOR 2)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",quantity:\"2\",result:\"\\u8c37\\u6599\"}",
+    statement: "substring('話家身圧費谷料村能計税金' FROM 6 FOR 2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"谷料"
+      output: "谷料"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",quantity:\"999\",result:\"\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
-    statement:"substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя' FROM 40 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",quantity:\"999\",result:\"\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
+    statement: "substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя' FROM 40 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
+      output: "ШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",quantity:\"4\",result:\"\\u0428\\u0429\\u042a\\u042b\"}",
-    statement:"substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя' FROM 40 FOR 4)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",quantity:\"4\",result:\"\\u0428\\u0429\\u042a\\u042b\"}",
+    statement: "substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя' FROM 40 FOR 4)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ШЩЪЫ"
+      output: "ШЩЪЫ"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"16\",quantity:\"999\",result:\"( \\xba _ \\xba\\u30ce)\"}",
-    statement:"substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)' FROM 16 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"16\",quantity:\"999\",result:\"( \\xba _ \\xba\\u30ce)\"}",
+    statement: "substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)' FROM 16 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"( º _ ºノ)"
+      output: "( º _ ºノ)"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"18\",quantity:\"5\",result:\"\\xba _ \\xba\"}",
-    statement:"substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)' FROM 18 FOR 5)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"18\",quantity:\"5\",result:\"\\xba _ \\xba\"}",
+    statement: "substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)' FROM 18 FOR 5)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"º _ º"
+      output: "º _ º"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",quantity:\"999\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
-    statement:"substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫' FROM 17 FOR 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",quantity:\"999\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
+    statement: "substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫' FROM 17 FOR 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
+      output: "𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",quantity:\"5\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c\"}",
-    statement:"substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫' FROM 17 FOR 5)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",quantity:\"5\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c\"}",
+    statement: "substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫' FROM 17 FOR 5)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"𝐣𝐮𝐦𝐩𝐬"
+      output: "𝐣𝐮𝐦𝐩𝐬"
     }
   },
   {
-    name:"substring valid cases 3 arguments using FROM syntax{target:\"\\U0001f469\\U0001f3fd\",start:\"1\",quantity:\"1\",result:\"\\U0001f469\"}",
-    statement:"substring('👩🏽' FROM 1 FOR 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments using FROM syntax{target:\"\\U0001f469\\U0001f3fd\",start:\"1\",quantity:\"1\",result:\"\\U0001f469\"}",
+    statement: "substring('👩🏽' FROM 1 FOR 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"👩"
+      output: "👩"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"123456789\",start:\"0\",quantity:\"999\",result:\"123456789\"}",
-    statement:"substring('123456789', 0, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"123456789\",start:\"0\",quantity:\"999\",result:\"123456789\"}",
+    statement: "substring('123456789', 0, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"123456789\",start:\"0\",quantity:\"2\",result:\"1\"}",
-    statement:"substring('123456789', 0, 2)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"123456789\",start:\"0\",quantity:\"2\",result:\"1\"}",
+    statement: "substring('123456789', 0, 2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1"
+      output: "1"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"123456789\",start:\"1\",quantity:\"999\",result:\"123456789\"}",
-    statement:"substring('123456789', 1, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"123456789\",start:\"1\",quantity:\"999\",result:\"123456789\"}",
+    statement: "substring('123456789', 1, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"123456789\",start:\"1\",quantity:\"2\",result:\"12\"}",
-    statement:"substring('123456789', 1, 2)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"123456789\",start:\"1\",quantity:\"2\",result:\"12\"}",
+    statement: "substring('123456789', 1, 2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"12"
+      output: "12"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"123456789\",start:\"2\",quantity:\"999\",result:\"23456789\"}",
-    statement:"substring('123456789', 2, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"123456789\",start:\"2\",quantity:\"999\",result:\"23456789\"}",
+    statement: "substring('123456789', 2, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"23456789"
+      output: "23456789"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"123456789\",start:\"2\",quantity:\"3\",result:\"234\"}",
-    statement:"substring('123456789', 2, 3)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"123456789\",start:\"2\",quantity:\"3\",result:\"234\"}",
+    statement: "substring('123456789', 2, 3)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"234"
+      output: "234"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"123456789\",start:\"-4\",quantity:\"999\",result:\"123456789\"}",
-    statement:"substring('123456789', -4, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"123456789\",start:\"-4\",quantity:\"999\",result:\"123456789\"}",
+    statement: "substring('123456789', -4, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789"
+      output: "123456789"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"123456789\",start:\"-4\",quantity:\"6\",result:\"1\"}",
-    statement:"substring('123456789', -4, 6)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"123456789\",start:\"-4\",quantity:\"6\",result:\"1\"}",
+    statement: "substring('123456789', -4, 6)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1"
+      output: "1"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\",start:\"-1\",quantity:\"999\",result:\"\"}",
-    statement:"substring('', -1, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\",start:\"-1\",quantity:\"999\",result:\"\"}",
+    statement: "substring('', -1, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\",start:\"0\",quantity:\"999\",result:\"\"}",
-    statement:"substring('', 0, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\",start:\"0\",quantity:\"999\",result:\"\"}",
+    statement: "substring('', 0, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"1\",start:\"-4\",quantity:\"1\",result:\"\"}",
-    statement:"substring('1', -4, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"1\",start:\"-4\",quantity:\"1\",result:\"\"}",
+    statement: "substring('1', -4, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"1\",start:\"-4\",quantity:\"0\",result:\"\"}",
-    statement:"substring('1', -4, 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"1\",start:\"-4\",quantity:\"0\",result:\"\"}",
+    statement: "substring('1', -4, 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"1\",start:\"1\",quantity:\"0\",result:\"\"}",
-    statement:"substring('1', 1, 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"1\",start:\"1\",quantity:\"0\",result:\"\"}",
+    statement: "substring('1', 1, 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"1\",start:\"0\",quantity:\"0\",result:\"\"}",
-    statement:"substring('1', 0, 0)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"1\",start:\"0\",quantity:\"0\",result:\"\"}",
+    statement: "substring('1', 0, 0)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",quantity:\"999\",result:\"\\U0001f638\\U0001f638\"}",
-    statement:"substring('😁😞😸😸', 3, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",quantity:\"999\",result:\"\\U0001f638\\U0001f638\"}",
+    statement: "substring('😁😞😸😸', 3, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"😸😸"
+      output: "😸😸"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",quantity:\"1\",result:\"\\U0001f638\"}",
-    statement:"substring('😁😞😸😸', 3, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\\U0001f601\\U0001f61e\\U0001f638\\U0001f638\",start:\"3\",quantity:\"1\",result:\"\\U0001f638\"}",
+    statement: "substring('😁😞😸😸', 3, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"😸"
+      output: "😸"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",quantity:\"999\",result:\"\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
-    statement:"substring('話家身圧費谷料村能計税金', 6, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",quantity:\"999\",result:\"\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
+    statement: "substring('話家身圧費谷料村能計税金', 6, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"谷料村能計税金"
+      output: "谷料村能計税金"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",quantity:\"2\",result:\"\\u8c37\\u6599\"}",
-    statement:"substring('話家身圧費谷料村能計税金', 6, 2)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",start:\"6\",quantity:\"2\",result:\"\\u8c37\\u6599\"}",
+    statement: "substring('話家身圧費谷料村能計税金', 6, 2)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"谷料"
+      output: "谷料"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",quantity:\"999\",result:\"\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
-    statement:"substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', 40, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",quantity:\"999\",result:\"\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
+    statement: "substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', 40, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
+      output: "ШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",quantity:\"4\",result:\"\\u0428\\u0429\\u042a\\u042b\"}",
-    statement:"substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', 40, 4)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",start:\"40\",quantity:\"4\",result:\"\\u0428\\u0429\\u042a\\u042b\"}",
+    statement: "substring('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', 40, 4)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ШЩЪЫ"
+      output: "ШЩЪЫ"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"16\",quantity:\"999\",result:\"( \\xba _ \\xba\\u30ce)\"}",
-    statement:"substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)', 16, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"16\",quantity:\"999\",result:\"( \\xba _ \\xba\\u30ce)\"}",
+    statement: "substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)', 16, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"( º _ ºノ)"
+      output: "( º _ ºノ)"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"18\",quantity:\"5\",result:\"\\xba _ \\xba\"}",
-    statement:"substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)', 18, 5)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",start:\"18\",quantity:\"5\",result:\"\\xba _ \\xba\"}",
+    statement: "substring('( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)', 18, 5)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"º _ º"
+      output: "º _ º"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",quantity:\"999\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
-    statement:"substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫', 17, 999)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",quantity:\"999\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
+    statement: "substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫', 17, 999)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
+      output: "𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",quantity:\"5\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c\"}",
-    statement:"substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫', 17, 5)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",start:\"17\",quantity:\"5\",result:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c\"}",
+    statement: "substring('𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫', 17, 5)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"𝐣𝐮𝐦𝐩𝐬"
+      output: "𝐣𝐮𝐦𝐩𝐬"
     }
   },
   {
-    name:"substring valid cases 3 arguments{target:\"\\U0001f469\\U0001f3fd\",start:\"1\",quantity:\"1\",result:\"\\U0001f469\"}",
-    statement:"substring('👩🏽', 1, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring valid cases 3 arguments{target:\"\\U0001f469\\U0001f3fd\",start:\"1\",quantity:\"1\",result:\"\\U0001f469\"}",
+    statement: "substring('👩🏽', 1, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"👩"
+      output: "👩"
     }
   },
   {
-    name:"substring null and missing propagation 2 arguments{target:\"null\",start_pos:\"1\"}",
-    statement:"substring(null, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring null and missing propagation 2 arguments{target:\"null\",start_pos:\"1\"}",
+    statement: "substring(null, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"substring null and missing propagation 2 arguments{target:\"''\",start_pos:\"null\"}",
-    statement:"substring('', null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring null and missing propagation 2 arguments{target:\"''\",start_pos:\"null\"}",
+    statement: "substring('', null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"substring null and missing propagation 2 arguments{target:\"null\",start_pos:\"null\"}",
-    statement:"substring(null, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "substring null and missing propagation 2 arguments{target:\"null\",start_pos:\"null\"}",
+    statement: "substring(null, null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"substring null and missing propagation 2 arguments{target:\"missing\",start_pos:\"1\"}",
-    statement:"substring(missing, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 2 arguments{target:\"''\",start_pos:\"missing\"}",
-    statement:"substring('', missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 2 arguments{target:\"missing\",start_pos:\"missing\"}",
-    statement:"substring(missing, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 2 arguments{target:\"null\",start_pos:\"missing\"}",
-    statement:"substring(null, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 2 arguments{target:\"missing\",start_pos:\"null\"}",
-    statement:"substring(missing, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"1\",quantity:\"1\"}",
-    statement:"substring(null, 1, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"1\",quantity:\"null\"}",
-    statement:"substring(null, 1, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"1\",quantity:\"missing\"}",
-    statement:"substring(null, 1, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"null\",quantity:\"1\"}",
-    statement:"substring(null, null, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"null\",quantity:\"null\"}",
-    statement:"substring(null, null, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"null\",quantity:\"missing\"}",
-    statement:"substring(null, null, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"missing\",quantity:\"1\"}",
-    statement:"substring(null, missing, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"missing\",quantity:\"null\"}",
-    statement:"substring(null, missing, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"missing\",quantity:\"missing\"}",
-    statement:"substring(null, missing, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"1\",quantity:\"1\"}",
-    statement:"substring(missing, 1, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"1\",quantity:\"null\"}",
-    statement:"substring(missing, 1, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"1\",quantity:\"missing\"}",
-    statement:"substring(missing, 1, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"null\",quantity:\"1\"}",
-    statement:"substring(missing, null, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"null\",quantity:\"null\"}",
-    statement:"substring(missing, null, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"null\",quantity:\"missing\"}",
-    statement:"substring(missing, null, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"missing\",quantity:\"1\"}",
-    statement:"substring(missing, missing, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"missing\",quantity:\"null\"}",
-    statement:"substring(missing, missing, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"missing\",quantity:\"missing\"}",
-    statement:"substring(missing, missing, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"1\",quantity:\"null\"}",
-    statement:"substring('', 1, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"1\",quantity:\"missing\"}",
-    statement:"substring('', 1, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"null\",quantity:\"1\"}",
-    statement:"substring('', null, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"null\",quantity:\"null\"}",
-    statement:"substring('', null, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"null\",quantity:\"missing\"}",
-    statement:"substring('', null, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"missing\",quantity:\"1\"}",
-    statement:"substring('', missing, 1)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"missing\",quantity:\"null\"}",
-    statement:"substring('', missing, null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"missing\",quantity:\"missing\"}",
-    statement:"substring('', missing, missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"substring invalid quantity",
-    statement:"substring('1', 4, -11)",
-    assert:[
+    name: "substring null and missing propagation 2 arguments{target:\"missing\",start_pos:\"1\"}",
+    statement: "substring(missing, 1)",
+    assert: [
       {
-        evalMode:EvalModeError,
-        result:EvaluationFail
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 2 arguments{target:\"''\",start_pos:\"missing\"}",
+    statement: "substring('', missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 2 arguments{target:\"missing\",start_pos:\"missing\"}",
+    statement: "substring(missing, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 2 arguments{target:\"null\",start_pos:\"missing\"}",
+    statement: "substring(null, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 2 arguments{target:\"missing\",start_pos:\"null\"}",
+    statement: "substring(missing, null)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"1\",quantity:\"1\"}",
+    statement: "substring(null, 1, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"1\",quantity:\"null\"}",
+    statement: "substring(null, 1, null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"1\",quantity:\"missing\"}",
+    statement: "substring(null, 1, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"null\",quantity:\"1\"}",
+    statement: "substring(null, null, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"null\",quantity:\"null\"}",
+    statement: "substring(null, null, null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"null\",quantity:\"missing\"}",
+    statement: "substring(null, null, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"missing\",quantity:\"1\"}",
+    statement: "substring(null, missing, 1)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"missing\",quantity:\"null\"}",
+    statement: "substring(null, missing, null)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"null\",start_pos:\"missing\",quantity:\"missing\"}",
+    statement: "substring(null, missing, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"1\",quantity:\"1\"}",
+    statement: "substring(missing, 1, 1)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"1\",quantity:\"null\"}",
+    statement: "substring(missing, 1, null)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"1\",quantity:\"missing\"}",
+    statement: "substring(missing, 1, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"null\",quantity:\"1\"}",
+    statement: "substring(missing, null, 1)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"null\",quantity:\"null\"}",
+    statement: "substring(missing, null, null)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"null\",quantity:\"missing\"}",
+    statement: "substring(missing, null, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"missing\",quantity:\"1\"}",
+    statement: "substring(missing, missing, 1)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"missing\",quantity:\"null\"}",
+    statement: "substring(missing, missing, null)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"missing\",start_pos:\"missing\",quantity:\"missing\"}",
+    statement: "substring(missing, missing, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"1\",quantity:\"null\"}",
+    statement: "substring('', 1, null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"1\",quantity:\"missing\"}",
+    statement: "substring('', 1, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
+        EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"null\",quantity:\"1\"}",
+    statement: "substring('', null, 1)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"null\",quantity:\"null\"}",
+    statement: "substring('', null, null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"null\",quantity:\"missing\"}",
+    statement: "substring('', null, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"missing\",quantity:\"1\"}",
+    statement: "substring('', missing, 1)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"missing\",quantity:\"null\"}",
+    statement: "substring('', missing, null)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring null and missing propagation 3 arguments{target:\"''\",start_pos:\"missing\",quantity:\"missing\"}",
+    statement: "substring('', missing, missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "substring invalid quantity",
+    statement: "substring('1', 4, -11)",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ]
   }

--- a/partiql-tests-data/eval/primitives/functions/trim.ion
+++ b/partiql-tests-data/eval/primitives/functions/trim.ion
@@ -1,722 +1,779 @@
 trim::[
   {
-    name:"trim valid cases{spec:\"both\",to_remove:\"\\U0001f4a9\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f601\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\",result:\"\\U0001f601\"}",
-    statement:"trim(both '💩' from '💩💩💩💩😁💩💩💩💩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"both\",to_remove:\"\\U0001f4a9\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f601\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\",result:\"\\U0001f601\"}",
+    statement: "trim(both '💩' from '💩💩💩💩😁💩💩💩💩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"😁"
+      output: "😁"
     }
   },
   {
-    name:"trim valid cases{spec:\"leading\",to_remove:\"\\U0001f4a9\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f601\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\",result:\"\\U0001f601\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\"}",
-    statement:"trim(leading '💩' from '💩💩💩💩😁💩💩💩💩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"leading\",to_remove:\"\\U0001f4a9\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f601\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\",result:\"\\U0001f601\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\"}",
+    statement: "trim(leading '💩' from '💩💩💩💩😁💩💩💩💩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"😁💩💩💩💩"
+      output: "😁💩💩💩💩"
     }
   },
   {
-    name:"trim valid cases{spec:\"trailing\",to_remove:\"\\U0001f4a9\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f601\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\",result:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f601\"}",
-    statement:"trim(trailing '💩' from '💩💩💩💩😁💩💩💩💩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"trailing\",to_remove:\"\\U0001f4a9\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f601\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\",result:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f601\"}",
+    statement: "trim(trailing '💩' from '💩💩💩💩😁💩💩💩💩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"💩💩💩💩😁"
+      output: "💩💩💩💩😁"
     }
   },
   {
-    name:"trim valid cases{spec:\"both\",to_remove:\"12\",target:\"111112a1212121211\",result:\"a\"}",
-    statement:"trim(both '12' from '111112a1212121211')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"both\",to_remove:\"12\",target:\"111112a1212121211\",result:\"a\"}",
+    statement: "trim(both '12' from '111112a1212121211')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"a"
+      output: "a"
     }
   },
   {
-    name:"trim valid cases{spec:\"leading\",to_remove:\"12\",target:\"111112a1212121211\",result:\"a1212121211\"}",
-    statement:"trim(leading '12' from '111112a1212121211')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"leading\",to_remove:\"12\",target:\"111112a1212121211\",result:\"a1212121211\"}",
+    statement: "trim(leading '12' from '111112a1212121211')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"a1212121211"
+      output: "a1212121211"
     }
   },
   {
-    name:"trim valid cases{spec:\"trailing\",to_remove:\"12\",target:\"111112a1212121211\",result:\"111112a\"}",
-    statement:"trim(trailing '12' from '111112a1212121211')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"trailing\",to_remove:\"12\",target:\"111112a1212121211\",result:\"111112a\"}",
+    statement: "trim(trailing '12' from '111112a1212121211')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"111112a"
+      output: "111112a"
     }
   },
   {
-    name:"trim valid cases{spec:\"both\",to_remove:\"\\U0001f4a9\\U0001f638\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638\",result:\"1\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\"}",
-    statement:"trim(both '💩😸' from '💩💩💩😸😸😸1💩💩💩😸😸😸a💩💩💩😸😸😸1💩💩💩😸😸😸')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"both\",to_remove:\"\\U0001f4a9\\U0001f638\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638\",result:\"1\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\"}",
+    statement: "trim(both '💩😸' from '💩💩💩😸😸😸1💩💩💩😸😸😸a💩💩💩😸😸😸1💩💩💩😸😸😸')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1💩💩💩😸😸😸a💩💩💩😸😸😸1"
+      output: "1💩💩💩😸😸😸a💩💩💩😸😸😸1"
     }
   },
   {
-    name:"trim valid cases{spec:\"leading\",to_remove:\"\\U0001f4a9\\U0001f638\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638\",result:\"1\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638\"}",
-    statement:"trim(leading '💩😸' from '💩💩💩😸😸😸1💩💩💩😸😸😸a💩💩💩😸😸😸1💩💩💩😸😸😸')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"leading\",to_remove:\"\\U0001f4a9\\U0001f638\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638\",result:\"1\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638\"}",
+    statement: "trim(leading '💩😸' from '💩💩💩😸😸😸1💩💩💩😸😸😸a💩💩💩😸😸😸1💩💩💩😸😸😸')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1💩💩💩😸😸😸a💩💩💩😸😸😸1💩💩💩😸😸😸"
+      output: "1💩💩💩😸😸😸a💩💩💩😸😸😸1💩💩💩😸😸😸"
     }
   },
   {
-    name:"trim valid cases{spec:\"trailing\",to_remove:\"\\U0001f4a9\\U0001f638\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638\",result:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\"}",
-    statement:"trim(trailing '💩😸' from '💩💩💩😸😸😸1💩💩💩😸😸😸a💩💩💩😸😸😸1💩💩💩😸😸😸')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"trailing\",to_remove:\"\\U0001f4a9\\U0001f638\",target:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638\",result:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f638a\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f638\\U0001f638\\U0001f6381\"}",
+    statement: "trim(trailing '💩😸' from '💩💩💩😸😸😸1💩💩💩😸😸😸a💩💩💩😸😸😸1💩💩💩😸😸😸')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"💩💩💩😸😸😸1💩💩💩😸😸😸a💩💩💩😸😸😸1"
+      output: "💩💩💩😸😸😸1💩💩💩😸😸😸a💩💩💩😸😸😸1"
     }
   },
   {
-    name:"trim valid cases{spec:\"both\",to_remove:\"\\u8a71 \",target:\"\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a71\\u8a71\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71    \",result:\"\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\"}",
-    statement:"trim(both '話 ' from '話話 話話話話話話費谷料村能話話話話 話話話話 ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"both\",to_remove:\"\\u8a71 \",target:\"\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a71\\u8a71\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71    \",result:\"\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\"}",
+    statement: "trim(both '話 ' from '話話 話話話話話話費谷料村能話話話話 話話話話 ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"費谷料村能"
+      output: "費谷料村能"
     }
   },
   {
-    name:"trim valid cases{spec:\"leading\",to_remove:\"\\u8a71 \",target:\"\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a71\\u8a71\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71    \",result:\"\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a71\\u8a71\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71    \"}",
-    statement:"trim(leading '話 ' from '話話 話話話話話話費谷料村能話話話話 話話話話    ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"leading\",to_remove:\"\\u8a71 \",target:\"\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a71\\u8a71\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71    \",result:\"\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a71\\u8a71\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71    \"}",
+    statement: "trim(leading '話 ' from '話話 話話話話話話費谷料村能話話話話 話話話話    ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"費谷料村能話話話話 話話話話    "
+      output: "費谷料村能話話話話 話話話話    "
     }
   },
   {
-    name:"trim valid cases{spec:\"trailing\",to_remove:\"\\u8a71 \",target:\"\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a71\\u8a71\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71    \",result:\"\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\"}",
-    statement:"trim(trailing '話 ' from '話話 話話話話話話費谷料村能話話話話 話話話話 ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"trailing\",to_remove:\"\\u8a71 \",target:\"\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a71\\u8a71\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71    \",result:\"\\u8a71\\u8a71 \\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8a71\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\"}",
+    statement: "trim(trailing '話 ' from '話話 話話話話話話費谷料村能話話話話 話話話話 ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"話話 話話話話話話費谷料村能"
+      output: "話話 話話話話話話費谷料村能"
     }
   },
   {
-    name:"trim valid cases{spec:\"both\",to_remove:\"\\xb0\\xba\\u25a1(\\uff09)\\u256f\\u30ce\\ufe35_ \",target:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:\"\\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\"}",
-    statement:"trim(both '°º□(）)╯ノ︵_ ' from '(╯°□°）╯︵ ┻━┻ ┬─┬ノ( º _ ºノ)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"both\",to_remove:\"\\xb0\\xba\\u25a1(\\uff09)\\u256f\\u30ce\\ufe35_ \",target:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:\"\\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\"}",
+    statement: "trim(both '°º□(）)╯ノ︵_ ' from '(╯°□°）╯︵ ┻━┻ ┬─┬ノ( º _ ºノ)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"┻━┻ ┬─┬"
+      output: "┻━┻ ┬─┬"
     }
   },
   {
-    name:"trim valid cases{spec:\"leading\",to_remove:\"\\xb0\\xba\\u25a1(\\uff09)\\u256f\\u30ce\\ufe35_ \",target:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:\"\\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\"}",
-    statement:"trim(leading '°º□(）)╯ノ︵_ ' from '(╯°□°）╯︵ ┻━┻ ┬─┬ノ( º _ ºノ)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"leading\",to_remove:\"\\xb0\\xba\\u25a1(\\uff09)\\u256f\\u30ce\\ufe35_ \",target:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:\"\\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\"}",
+    statement: "trim(leading '°º□(）)╯ノ︵_ ' from '(╯°□°）╯︵ ┻━┻ ┬─┬ノ( º _ ºノ)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"┻━┻ ┬─┬ノ( º _ ºノ)"
+      output: "┻━┻ ┬─┬ノ( º _ ºノ)"
     }
   },
   {
-    name:"trim valid cases{spec:\"trailing\",to_remove:\"\\xb0\\xba\\u25a1(\\uff09)\\u256f\\u30ce\\ufe35_ \",target:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\"}",
-    statement:"trim(trailing '°º□(）)╯ノ︵_ ' from '(╯°□°）╯︵ ┻━┻ ┬─┬ノ( º _ ºノ)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"trailing\",to_remove:\"\\xb0\\xba\\u25a1(\\uff09)\\u256f\\u30ce\\ufe35_ \",target:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b \\u252c\\u2500\\u252c\"}",
+    statement: "trim(trailing '°º□(）)╯ノ︵_ ' from '(╯°□°）╯︵ ┻━┻ ┬─┬ノ( º _ ºノ)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"(╯°□°）╯︵ ┻━┻ ┬─┬"
+      output: "(╯°□°）╯︵ ┻━┻ ┬─┬"
     }
   },
   {
-    name:"trim valid cases{spec:\"both\",to_remove:\"\\U0001f476\\U0001f3fb\",target:\"\\U0001f476\\U0001f3fb\\U0001f469\\U0001f476\\U0001f3fb\",result:\"\\U0001f469\"}",
-    statement:"trim(both '👶🏻' from '👶🏻👩👶🏻')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"both\",to_remove:\"\\U0001f476\\U0001f3fb\",target:\"\\U0001f476\\U0001f3fb\\U0001f469\\U0001f476\\U0001f3fb\",result:\"\\U0001f469\"}",
+    statement: "trim(both '👶🏻' from '👶🏻👩👶🏻')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"👩"
+      output: "👩"
     }
   },
   {
-    name:"trim valid cases{spec:\"leading\",to_remove:\"\\U0001f476\\U0001f3fb\",target:\"\\U0001f476\\U0001f3fb\\U0001f469\\U0001f476\\U0001f3fb\",result:\"\\U0001f469\\U0001f476\\U0001f3fb\"}",
-    statement:"trim(leading '👶🏻' from '👶🏻👩👶🏻')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"leading\",to_remove:\"\\U0001f476\\U0001f3fb\",target:\"\\U0001f476\\U0001f3fb\\U0001f469\\U0001f476\\U0001f3fb\",result:\"\\U0001f469\\U0001f476\\U0001f3fb\"}",
+    statement: "trim(leading '👶🏻' from '👶🏻👩👶🏻')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"👩👶🏻"
+      output: "👩👶🏻"
     }
   },
   {
-    name:"trim valid cases{spec:\"trailing\",to_remove:\"\\U0001f476\\U0001f3fb\",target:\"\\U0001f476\\U0001f3fb\\U0001f469\\U0001f476\\U0001f3fb\",result:\"\\U0001f476\\U0001f3fb\\U0001f469\"}",
-    statement:"trim(trailing '👶🏻' from '👶🏻👩👶🏻')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"trailing\",to_remove:\"\\U0001f476\\U0001f3fb\",target:\"\\U0001f476\\U0001f3fb\\U0001f469\\U0001f476\\U0001f3fb\",result:\"\\U0001f476\\U0001f3fb\\U0001f469\"}",
+    statement: "trim(trailing '👶🏻' from '👶🏻👩👶🏻')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"👶🏻👩"
+      output: "👶🏻👩"
     }
   },
   {
-    name:"trim valid cases{spec:\"both\",to_remove:\" \",target:\"            \",result:\"\"}",
-    statement:"trim(both ' ' from ' ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"both\",to_remove:\" \",target:\"            \",result:\"\"}",
+    statement: "trim(both ' ' from ' ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"trim valid cases{spec:\"leading\",to_remove:\" \",target:\"            \",result:\"\"}",
-    statement:"trim(leading ' ' from ' ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"leading\",to_remove:\" \",target:\"            \",result:\"\"}",
+    statement: "trim(leading ' ' from ' ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"trim valid cases{spec:\"trailing\",to_remove:\" \",target:\"            \",result:\"\"}",
-    statement:"trim(trailing ' ' from ' ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim valid cases{spec:\"trailing\",to_remove:\" \",target:\"            \",result:\"\"}",
+    statement: "trim(trailing ' ' from ' ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:""
+      output: ""
     }
   },
   {
-    name:"trim variations on valid syntax{sql:\"trim('      foobar       ')\"}",
-    statement:"trim(' foobar ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim variations on valid syntax{sql:\"trim('      foobar       ')\"}",
+    statement: "trim(' foobar ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"foobar"
+      output: "foobar"
     }
   },
   {
-    name:"trim variations on valid syntax{sql:\"trim(from '      foobar       ')\"}",
-    statement:"trim(from ' foobar ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim variations on valid syntax{sql:\"trim(from '      foobar       ')\"}",
+    statement: "trim(from ' foobar ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"foobar"
+      output: "foobar"
     }
   },
   {
-    name:"trim variations on valid syntax{sql:\"trim(both from '      foobar       ')\"}",
-    statement:"trim(both from ' foobar ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim variations on valid syntax{sql:\"trim(both from '      foobar       ')\"}",
+    statement: "trim(both from ' foobar ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"foobar"
+      output: "foobar"
     }
   },
   {
-    name:"trim variations on valid syntax{sql:\"trim(both ' ' from '      foobar       ')\"}",
-    statement:"trim(both ' ' from ' foobar ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim variations on valid syntax{sql:\"trim(both ' ' from '      foobar       ')\"}",
+    statement: "trim(both ' ' from ' foobar ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"foobar"
+      output: "foobar"
     }
   },
   {
-    name:"trim variations on valid syntax{sql:\"trim('12' from '1212foobar1212')\"}",
-    statement:"trim('12' from '1212foobar1212')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim variations on valid syntax{sql:\"trim('12' from '1212foobar1212')\"}",
+    statement: "trim('12' from '1212foobar1212')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"foobar"
+      output: "foobar"
     }
   },
   {
-    name:"trim variations on valid syntax{sql:\"trim('12' from 'foobar1212')\"}",
-    statement:"trim('12' from 'foobar1212')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim variations on valid syntax{sql:\"trim('12' from 'foobar1212')\"}",
+    statement: "trim('12' from 'foobar1212')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"foobar"
+      output: "foobar"
     }
   },
   {
-    name:"trim variations on valid syntax{sql:\"trim('12' from '1212foobar')\"}",
-    statement:"trim('12' from '1212foobar')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim variations on valid syntax{sql:\"trim('12' from '1212foobar')\"}",
+    statement: "trim('12' from '1212foobar')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"foobar"
+      output: "foobar"
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(null)\"}",
-    statement:"trim(null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(null)\"}",
+    statement: "trim(null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(missing)\"}",
-    statement:"trim(missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(missing)\"}",
+    statement: "trim(missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(leading from null)\"}",
+    statement: "trim(leading from null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(leading from null)\"}",
-    statement:"trim(leading from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(trailing from null)\"}",
+    statement: "trim(trailing from null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(trailing from null)\"}",
-    statement:"trim(trailing from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(both from null)\"}",
+    statement: "trim(both from null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(both from null)\"}",
-    statement:"trim(both from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(leading from missing)\"}",
+    statement: "trim(leading from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(trailing from missing)\"}",
+    statement: "trim(trailing from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(both from missing)\"}",
+    statement: "trim(both from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(leading '' from null)\"}",
+    statement: "trim(leading '' from null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(leading from missing)\"}",
-    statement:"trim(leading from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(trailing '' from null)\"}",
+    statement: "trim(trailing '' from null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(trailing from missing)\"}",
-    statement:"trim(trailing from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(both '' from null)\"}",
+    statement: "trim(both '' from null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(both from missing)\"}",
-    statement:"trim(both from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(leading '' from missing)\"}",
+    statement: "trim(leading '' from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(trailing '' from missing)\"}",
+    statement: "trim(trailing '' from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(both '' from missing)\"}",
+    statement: "trim(both '' from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(leading null from '')\"}",
+    statement: "trim(leading null from '')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(leading '' from null)\"}",
-    statement:"trim(leading '' from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(trailing null from '')\"}",
+    statement: "trim(trailing null from '')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(trailing '' from null)\"}",
-    statement:"trim(trailing '' from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(both null from '')\"}",
+    statement: "trim(both null from '')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(both '' from null)\"}",
-    statement:"trim(both '' from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(leading missing from '')\"}",
+    statement: "trim(leading missing from '')",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(trailing missing from '')\"}",
+    statement: "trim(trailing missing from '')",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(both missing from '')\"}",
+    statement: "trim(both missing from '')",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(leading null from missing)\"}",
+    statement: "trim(leading null from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(trailing null from missing)\"}",
+    statement: "trim(trailing null from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(both null from missing)\"}",
+    statement: "trim(both null from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(leading missing from null)\"}",
+    statement: "trim(leading missing from null)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(trailing missing from null)\"}",
+    statement: "trim(trailing missing from null)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(both missing from null)\"}",
+    statement: "trim(both missing from null)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "trim null and missing propagation{sql:\"trim(leading null from null)\"}",
+    statement: "trim(leading null from null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(leading '' from missing)\"}",
-    statement:"trim(leading '' from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(trailing null from null)\"}",
+    statement: "trim(trailing null from null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(trailing '' from missing)\"}",
-    statement:"trim(trailing '' from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "trim null and missing propagation{sql:\"trim(both null from null)\"}",
+    statement: "trim(both null from null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output: null
     }
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(both '' from missing)\"}",
-    statement:"trim(both '' from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+    name: "trim null and missing propagation{sql:\"trim(leading missing from missing)\"}",
+    statement: "trim(leading missing from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(leading null from '')\"}",
-    statement:"trim(leading null from '')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
+    name: "trim null and missing propagation{sql:\"trim(trailing missing from missing)\"}",
+    statement: "trim(trailing missing from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
-    name:"trim null and missing propagation{sql:\"trim(trailing null from '')\"}",
-    statement:"trim(trailing null from '')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(both null from '')\"}",
-    statement:"trim(both null from '')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(leading missing from '')\"}",
-    statement:"trim(leading missing from '')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(trailing missing from '')\"}",
-    statement:"trim(trailing missing from '')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(both missing from '')\"}",
-    statement:"trim(both missing from '')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(leading null from missing)\"}",
-    statement:"trim(leading null from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(trailing null from missing)\"}",
-    statement:"trim(trailing null from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(both null from missing)\"}",
-    statement:"trim(both null from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(leading missing from null)\"}",
-    statement:"trim(leading missing from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(trailing missing from null)\"}",
-    statement:"trim(trailing missing from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(both missing from null)\"}",
-    statement:"trim(both missing from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(leading null from null)\"}",
-    statement:"trim(leading null from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(trailing null from null)\"}",
-    statement:"trim(trailing null from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(both null from null)\"}",
-    statement:"trim(both null from null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(leading missing from missing)\"}",
-    statement:"trim(leading missing from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(trailing missing from missing)\"}",
-    statement:"trim(trailing missing from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"trim null and missing propagation{sql:\"trim(both missing from missing)\"}",
-    statement:"trim(both missing from missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+    name: "trim null and missing propagation{sql:\"trim(both missing from missing)\"}",
+    statement: "trim(both missing from missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   }
 ]

--- a/partiql-tests-data/eval/primitives/functions/upper.ion
+++ b/partiql-tests-data/eval/primitives/functions/upper.ion
@@ -1,1646 +1,1649 @@
 upper::[
   {
-    name:"upper valid cases{in:\" !\\\"#%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\",result:\" !\\\"#%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~\"}",
-    statement:"upper(' !\"#$%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\" !\\\"#%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\",result:\" !\\\"#%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~\"}",
+    statement: "upper(' !\"#$%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:" !\"#$%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~"
+      output: " !\"#$%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~"
     }
   },
   {
-    name:"upper valid cases{in:\"\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xff\",result:\"\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\u039c\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xf7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\u0178\"}",
-    statement:"upper('¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xff\",result:\"\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\u039c\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xf7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\u0178\"}",
+    statement: "upper('¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"¡¢£¤¥¦§¨©ª«¬­®¯°±²³´Μ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ÷ØÙÚÛÜÝÞŸ"
+      output: "¡¢£¤¥¦§¨©ª«¬­®¯°±²³´Μ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ÷ØÙÚÛÜÝÞŸ"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u0100\\u0101\\u0102\\u0103\\u0104\\u0105\\u0106\\u0107\\u0108\\u0109\\u010a\\u010b\\u010c\\u010d\\u010e\\u010f\\u0110\\u0111\\u0112\\u0113\\u0114\\u0115\\u0116\\u0117\\u0118\\u0119\\u011a\\u011b\\u011c\\u011d\\u011e\\u011f\\u0120\\u0121\\u0122\\u0123\\u0124\\u0125\\u0126\\u0127\\u0128\\u0129\\u012a\\u012b\\u012c\\u012d\\u012e\\u012f\\u0131\\u0132\\u0133\\u0134\\u0135\\u0136\\u0137\\u0138\\u0139\\u013a\\u013b\\u013c\\u013d\\u013e\\u013f\\u0140\\u0141\\u0142\\u0143\\u0144\\u0145\\u0146\\u0147\\u0148\\u014a\\u014b\\u014c\\u014d\\u014e\\u014f\\u0150\\u0151\\u0152\\u0153\\u0154\\u0155\\u0156\\u0157\\u0158\\u0159\\u015a\\u015b\\u015c\\u015d\\u015e\\u015f\\u0160\\u0161\\u0162\\u0163\\u0164\\u0165\\u0166\\u0167\\u0168\\u0169\\u016a\\u016b\\u016c\\u016d\\u016e\\u016f\\u0170\\u0171\\u0172\\u0173\\u0174\\u0175\\u0176\\u0177\\u0178\\u0179\\u017a\\u017b\\u017c\\u017d\\u017e\",result:\"\\u0100\\u0100\\u0102\\u0102\\u0104\\u0104\\u0106\\u0106\\u0108\\u0108\\u010a\\u010a\\u010c\\u010c\\u010e\\u010e\\u0110\\u0110\\u0112\\u0112\\u0114\\u0114\\u0116\\u0116\\u0118\\u0118\\u011a\\u011a\\u011c\\u011c\\u011e\\u011e\\u0120\\u0120\\u0122\\u0122\\u0124\\u0124\\u0126\\u0126\\u0128\\u0128\\u012a\\u012a\\u012c\\u012c\\u012e\\u012eI\\u0132\\u0132\\u0134\\u0134\\u0136\\u0136\\u0138\\u0139\\u0139\\u013b\\u013b\\u013d\\u013d\\u013f\\u013f\\u0141\\u0141\\u0143\\u0143\\u0145\\u0145\\u0147\\u0147\\u014a\\u014a\\u014c\\u014c\\u014e\\u014e\\u0150\\u0150\\u0152\\u0152\\u0154\\u0154\\u0156\\u0156\\u0158\\u0158\\u015a\\u015a\\u015c\\u015c\\u015e\\u015e\\u0160\\u0160\\u0162\\u0162\\u0164\\u0164\\u0166\\u0166\\u0168\\u0168\\u016a\\u016a\\u016c\\u016c\\u016e\\u016e\\u0170\\u0170\\u0172\\u0172\\u0174\\u0174\\u0176\\u0176\\u0178\\u0179\\u0179\\u017b\\u017b\\u017d\\u017d\"}",
-    statement:"upper('ĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽž')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u0100\\u0101\\u0102\\u0103\\u0104\\u0105\\u0106\\u0107\\u0108\\u0109\\u010a\\u010b\\u010c\\u010d\\u010e\\u010f\\u0110\\u0111\\u0112\\u0113\\u0114\\u0115\\u0116\\u0117\\u0118\\u0119\\u011a\\u011b\\u011c\\u011d\\u011e\\u011f\\u0120\\u0121\\u0122\\u0123\\u0124\\u0125\\u0126\\u0127\\u0128\\u0129\\u012a\\u012b\\u012c\\u012d\\u012e\\u012f\\u0131\\u0132\\u0133\\u0134\\u0135\\u0136\\u0137\\u0138\\u0139\\u013a\\u013b\\u013c\\u013d\\u013e\\u013f\\u0140\\u0141\\u0142\\u0143\\u0144\\u0145\\u0146\\u0147\\u0148\\u014a\\u014b\\u014c\\u014d\\u014e\\u014f\\u0150\\u0151\\u0152\\u0153\\u0154\\u0155\\u0156\\u0157\\u0158\\u0159\\u015a\\u015b\\u015c\\u015d\\u015e\\u015f\\u0160\\u0161\\u0162\\u0163\\u0164\\u0165\\u0166\\u0167\\u0168\\u0169\\u016a\\u016b\\u016c\\u016d\\u016e\\u016f\\u0170\\u0171\\u0172\\u0173\\u0174\\u0175\\u0176\\u0177\\u0178\\u0179\\u017a\\u017b\\u017c\\u017d\\u017e\",result:\"\\u0100\\u0100\\u0102\\u0102\\u0104\\u0104\\u0106\\u0106\\u0108\\u0108\\u010a\\u010a\\u010c\\u010c\\u010e\\u010e\\u0110\\u0110\\u0112\\u0112\\u0114\\u0114\\u0116\\u0116\\u0118\\u0118\\u011a\\u011a\\u011c\\u011c\\u011e\\u011e\\u0120\\u0120\\u0122\\u0122\\u0124\\u0124\\u0126\\u0126\\u0128\\u0128\\u012a\\u012a\\u012c\\u012c\\u012e\\u012eI\\u0132\\u0132\\u0134\\u0134\\u0136\\u0136\\u0138\\u0139\\u0139\\u013b\\u013b\\u013d\\u013d\\u013f\\u013f\\u0141\\u0141\\u0143\\u0143\\u0145\\u0145\\u0147\\u0147\\u014a\\u014a\\u014c\\u014c\\u014e\\u014e\\u0150\\u0150\\u0152\\u0152\\u0154\\u0154\\u0156\\u0156\\u0158\\u0158\\u015a\\u015a\\u015c\\u015c\\u015e\\u015e\\u0160\\u0160\\u0162\\u0162\\u0164\\u0164\\u0166\\u0166\\u0168\\u0168\\u016a\\u016a\\u016c\\u016c\\u016e\\u016e\\u0170\\u0170\\u0172\\u0172\\u0174\\u0174\\u0176\\u0176\\u0178\\u0179\\u0179\\u017b\\u017b\\u017d\\u017d\"}",
+    statement: "upper('ĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽž')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ĀĀĂĂĄĄĆĆĈĈĊĊČČĎĎĐĐĒĒĔĔĖĖĘĘĚĚĜĜĞĞĠĠĢĢĤĤĦĦĨĨĪĪĬĬĮĮIĲĲĴĴĶĶĸĹĹĻĻĽĽĿĿŁŁŃŃŅŅŇŇŊŊŌŌŎŎŐŐŒŒŔŔŖŖŘŘŚŚŜŜŞŞŠŠŢŢŤŤŦŦŨŨŪŪŬŬŮŮŰŰŲŲŴŴŶŶŸŹŹŻŻŽŽ"
+      output: "ĀĀĂĂĄĄĆĆĈĈĊĊČČĎĎĐĐĒĒĔĔĖĖĘĘĚĚĜĜĞĞĠĠĢĢĤĤĦĦĨĨĪĪĬĬĮĮIĲĲĴĴĶĶĸĹĹĻĻĽĽĿĿŁŁŃŃŅŅŇŇŊŊŌŌŎŎŐŐŒŒŔŔŖŖŘŘŚŚŜŜŞŞŠŠŢŢŤŤŦŦŨŨŪŪŬŬŮŮŰŰŲŲŴŴŶŶŸŹŹŻŻŽŽ"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u0180\\u0181\\u0182\\u0183\\u0184\\u0185\\u0186\\u0187\\u0188\\u0189\\u018a\\u018b\\u018c\\u018d\\u018e\\u018f\\u0190\\u0191\\u0192\\u0193\\u0194\\u0195\\u0196\\u0197\\u0198\\u0199\\u019a\\u019b\\u019c\\u019d\\u019e\\u019f\\u01a0\\u01a1\\u01a2\\u01a3\\u01a4\\u01a5\\u01a6\\u01a7\\u01a8\\u01a9\\u01aa\\u01ab\\u01ac\\u01ad\\u01ae\\u01af\\u01b0\\u01b1\\u01b2\\u01b3\\u01b4\\u01b5\\u01b6\\u01b7\\u01b8\\u01b9\\u01ba\\u01bb\\u01bc\\u01bd\\u01be\\u01bf\\u01c0\\u01c1\\u01c2\\u01c3\\u01c4\\u01c5\\u01c6\\u01c7\\u01c8\\u01c9\\u01ca\\u01cb\\u01cc\\u01cd\\u01ce\\u01cf\\u01d0\\u01d1\\u01d2\\u01d3\\u01d4\\u01d5\\u01d6\\u01d7\\u01d8\\u01d9\\u01da\\u01db\\u01dc\\u01dd\\u01de\\u01df\\u01e0\\u01e1\\u01e2\\u01e3\\u01e4\\u01e5\\u01e6\\u01e7\\u01e8\\u01e9\\u01ea\\u01eb\\u01ec\\u01ed\\u01ee\\u01ef\\u01f0\\u01f1\\u01f2\\u01f3\\u01f4\\u01f5\\u01f6\\u01f7\\u01f8\\u01f9\\u01fa\\u01fb\\u01fc\\u01fd\\u01fe\\u01ff\\u0200\\u0201\\u0202\\u0203\\u0204\\u0205\\u0206\\u0207\\u0208\\u0209\\u020a\\u020b\\u020c\\u020d\\u020e\\u020f\\u0210\\u0211\\u0212\\u0213\\u0214\\u0215\\u0216\\u0217\\u0218\\u0219\\u021a\\u021b\\u021c\\u021d\\u021e\\u021f\\u0220\\u0221\\u0222\\u0223\\u0224\\u0225\\u0226\\u0227\\u0228\\u0229\\u022a\\u022b\\u022c\\u022d\\u022e\\u022f\\u0230\\u0231\\u0232\\u0233\\u0234\\u0235\\u0236\\u0237\\u0238\\u0239\\u023a\\u023b\\u023c\\u023d\\u023e\\u023f\\u0240\\u0241\\u0242\\u0243\\u0244\\u0245\\u0246\\u0247\\u0248\\u0249\\u024a\\u024b\\u024c\\u024d\\u024e\\u024f\",result:\"\\u0243\\u0181\\u0182\\u0182\\u0184\\u0184\\u0186\\u0187\\u0187\\u0189\\u018a\\u018b\\u018b\\u018d\\u018e\\u018f\\u0190\\u0191\\u0191\\u0193\\u0194\\u01f6\\u0196\\u0197\\u0198\\u0198\\u023d\\u019b\\u019c\\u019d\\u0220\\u019f\\u01a0\\u01a0\\u01a2\\u01a2\\u01a4\\u01a4\\u01a6\\u01a7\\u01a7\\u01a9\\u01aa\\u01ab\\u01ac\\u01ac\\u01ae\\u01af\\u01af\\u01b1\\u01b2\\u01b3\\u01b3\\u01b5\\u01b5\\u01b7\\u01b8\\u01b8\\u01ba\\u01bb\\u01bc\\u01bc\\u01be\\u01f7\\u01c0\\u01c1\\u01c2\\u01c3\\u01c4\\u01c4\\u01c4\\u01c7\\u01c7\\u01c7\\u01ca\\u01ca\\u01ca\\u01cd\\u01cd\\u01cf\\u01cf\\u01d1\\u01d1\\u01d3\\u01d3\\u01d5\\u01d5\\u01d7\\u01d7\\u01d9\\u01d9\\u01db\\u01db\\u018e\\u01de\\u01de\\u01e0\\u01e0\\u01e2\\u01e2\\u01e4\\u01e4\\u01e6\\u01e6\\u01e8\\u01e8\\u01ea\\u01ea\\u01ec\\u01ec\\u01ee\\u01eeJ\\u030c\\u01f1\\u01f1\\u01f1\\u01f4\\u01f4\\u01f6\\u01f7\\u01f8\\u01f8\\u01fa\\u01fa\\u01fc\\u01fc\\u01fe\\u01fe\\u0200\\u0200\\u0202\\u0202\\u0204\\u0204\\u0206\\u0206\\u0208\\u0208\\u020a\\u020a\\u020c\\u020c\\u020e\\u020e\\u0210\\u0210\\u0212\\u0212\\u0214\\u0214\\u0216\\u0216\\u0218\\u0218\\u021a\\u021a\\u021c\\u021c\\u021e\\u021e\\u0220\\u0221\\u0222\\u0222\\u0224\\u0224\\u0226\\u0226\\u0228\\u0228\\u022a\\u022a\\u022c\\u022c\\u022e\\u022e\\u0230\\u0230\\u0232\\u0232\\u0234\\u0235\\u0236\\u0237\\u0238\\u0239\\u023a\\u023b\\u023b\\u023d\\u023e\\u2c7e\\u2c7f\\u0241\\u0241\\u0243\\u0244\\u0245\\u0246\\u0246\\u0248\\u0248\\u024a\\u024a\\u024c\\u024c\\u024e\\u024e\"}",
-    statement:"upper('ƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴǵǶǷǸǹǺǻǼǽǾǿȀȁȂȃȄȅȆȇȈȉȊȋȌȍȎȏȐȑȒȓȔȕȖȗȘșȚțȜȝȞȟȠȡȢȣȤȥȦȧȨȩȪȫȬȭȮȯȰȱȲȳȴȵȶȷȸȹȺȻȼȽȾȿɀɁɂɃɄɅɆɇɈɉɊɋɌɍɎɏ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u0180\\u0181\\u0182\\u0183\\u0184\\u0185\\u0186\\u0187\\u0188\\u0189\\u018a\\u018b\\u018c\\u018d\\u018e\\u018f\\u0190\\u0191\\u0192\\u0193\\u0194\\u0195\\u0196\\u0197\\u0198\\u0199\\u019a\\u019b\\u019c\\u019d\\u019e\\u019f\\u01a0\\u01a1\\u01a2\\u01a3\\u01a4\\u01a5\\u01a6\\u01a7\\u01a8\\u01a9\\u01aa\\u01ab\\u01ac\\u01ad\\u01ae\\u01af\\u01b0\\u01b1\\u01b2\\u01b3\\u01b4\\u01b5\\u01b6\\u01b7\\u01b8\\u01b9\\u01ba\\u01bb\\u01bc\\u01bd\\u01be\\u01bf\\u01c0\\u01c1\\u01c2\\u01c3\\u01c4\\u01c5\\u01c6\\u01c7\\u01c8\\u01c9\\u01ca\\u01cb\\u01cc\\u01cd\\u01ce\\u01cf\\u01d0\\u01d1\\u01d2\\u01d3\\u01d4\\u01d5\\u01d6\\u01d7\\u01d8\\u01d9\\u01da\\u01db\\u01dc\\u01dd\\u01de\\u01df\\u01e0\\u01e1\\u01e2\\u01e3\\u01e4\\u01e5\\u01e6\\u01e7\\u01e8\\u01e9\\u01ea\\u01eb\\u01ec\\u01ed\\u01ee\\u01ef\\u01f0\\u01f1\\u01f2\\u01f3\\u01f4\\u01f5\\u01f6\\u01f7\\u01f8\\u01f9\\u01fa\\u01fb\\u01fc\\u01fd\\u01fe\\u01ff\\u0200\\u0201\\u0202\\u0203\\u0204\\u0205\\u0206\\u0207\\u0208\\u0209\\u020a\\u020b\\u020c\\u020d\\u020e\\u020f\\u0210\\u0211\\u0212\\u0213\\u0214\\u0215\\u0216\\u0217\\u0218\\u0219\\u021a\\u021b\\u021c\\u021d\\u021e\\u021f\\u0220\\u0221\\u0222\\u0223\\u0224\\u0225\\u0226\\u0227\\u0228\\u0229\\u022a\\u022b\\u022c\\u022d\\u022e\\u022f\\u0230\\u0231\\u0232\\u0233\\u0234\\u0235\\u0236\\u0237\\u0238\\u0239\\u023a\\u023b\\u023c\\u023d\\u023e\\u023f\\u0240\\u0241\\u0242\\u0243\\u0244\\u0245\\u0246\\u0247\\u0248\\u0249\\u024a\\u024b\\u024c\\u024d\\u024e\\u024f\",result:\"\\u0243\\u0181\\u0182\\u0182\\u0184\\u0184\\u0186\\u0187\\u0187\\u0189\\u018a\\u018b\\u018b\\u018d\\u018e\\u018f\\u0190\\u0191\\u0191\\u0193\\u0194\\u01f6\\u0196\\u0197\\u0198\\u0198\\u023d\\u019b\\u019c\\u019d\\u0220\\u019f\\u01a0\\u01a0\\u01a2\\u01a2\\u01a4\\u01a4\\u01a6\\u01a7\\u01a7\\u01a9\\u01aa\\u01ab\\u01ac\\u01ac\\u01ae\\u01af\\u01af\\u01b1\\u01b2\\u01b3\\u01b3\\u01b5\\u01b5\\u01b7\\u01b8\\u01b8\\u01ba\\u01bb\\u01bc\\u01bc\\u01be\\u01f7\\u01c0\\u01c1\\u01c2\\u01c3\\u01c4\\u01c4\\u01c4\\u01c7\\u01c7\\u01c7\\u01ca\\u01ca\\u01ca\\u01cd\\u01cd\\u01cf\\u01cf\\u01d1\\u01d1\\u01d3\\u01d3\\u01d5\\u01d5\\u01d7\\u01d7\\u01d9\\u01d9\\u01db\\u01db\\u018e\\u01de\\u01de\\u01e0\\u01e0\\u01e2\\u01e2\\u01e4\\u01e4\\u01e6\\u01e6\\u01e8\\u01e8\\u01ea\\u01ea\\u01ec\\u01ec\\u01ee\\u01eeJ\\u030c\\u01f1\\u01f1\\u01f1\\u01f4\\u01f4\\u01f6\\u01f7\\u01f8\\u01f8\\u01fa\\u01fa\\u01fc\\u01fc\\u01fe\\u01fe\\u0200\\u0200\\u0202\\u0202\\u0204\\u0204\\u0206\\u0206\\u0208\\u0208\\u020a\\u020a\\u020c\\u020c\\u020e\\u020e\\u0210\\u0210\\u0212\\u0212\\u0214\\u0214\\u0216\\u0216\\u0218\\u0218\\u021a\\u021a\\u021c\\u021c\\u021e\\u021e\\u0220\\u0221\\u0222\\u0222\\u0224\\u0224\\u0226\\u0226\\u0228\\u0228\\u022a\\u022a\\u022c\\u022c\\u022e\\u022e\\u0230\\u0230\\u0232\\u0232\\u0234\\u0235\\u0236\\u0237\\u0238\\u0239\\u023a\\u023b\\u023b\\u023d\\u023e\\u2c7e\\u2c7f\\u0241\\u0241\\u0243\\u0244\\u0245\\u0246\\u0246\\u0248\\u0248\\u024a\\u024a\\u024c\\u024c\\u024e\\u024e\"}",
+    statement: "upper('ƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴǵǶǷǸǹǺǻǼǽǾǿȀȁȂȃȄȅȆȇȈȉȊȋȌȍȎȏȐȑȒȓȔȕȖȗȘșȚțȜȝȞȟȠȡȢȣȤȥȦȧȨȩȪȫȬȭȮȯȰȱȲȳȴȵȶȷȸȹȺȻȼȽȾȿɀɁɂɃɄɅɆɇɈɉɊɋɌɍɎɏ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ɃƁƂƂƄƄƆƇƇƉƊƋƋƍƎƏƐƑƑƓƔǶƖƗƘƘȽƛƜƝȠƟƠƠƢƢƤƤƦƧƧƩƪƫƬƬƮƯƯƱƲƳƳƵƵƷƸƸƺƻƼƼƾǷǀǁǂǃǄǄǄǇǇǇǊǊǊǍǍǏǏǑǑǓǓǕǕǗǗǙǙǛǛƎǞǞǠǠǢǢǤǤǦǦǨǨǪǪǬǬǮǮJ̌ǱǱǱǴǴǶǷǸǸǺǺǼǼǾǾȀȀȂȂȄȄȆȆȈȈȊȊȌȌȎȎȐȐȒȒȔȔȖȖȘȘȚȚȜȜȞȞȠȡȢȢȤȤȦȦȨȨȪȪȬȬȮȮȰȰȲȲȴȵȶȷȸȹȺȻȻȽȾⱾⱿɁɁɃɄɅɆɆɈɈɊɊɌɌɎɎ"
+      output: "ɃƁƂƂƄƄƆƇƇƉƊƋƋƍƎƏƐƑƑƓƔǶƖƗƘƘȽƛƜƝȠƟƠƠƢƢƤƤƦƧƧƩƪƫƬƬƮƯƯƱƲƳƳƵƵƷƸƸƺƻƼƼƾǷǀǁǂǃǄǄǄǇǇǇǊǊǊǍǍǏǏǑǑǓǓǕǕǗǗǙǙǛǛƎǞǞǠǠǢǢǤǤǦǦǨǨǪǪǬǬǮǮJ̌ǱǱǱǴǴǶǷǸǸǺǺǼǼǾǾȀȀȂȂȄȄȆȆȈȈȊȊȌȌȎȎȐȐȒȒȔȔȖȖȘȘȚȚȜȜȞȞȠȡȢȢȤȤȦȦȨȨȪȪȬȬȮȮȰȰȲȲȴȵȶȷȸȹȺȻȻȽȾⱾⱿɁɁɃɄɅɆɆɈɈɊɊɌɌɎɎ"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u2c60\\u2c61\\u2c62\\u2c63\\u2c64\\u2c65\\u2c66\\u2c67\\u2c68\\u2c69\\u2c6a\\u2c6b\\u2c6c\\u2c6d\\u2c6e\\u2c6f\\u2c70\\u2c71\\u2c72\\u2c73\\u2c74\\u2c75\\u2c76\\u2c77\\u2c78\\u2c79\\u2c7a\\u2c7b\\u2c7c\\u2c7d\\u2c7e\\u2c7f\",result:\"\\u2c60\\u2c60\\u2c62\\u2c63\\u2c64\\u023a\\u023e\\u2c67\\u2c67\\u2c69\\u2c69\\u2c6b\\u2c6b\\u2c6d\\u2c6e\\u2c6f\\u2c70\\u2c71\\u2c72\\u2c72\\u2c74\\u2c75\\u2c75\\u2c77\\u2c78\\u2c79\\u2c7a\\u2c7b\\u2c7c\\u2c7d\\u2c7e\\u2c7f\"}",
-    statement:"upper('ⱠⱡⱢⱣⱤⱥⱦⱧⱨⱩⱪⱫⱬⱭⱮⱯⱰⱱⱲⱳⱴⱵⱶⱷⱸⱹⱺⱻⱼⱽⱾⱿ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u2c60\\u2c61\\u2c62\\u2c63\\u2c64\\u2c65\\u2c66\\u2c67\\u2c68\\u2c69\\u2c6a\\u2c6b\\u2c6c\\u2c6d\\u2c6e\\u2c6f\\u2c70\\u2c71\\u2c72\\u2c73\\u2c74\\u2c75\\u2c76\\u2c77\\u2c78\\u2c79\\u2c7a\\u2c7b\\u2c7c\\u2c7d\\u2c7e\\u2c7f\",result:\"\\u2c60\\u2c60\\u2c62\\u2c63\\u2c64\\u023a\\u023e\\u2c67\\u2c67\\u2c69\\u2c69\\u2c6b\\u2c6b\\u2c6d\\u2c6e\\u2c6f\\u2c70\\u2c71\\u2c72\\u2c72\\u2c74\\u2c75\\u2c75\\u2c77\\u2c78\\u2c79\\u2c7a\\u2c7b\\u2c7c\\u2c7d\\u2c7e\\u2c7f\"}",
+    statement: "upper('ⱠⱡⱢⱣⱤⱥⱦⱧⱨⱩⱪⱫⱬⱭⱮⱯⱰⱱⱲⱳⱴⱵⱶⱷⱸⱹⱺⱻⱼⱽⱾⱿ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ⱠⱠⱢⱣⱤȺȾⱧⱧⱩⱩⱫⱫⱭⱮⱯⱰⱱⱲⱲⱴⱵⱵⱷⱸⱹⱺⱻⱼⱽⱾⱿ"
+      output: "ⱠⱠⱢⱣⱤȺȾⱧⱧⱩⱩⱫⱫⱭⱮⱯⱰⱱⱲⱲⱴⱵⱵⱷⱸⱹⱺⱻⱼⱽⱾⱿ"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\\u3041\\u3066\\u30c8\\u30ad\\u307b\\u30c3\\u0394\\u03d5\\u03be\\u0391\",result:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\\u3041\\u3066\\u30c8\\u30ad\\u307b\\u30c3\\u0394\\u03a6\\u039e\\u0391\"}",
-    statement:"upper('話家身圧費谷料村能計税金ぁてトキほッΔϕξΑ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\\u3041\\u3066\\u30c8\\u30ad\\u307b\\u30c3\\u0394\\u03d5\\u03be\\u0391\",result:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\\u3041\\u3066\\u30c8\\u30ad\\u307b\\u30c3\\u0394\\u03a6\\u039e\\u0391\"}",
+    statement: "upper('話家身圧費谷料村能計税金ぁてトキほッΔϕξΑ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"話家身圧費谷料村能計税金ぁてトキほッΔΦΞΑ"
+      output: "話家身圧費谷料村能計税金ぁてトキほッΔΦΞΑ"
     }
   },
   {
-    name:"upper valid cases{in:\"undefined\",result:\"UNDEFINED\"}",
-    statement:"upper('undefined')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"undefined\",result:\"UNDEFINED\"}",
+    statement: "upper('undefined')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"UNDEFINED"
+      output: "UNDEFINED"
     }
   },
   {
-    name:"upper valid cases{in:\"undef\",result:\"UNDEF\"}",
-    statement:"upper('undef')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"undef\",result:\"UNDEF\"}",
+    statement: "upper('undef')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"UNDEF"
+      output: "UNDEF"
     }
   },
   {
-    name:"upper valid cases{in:\"null\",result:\"NULL\"}",
-    statement:"upper('null')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"null\",result:\"NULL\"}",
+    statement: "upper('null')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"NULL"
+      output: "NULL"
     }
   },
   {
-    name:"upper valid cases{in:\"NULL\",result:\"NULL\"}",
-    statement:"upper('NULL')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"NULL\",result:\"NULL\"}",
+    statement: "upper('NULL')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"NULL"
+      output: "NULL"
     }
   },
   {
-    name:"upper valid cases{in:\"(null)\",result:\"(NULL)\"}",
-    statement:"upper('(null)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"(null)\",result:\"(NULL)\"}",
+    statement: "upper('(null)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"(NULL)"
+      output: "(NULL)"
     }
   },
   {
-    name:"upper valid cases{in:\"nil\",result:\"NIL\"}",
-    statement:"upper('nil')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"nil\",result:\"NIL\"}",
+    statement: "upper('nil')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"NIL"
+      output: "NIL"
     }
   },
   {
-    name:"upper valid cases{in:\"NIL\",result:\"NIL\"}",
-    statement:"upper('NIL')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"NIL\",result:\"NIL\"}",
+    statement: "upper('NIL')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"NIL"
+      output: "NIL"
     }
   },
   {
-    name:"upper valid cases{in:\"true\",result:\"TRUE\"}",
-    statement:"upper('true')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"true\",result:\"TRUE\"}",
+    statement: "upper('true')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"TRUE"
+      output: "TRUE"
     }
   },
   {
-    name:"upper valid cases{in:\"false\",result:\"FALSE\"}",
-    statement:"upper('false')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"false\",result:\"FALSE\"}",
+    statement: "upper('false')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"FALSE"
+      output: "FALSE"
     }
   },
   {
-    name:"upper valid cases{in:\"True\",result:\"TRUE\"}",
-    statement:"upper('True')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"True\",result:\"TRUE\"}",
+    statement: "upper('True')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"TRUE"
+      output: "TRUE"
     }
   },
   {
-    name:"upper valid cases{in:\"False\",result:\"FALSE\"}",
-    statement:"upper('False')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"False\",result:\"FALSE\"}",
+    statement: "upper('False')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"FALSE"
+      output: "FALSE"
     }
   },
   {
-    name:"upper valid cases{in:\"TRUE\",result:\"TRUE\"}",
-    statement:"upper('TRUE')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"TRUE\",result:\"TRUE\"}",
+    statement: "upper('TRUE')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"TRUE"
+      output: "TRUE"
     }
   },
   {
-    name:"upper valid cases{in:\"FALSE\",result:\"FALSE\"}",
-    statement:"upper('FALSE')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"FALSE\",result:\"FALSE\"}",
+    statement: "upper('FALSE')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"FALSE"
+      output: "FALSE"
     }
   },
   {
-    name:"upper valid cases{in:\"None\",result:\"NONE\"}",
-    statement:"upper('None')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"None\",result:\"NONE\"}",
+    statement: "upper('None')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"NONE"
+      output: "NONE"
     }
   },
   {
-    name:"upper valid cases{in:\"hasOwnProperty\",result:\"HASOWNPROPERTY\"}",
-    statement:"upper('hasOwnProperty')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"hasOwnProperty\",result:\"HASOWNPROPERTY\"}",
+    statement: "upper('hasOwnProperty')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"HASOWNPROPERTY"
+      output: "HASOWNPROPERTY"
     }
   },
   {
-    name:"upper valid cases{in:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\",result:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\"}",
-    statement:"upper('999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\",result:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\"}",
+    statement: "upper('999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"
+      output: "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"
     }
   },
   {
-    name:"upper valid cases{in:\"123456789012345678901234567890123456789\",result:\"123456789012345678901234567890123456789\"}",
-    statement:"upper('123456789012345678901234567890123456789')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"123456789012345678901234567890123456789\",result:\"123456789012345678901234567890123456789\"}",
+    statement: "upper('123456789012345678901234567890123456789')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"123456789012345678901234567890123456789"
+      output: "123456789012345678901234567890123456789"
     }
   },
   {
-    name:"upper valid cases{in:\"0\",result:\"0\"}",
-    statement:"upper('0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0\",result:\"0\"}",
+    statement: "upper('0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0"
+      output: "0"
     }
   },
   {
-    name:"upper valid cases{in:\"1\",result:\"1\"}",
-    statement:"upper('1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1\",result:\"1\"}",
+    statement: "upper('1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1"
+      output: "1"
     }
   },
   {
-    name:"upper valid cases{in:\"1.00\",result:\"1.00\"}",
-    statement:"upper('1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1.00\",result:\"1.00\"}",
+    statement: "upper('1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1.00"
+      output: "1.00"
     }
   },
   {
-    name:"upper valid cases{in:\"1.00\",result:\"1.00\"}",
-    statement:"upper('$1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1.00\",result:\"1.00\"}",
+    statement: "upper('$1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"$1.00"
+      output: "$1.00"
     }
   },
   {
-    name:"upper valid cases{in:\"1/2\",result:\"1/2\"}",
-    statement:"upper('1/2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1/2\",result:\"1/2\"}",
+    statement: "upper('1/2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1/2"
+      output: "1/2"
     }
   },
   {
-    name:"upper valid cases{in:\"1E2\",result:\"1E2\"}",
-    statement:"upper('1E2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1E2\",result:\"1E2\"}",
+    statement: "upper('1E2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1E2"
+      output: "1E2"
     }
   },
   {
-    name:"upper valid cases{in:\"1E02\",result:\"1E02\"}",
-    statement:"upper('1E02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1E02\",result:\"1E02\"}",
+    statement: "upper('1E02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1E02"
+      output: "1E02"
     }
   },
   {
-    name:"upper valid cases{in:\"1E+02\",result:\"1E+02\"}",
-    statement:"upper('1E+02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1E+02\",result:\"1E+02\"}",
+    statement: "upper('1E+02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1E+02"
+      output: "1E+02"
     }
   },
   {
-    name:"upper valid cases{in:\"-1\",result:\"-1\"}",
-    statement:"upper('-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-1\",result:\"-1\"}",
+    statement: "upper('-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1"
+      output: "-1"
     }
   },
   {
-    name:"upper valid cases{in:\"-1.00\",result:\"-1.00\"}",
-    statement:"upper('-1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-1.00\",result:\"-1.00\"}",
+    statement: "upper('-1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1.00"
+      output: "-1.00"
     }
   },
   {
-    name:"upper valid cases{in:\"-1.00\",result:\"-1.00\"}",
-    statement:"upper('-$1.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-1.00\",result:\"-1.00\"}",
+    statement: "upper('-$1.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-$1.00"
+      output: "-$1.00"
     }
   },
   {
-    name:"upper valid cases{in:\"-1/2\",result:\"-1/2\"}",
-    statement:"upper('-1/2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-1/2\",result:\"-1/2\"}",
+    statement: "upper('-1/2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1/2"
+      output: "-1/2"
     }
   },
   {
-    name:"upper valid cases{in:\"-1E2\",result:\"-1E2\"}",
-    statement:"upper('-1E2')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-1E2\",result:\"-1E2\"}",
+    statement: "upper('-1E2')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1E2"
+      output: "-1E2"
     }
   },
   {
-    name:"upper valid cases{in:\"-1E02\",result:\"-1E02\"}",
-    statement:"upper('-1E02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-1E02\",result:\"-1E02\"}",
+    statement: "upper('-1E02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1E02"
+      output: "-1E02"
     }
   },
   {
-    name:"upper valid cases{in:\"-1E+02\",result:\"-1E+02\"}",
-    statement:"upper('-1E+02')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-1E+02\",result:\"-1E+02\"}",
+    statement: "upper('-1E+02')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1E+02"
+      output: "-1E+02"
     }
   },
   {
-    name:"upper valid cases{in:\"1/0\",result:\"1/0\"}",
-    statement:"upper('1/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1/0\",result:\"1/0\"}",
+    statement: "upper('1/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1/0"
+      output: "1/0"
     }
   },
   {
-    name:"upper valid cases{in:\"0/0\",result:\"0/0\"}",
-    statement:"upper('0/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0/0\",result:\"0/0\"}",
+    statement: "upper('0/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0/0"
+      output: "0/0"
     }
   },
   {
-    name:"upper valid cases{in:\"-2147483648/-1\",result:\"-2147483648/-1\"}",
-    statement:"upper('-2147483648/-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-2147483648/-1\",result:\"-2147483648/-1\"}",
+    statement: "upper('-2147483648/-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-2147483648/-1"
+      output: "-2147483648/-1"
     }
   },
   {
-    name:"upper valid cases{in:\"-9223372036854775808/-1\",result:\"-9223372036854775808/-1\"}",
-    statement:"upper('-9223372036854775808/-1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-9223372036854775808/-1\",result:\"-9223372036854775808/-1\"}",
+    statement: "upper('-9223372036854775808/-1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-9223372036854775808/-1"
+      output: "-9223372036854775808/-1"
     }
   },
   {
-    name:"upper valid cases{in:\"-0\",result:\"-0\"}",
-    statement:"upper('-0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-0\",result:\"-0\"}",
+    statement: "upper('-0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-0"
+      output: "-0"
     }
   },
   {
-    name:"upper valid cases{in:\"-0.0\",result:\"-0.0\"}",
-    statement:"upper('-0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-0.0\",result:\"-0.0\"}",
+    statement: "upper('-0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-0.0"
+      output: "-0.0"
     }
   },
   {
-    name:"upper valid cases{in:\"+0\",result:\"+0\"}",
-    statement:"upper('+0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"+0\",result:\"+0\"}",
+    statement: "upper('+0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"+0"
+      output: "+0"
     }
   },
   {
-    name:"upper valid cases{in:\"+0.0\",result:\"+0.0\"}",
-    statement:"upper('+0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"+0.0\",result:\"+0.0\"}",
+    statement: "upper('+0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"+0.0"
+      output: "+0.0"
     }
   },
   {
-    name:"upper valid cases{in:\"0.00\",result:\"0.00\"}",
-    statement:"upper('0.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0.00\",result:\"0.00\"}",
+    statement: "upper('0.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0.00"
+      output: "0.00"
     }
   },
   {
-    name:"upper valid cases{in:\"0..0\",result:\"0..0\"}",
-    statement:"upper('0..0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0..0\",result:\"0..0\"}",
+    statement: "upper('0..0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0..0"
+      output: "0..0"
     }
   },
   {
-    name:"upper valid cases{in:\".\",result:\".\"}",
-    statement:"upper('.')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\".\",result:\".\"}",
+    statement: "upper('.')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"."
+      output: "."
     }
   },
   {
-    name:"upper valid cases{in:\"0.0.0\",result:\"0.0.0\"}",
-    statement:"upper('0.0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0.0.0\",result:\"0.0.0\"}",
+    statement: "upper('0.0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0.0.0"
+      output: "0.0.0"
     }
   },
   {
-    name:"upper valid cases{in:\"0,00\",result:\"0,00\"}",
-    statement:"upper('0,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0,00\",result:\"0,00\"}",
+    statement: "upper('0,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0,00"
+      output: "0,00"
     }
   },
   {
-    name:"upper valid cases{in:\"0,,0\",result:\"0,,0\"}",
-    statement:"upper('0,,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0,,0\",result:\"0,,0\"}",
+    statement: "upper('0,,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0,,0"
+      output: "0,,0"
     }
   },
   {
-    name:"upper valid cases{in:\",\",result:\",\"}",
-    statement:"upper(',')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\",\",result:\",\"}",
+    statement: "upper(',')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:","
+      output: ","
     }
   },
   {
-    name:"upper valid cases{in:\"0,0,0\",result:\"0,0,0\"}",
-    statement:"upper('0,0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0,0,0\",result:\"0,0,0\"}",
+    statement: "upper('0,0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0,0,0"
+      output: "0,0,0"
     }
   },
   {
-    name:"upper valid cases{in:\"0.0/0\",result:\"0.0/0\"}",
-    statement:"upper('0.0/0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0.0/0\",result:\"0.0/0\"}",
+    statement: "upper('0.0/0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0.0/0"
+      output: "0.0/0"
     }
   },
   {
-    name:"upper valid cases{in:\"1.0/0.0\",result:\"1.0/0.0\"}",
-    statement:"upper('1.0/0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1.0/0.0\",result:\"1.0/0.0\"}",
+    statement: "upper('1.0/0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1.0/0.0"
+      output: "1.0/0.0"
     }
   },
   {
-    name:"upper valid cases{in:\"0.0/0.0\",result:\"0.0/0.0\"}",
-    statement:"upper('0.0/0.0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0.0/0.0\",result:\"0.0/0.0\"}",
+    statement: "upper('0.0/0.0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0.0/0.0"
+      output: "0.0/0.0"
     }
   },
   {
-    name:"upper valid cases{in:\"1,0/0,0\",result:\"1,0/0,0\"}",
-    statement:"upper('1,0/0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1,0/0,0\",result:\"1,0/0,0\"}",
+    statement: "upper('1,0/0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1,0/0,0"
+      output: "1,0/0,0"
     }
   },
   {
-    name:"upper valid cases{in:\"0,0/0,0\",result:\"0,0/0,0\"}",
-    statement:"upper('0,0/0,0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0,0/0,0\",result:\"0,0/0,0\"}",
+    statement: "upper('0,0/0,0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0,0/0,0"
+      output: "0,0/0,0"
     }
   },
   {
-    name:"upper valid cases{in:\"--1\",result:\"--1\"}",
-    statement:"upper('--1')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"--1\",result:\"--1\"}",
+    statement: "upper('--1')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"--1"
+      output: "--1"
     }
   },
   {
-    name:"upper valid cases{in:\"-\",result:\"-\"}",
-    statement:"upper('-')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-\",result:\"-\"}",
+    statement: "upper('-')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-"
+      output: "-"
     }
   },
   {
-    name:"upper valid cases{in:\"-.\",result:\"-.\"}",
-    statement:"upper('-.')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-.\",result:\"-.\"}",
+    statement: "upper('-.')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-."
+      output: "-."
     }
   },
   {
-    name:"upper valid cases{in:\"-,\",result:\"-,\"}",
-    statement:"upper('-,')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-,\",result:\"-,\"}",
+    statement: "upper('-,')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-,"
+      output: "-,"
     }
   },
   {
-    name:"upper valid cases{in:\"NaN\",result:\"NAN\"}",
-    statement:"upper('NaN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"NaN\",result:\"NAN\"}",
+    statement: "upper('NaN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"NAN"
+      output: "NAN"
     }
   },
   {
-    name:"upper valid cases{in:\"Infinity\",result:\"INFINITY\"}",
-    statement:"upper('Infinity')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"Infinity\",result:\"INFINITY\"}",
+    statement: "upper('Infinity')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"INFINITY"
+      output: "INFINITY"
     }
   },
   {
-    name:"upper valid cases{in:\"-Infinity\",result:\"-INFINITY\"}",
-    statement:"upper('-Infinity')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-Infinity\",result:\"-INFINITY\"}",
+    statement: "upper('-Infinity')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-INFINITY"
+      output: "-INFINITY"
     }
   },
   {
-    name:"upper valid cases{in:\"INF\",result:\"INF\"}",
-    statement:"upper('INF')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"INF\",result:\"INF\"}",
+    statement: "upper('INF')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"INF"
+      output: "INF"
     }
   },
   {
-    name:"upper valid cases{in:\"1#INF\",result:\"1#INF\"}",
-    statement:"upper('1#INF')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1#INF\",result:\"1#INF\"}",
+    statement: "upper('1#INF')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1#INF"
+      output: "1#INF"
     }
   },
   {
-    name:"upper valid cases{in:\"-1#IND\",result:\"-1#IND\"}",
-    statement:"upper('-1#IND')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"-1#IND\",result:\"-1#IND\"}",
+    statement: "upper('-1#IND')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"-1#IND"
+      output: "-1#IND"
     }
   },
   {
-    name:"upper valid cases{in:\"1#QNAN\",result:\"1#QNAN\"}",
-    statement:"upper('1#QNAN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1#QNAN\",result:\"1#QNAN\"}",
+    statement: "upper('1#QNAN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1#QNAN"
+      output: "1#QNAN"
     }
   },
   {
-    name:"upper valid cases{in:\"1#SNAN\",result:\"1#SNAN\"}",
-    statement:"upper('1#SNAN')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1#SNAN\",result:\"1#SNAN\"}",
+    statement: "upper('1#SNAN')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1#SNAN"
+      output: "1#SNAN"
     }
   },
   {
-    name:"upper valid cases{in:\"1#IND\",result:\"1#IND\"}",
-    statement:"upper('1#IND')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1#IND\",result:\"1#IND\"}",
+    statement: "upper('1#IND')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1#IND"
+      output: "1#IND"
     }
   },
   {
-    name:"upper valid cases{in:\"0x0\",result:\"0X0\"}",
-    statement:"upper('0x0')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0x0\",result:\"0X0\"}",
+    statement: "upper('0x0')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0X0"
+      output: "0X0"
     }
   },
   {
-    name:"upper valid cases{in:\"0xffffffff\",result:\"0XFFFFFFFF\"}",
-    statement:"upper('0xffffffff')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0xffffffff\",result:\"0XFFFFFFFF\"}",
+    statement: "upper('0xffffffff')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0XFFFFFFFF"
+      output: "0XFFFFFFFF"
     }
   },
   {
-    name:"upper valid cases{in:\"0xffffffffffffffff\",result:\"0XFFFFFFFFFFFFFFFF\"}",
-    statement:"upper('0xffffffffffffffff')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0xffffffffffffffff\",result:\"0XFFFFFFFFFFFFFFFF\"}",
+    statement: "upper('0xffffffffffffffff')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0XFFFFFFFFFFFFFFFF"
+      output: "0XFFFFFFFFFFFFFFFF"
     }
   },
   {
-    name:"upper valid cases{in:\"0xabad1dea\",result:\"0XABAD1DEA\"}",
-    statement:"upper('0xabad1dea')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0xabad1dea\",result:\"0XABAD1DEA\"}",
+    statement: "upper('0xabad1dea')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0XABAD1DEA"
+      output: "0XABAD1DEA"
     }
   },
   {
-    name:"upper valid cases{in:\"1,000.00\",result:\"1,000.00\"}",
-    statement:"upper('1,000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1,000.00\",result:\"1,000.00\"}",
+    statement: "upper('1,000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1,000.00"
+      output: "1,000.00"
     }
   },
   {
-    name:"upper valid cases{in:\"1 000.00\",result:\"1 000.00\"}",
-    statement:"upper('1 000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1 000.00\",result:\"1 000.00\"}",
+    statement: "upper('1 000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1 000.00"
+      output: "1 000.00"
     }
   },
   {
-    name:"upper valid cases{in:\"1,000,000.00\",result:\"1,000,000.00\"}",
-    statement:"upper('1,000,000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1,000,000.00\",result:\"1,000,000.00\"}",
+    statement: "upper('1,000,000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1,000,000.00"
+      output: "1,000,000.00"
     }
   },
   {
-    name:"upper valid cases{in:\"1 000 000.00\",result:\"1 000 000.00\"}",
-    statement:"upper('1 000 000.00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1 000 000.00\",result:\"1 000 000.00\"}",
+    statement: "upper('1 000 000.00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1 000 000.00"
+      output: "1 000 000.00"
     }
   },
   {
-    name:"upper valid cases{in:\"1.000,00\",result:\"1.000,00\"}",
-    statement:"upper('1.000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1.000,00\",result:\"1.000,00\"}",
+    statement: "upper('1.000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1.000,00"
+      output: "1.000,00"
     }
   },
   {
-    name:"upper valid cases{in:\"1 000,00\",result:\"1 000,00\"}",
-    statement:"upper('1 000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1 000,00\",result:\"1 000,00\"}",
+    statement: "upper('1 000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1 000,00"
+      output: "1 000,00"
     }
   },
   {
-    name:"upper valid cases{in:\"1.000.000,00\",result:\"1.000.000,00\"}",
-    statement:"upper('1.000.000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1.000.000,00\",result:\"1.000.000,00\"}",
+    statement: "upper('1.000.000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1.000.000,00"
+      output: "1.000.000,00"
     }
   },
   {
-    name:"upper valid cases{in:\"1 000 000,00\",result:\"1 000 000,00\"}",
-    statement:"upper('1 000 000,00')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"1 000 000,00\",result:\"1 000 000,00\"}",
+    statement: "upper('1 000 000,00')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"1 000 000,00"
+      output: "1 000 000,00"
     }
   },
   {
-    name:"upper valid cases{in:\"01000\",result:\"01000\"}",
-    statement:"upper('01000')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"01000\",result:\"01000\"}",
+    statement: "upper('01000')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"01000"
+      output: "01000"
     }
   },
   {
-    name:"upper valid cases{in:\"08\",result:\"08\"}",
-    statement:"upper('08')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"08\",result:\"08\"}",
+    statement: "upper('08')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"08"
+      output: "08"
     }
   },
   {
-    name:"upper valid cases{in:\"09\",result:\"09\"}",
-    statement:"upper('09')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"09\",result:\"09\"}",
+    statement: "upper('09')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"09"
+      output: "09"
     }
   },
   {
-    name:"upper valid cases{in:\"2.2250738585072011e-308\",result:\"2.2250738585072011E-308\"}",
-    statement:"upper('2.2250738585072011e-308')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"2.2250738585072011e-308\",result:\"2.2250738585072011E-308\"}",
+    statement: "upper('2.2250738585072011e-308')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"2.2250738585072011E-308"
+      output: "2.2250738585072011E-308"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\"}",
-    statement:"upper('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\"}",
+    statement: "upper('ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ"
+      output: "ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ"
     }
   },
   {
-    name:"upper valid cases{in:\"<>?:\\\"{}|_+\",result:\"<>?:\\\"{}|_+\"}",
-    statement:"upper('<>?:\"{}|_+')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"<>?:\\\"{}|_+\",result:\"<>?:\\\"{}|_+\"}",
+    statement: "upper('<>?:\"{}|_+')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"<>?:\"{}|_+"
+      output: "<>?:\"{}|_+"
     }
   },
   {
-    name:"upper valid cases{in:\"!@#%^&*()`~\",result:\"!@#%^&*()`~\"}",
-    statement:"upper('!@#$%^&*()`~')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"!@#%^&*()`~\",result:\"!@#%^&*()`~\"}",
+    statement: "upper('!@#$%^&*()`~')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"!@#$%^&*()`~"
+      output: "!@#$%^&*()`~"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u03a9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\",result:\"\\u03a9\\u2248\\xc7\\u221a\\u222b\\u02dc\\u039c\\u2264\\u2265\\xf7\"}",
-    statement:"upper('Ω≈ç√∫˜µ≤≥÷')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u03a9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\",result:\"\\u03a9\\u2248\\xc7\\u221a\\u222b\\u02dc\\u039c\\u2264\\u2265\\xf7\"}",
+    statement: "upper('Ω≈ç√∫˜µ≤≥÷')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"Ω≈Ç√∫˜Μ≤≥÷"
+      output: "Ω≈Ç√∫˜Μ≤≥÷"
     }
   },
   {
-    name:"upper valid cases{in:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\",result:\"\\xc5SS\\u2202\\u0191\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xc6\"}",
-    statement:"upper('åß∂ƒ©˙∆˚¬…æ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\",result:\"\\xc5SS\\u2202\\u0191\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xc6\"}",
+    statement: "upper('åß∂ƒ©˙∆˚¬…æ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ÅSS∂Ƒ©˙∆˚¬…Æ"
+      output: "ÅSS∂Ƒ©˙∆˚¬…Æ"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\",result:\"\\u0152\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xd8\\u03a0\\u201c\\u2018\"}",
-    statement:"upper('œ∑´®†¥¨ˆøπ“‘')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\",result:\"\\u0152\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xd8\\u03a0\\u201c\\u2018\"}",
+    statement: "upper('œ∑´®†¥¨ˆøπ“‘')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"Œ∑´®†¥¨ˆØΠ“‘"
+      output: "Œ∑´®†¥¨ˆØΠ“‘"
     }
   },
   {
-    name:"upper valid cases{in:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\",result:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\"}",
-    statement:"upper('¡™£¢∞§¶•ªº–≠')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\",result:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\"}",
+    statement: "upper('¡™£¢∞§¶•ªº–≠')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"¡™£¢∞§¶•ªº–≠"
+      output: "¡™£¢∞§¶•ªº–≠"
     }
   },
   {
-    name:"upper valid cases{in:\"\\xb8\\u02db\\xc7\\u25ca\\u0131\\u02dc\\xc2\\xaf\\u02d8\\xbf\",result:\"\\xb8\\u02db\\xc7\\u25caI\\u02dc\\xc2\\xaf\\u02d8\\xbf\"}",
-    statement:"upper('¸˛Ç◊ı˜Â¯˘¿')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\xb8\\u02db\\xc7\\u25ca\\u0131\\u02dc\\xc2\\xaf\\u02d8\\xbf\",result:\"\\xb8\\u02db\\xc7\\u25caI\\u02dc\\xc2\\xaf\\u02d8\\xbf\"}",
+    statement: "upper('¸˛Ç◊ı˜Â¯˘¿')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"¸˛Ç◊I˜Â¯˘¿"
+      output: "¸˛Ç◊I˜Â¯˘¿"
     }
   },
   {
-    name:"upper valid cases{in:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\",result:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\"}",
-    statement:"upper('ÅÍÎÏ˝ÓÔÒÚÆ☃')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\",result:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\"}",
+    statement: "upper('ÅÍÎÏ˝ÓÔÒÚÆ☃')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ÅÍÎÏ˝ÓÔÒÚÆ☃"
+      output: "ÅÍÎÏ˝ÓÔÒÚÆ☃"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\",result:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\"}",
-    statement:"upper('Œ„´‰ˇÁ¨ˆØ∏”’')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\",result:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\"}",
+    statement: "upper('Œ„´‰ˇÁ¨ˆØ∏”’')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"Œ„´‰ˇÁ¨ˆØ∏”’"
+      output: "Œ„´‰ˇÁ¨ˆØ∏”’"
     }
   },
   {
-    name:"upper valid cases{in:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\",result:\"`\\u2044\\u20ac\\u2039\\u203aFIFL\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\"}",
-    statement:"upper('`⁄€‹›ﬁﬂ‡°·‚—±')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\",result:\"`\\u2044\\u20ac\\u2039\\u203aFIFL\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\"}",
+    statement: "upper('`⁄€‹›ﬁﬂ‡°·‚—±')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"`⁄€‹›FIFL‡°·‚—±"
+      output: "`⁄€‹›FIFL‡°·‚—±"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u215b\\u215c\\u215d\\u215e\",result:\"\\u215b\\u215c\\u215d\\u215e\"}",
-    statement:"upper('⅛⅜⅝⅞')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u215b\\u215c\\u215d\\u215e\",result:\"\\u215b\\u215c\\u215d\\u215e\"}",
+    statement: "upper('⅛⅜⅝⅞')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"⅛⅜⅝⅞"
+      output: "⅛⅜⅝⅞"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\",result:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\"}",
-    statement:"upper('٠١٢٣٤٥٦٧٨٩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\",result:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\"}",
+    statement: "upper('٠١٢٣٤٥٦٧٨٩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"٠١٢٣٤٥٦٧٨٩"
+      output: "٠١٢٣٤٥٦٧٨٩"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\",result:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\"}",
-    statement:"upper('田中さんにあげて下さい')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\",result:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\"}",
+    statement: "upper('田中さんにあげて下さい')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"田中さんにあげて下さい"
+      output: "田中さんにあげて下さい"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\",result:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\"}",
-    statement:"upper('パーティーへ行かないか')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\",result:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\"}",
+    statement: "upper('パーティーへ行かないか')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"パーティーへ行かないか"
+      output: "パーティーへ行かないか"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u548c\\u88fd\\u6f22\\u8a9e\",result:\"\\u548c\\u88fd\\u6f22\\u8a9e\"}",
-    statement:"upper('和製漢語')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u548c\\u88fd\\u6f22\\u8a9e\",result:\"\\u548c\\u88fd\\u6f22\\u8a9e\"}",
+    statement: "upper('和製漢語')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"和製漢語"
+      output: "和製漢語"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u90e8\\u843d\\u683c\",result:\"\\u90e8\\u843d\\u683c\"}",
-    statement:"upper('部落格')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u90e8\\u843d\\u683c\",result:\"\\u90e8\\u843d\\u683c\"}",
+    statement: "upper('部落格')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"部落格"
+      output: "部落格"
     }
   },
   {
-    name:"upper valid cases{in:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\",result:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\"}",
-    statement:"upper('사회과학원 어학연구소')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\",result:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\"}",
+    statement: "upper('사회과학원 어학연구소')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"사회과학원 어학연구소"
+      output: "사회과학원 어학연구소"
     }
   },
   {
-    name:"upper valid cases{in:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\",result:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\"}",
-    statement:"upper('찦차를 타고 온 펲시맨과 쑛다리 똠방각하')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\",result:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\"}",
+    statement: "upper('찦차를 타고 온 펲시맨과 쑛다리 똠방각하')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"찦차를 타고 온 펲시맨과 쑛다리 똠방각하"
+      output: "찦차를 타고 온 펲시맨과 쑛다리 똠방각하"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\",result:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\"}",
-    statement:"upper('社會科學院語學研究所')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\",result:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\"}",
+    statement: "upper('社會科學院語學研究所')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"社會科學院語學研究所"
+      output: "社會科學院語學研究所"
     }
   },
   {
-    name:"upper valid cases{in:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\",result:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\"}",
-    statement:"upper('울란바토르')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\",result:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\"}",
+    statement: "upper('울란바토르')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"울란바토르"
+      output: "울란바토르"
     }
   },
   {
-    name:"upper valid cases{in:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\",result:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\"}",
-    statement:"upper('𠜎𠜱𠝹𠱓𠱸𠲖𠳏')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\",result:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\"}",
+    statement: "upper('𠜎𠜱𠝹𠱓𠱸𠲖𠳏')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"𠜎𠜱𠝹𠱓𠱸𠲖𠳏"
+      output: "𠜎𠜱𠝹𠱓𠱸𠲖𠳏"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u023a\",result:\"\\u023a\"}",
-    statement:"upper('Ⱥ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u023a\",result:\"\\u023a\"}",
+    statement: "upper('Ⱥ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"Ⱥ"
+      output: "Ⱥ"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u023e\",result:\"\\u023e\"}",
-    statement:"upper('Ⱦ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u023e\",result:\"\\u023e\"}",
+    statement: "upper('Ⱦ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"Ⱦ"
+      output: "Ⱦ"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\",result:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\"}",
-    statement:"upper('ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\",result:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89\"}",
+    statement: "upper('ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ"
+      output: "ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ"
     }
   },
   {
-    name:"upper valid cases{in:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\",result:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\"}",
-    statement:"upper('(｡◕ ∀ ◕｡)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\",result:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\"}",
+    statement: "upper('(｡◕ ∀ ◕｡)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"(｡◕ ∀ ◕｡)"
+      output: "(｡◕ ∀ ◕｡)"
     }
   },
   {
-    name:"upper valid cases{in:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\",result:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\"}",
-    statement:"upper('｀ｨ(´∀｀∩')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\",result:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\"}",
+    statement: "upper('｀ｨ(´∀｀∩')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"｀ｨ(´∀｀∩"
+      output: "｀ｨ(´∀｀∩"
     }
   },
   {
-    name:"upper valid cases{in:\"__\\uff9b(,_,*)\",result:\"__\\uff9b(,_,*)\"}",
-    statement:"upper('__ﾛ(,_,*)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"__\\uff9b(,_,*)\",result:\"__\\uff9b(,_,*)\"}",
+    statement: "upper('__ﾛ(,_,*)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"__ﾛ(,_,*)"
+      output: "__ﾛ(,_,*)"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\",result:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\"}",
-    statement:"upper('・(￣∀￣)・:*:')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\",result:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\"}",
+    statement: "upper('・(￣∀￣)・:*:')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"・(￣∀￣)・:*:"
+      output: "・(￣∀￣)・:*:"
     }
   },
   {
-    name:"upper valid cases{in:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\",result:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\"}",
-    statement:"upper('ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\",result:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\"}",
+    statement: "upper('ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ"
+      output: "ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ"
     }
   },
   {
-    name:"upper valid cases{in:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\",result:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03a9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\"}",
-    statement:"upper(',。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\",result:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03a9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\"}",
+    statement: "upper(',。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:",。・:*:・゜’( ☻ Ω ☻ )。・:*:・゜’"
+      output: ",。・:*:・゜’( ☻ Ω ☻ )。・:*:・゜’"
     }
   },
   {
-    name:"upper valid cases{in:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\",result:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\"}",
-    statement:"upper('(╯°□°）╯︵ ┻━┻)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\",result:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\"}",
+    statement: "upper('(╯°□°）╯︵ ┻━┻)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"(╯°□°）╯︵ ┻━┻)"
+      output: "(╯°□°）╯︵ ┻━┻)"
     }
   },
   {
-    name:"upper valid cases{in:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\",result:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\"}",
-    statement:"upper('(ﾉಥ益ಥ）ﾉ﻿ ┻━┻')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\",result:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\"}",
+    statement: "upper('(ﾉಥ益ಥ）ﾉ﻿ ┻━┻')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"(ﾉಥ益ಥ）ﾉ﻿ ┻━┻"
+      output: "(ﾉಥ益ಥ）ﾉ﻿ ┻━┻"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\"}",
-    statement:"upper('┬─┬ノ( º _ ºノ)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\",result:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\"}",
+    statement: "upper('┬─┬ノ( º _ ºノ)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"┬─┬ノ( º _ ºノ)"
+      output: "┬─┬ノ( º _ ºノ)"
     }
   },
   {
-    name:"upper valid cases{in:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\",result:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\"}",
-    statement:"upper('( ͡° ͜ʖ ͡°)')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\",result:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\"}",
+    statement: "upper('( ͡° ͜ʖ ͡°)')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"( ͡° ͜ʖ ͡°)"
+      output: "( ͡° ͜ʖ ͡°)"
     }
   },
   {
-    name:"upper valid cases{in:\"\\U0001f60d\",result:\"\\U0001f60d\"}",
-    statement:"upper('😍')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\U0001f60d\",result:\"\\U0001f60d\"}",
+    statement: "upper('😍')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"😍"
+      output: "😍"
     }
   },
   {
-    name:"upper valid cases{in:\"\\U0001f469\\U0001f3fd\",result:\"\\U0001f469\\U0001f3fd\"}",
-    statement:"upper('👩🏽')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\U0001f469\\U0001f3fd\",result:\"\\U0001f469\\U0001f3fd\"}",
+    statement: "upper('👩🏽')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"👩🏽"
+      output: "👩🏽"
     }
   },
   {
-    name:"upper valid cases{in:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\",result:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\"}",
-    statement:"upper('👾 🙇 💁 🙅 🙆 🙋 🙎 🙍')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\",result:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\"}",
+    statement: "upper('👾 🙇 💁 🙅 🙆 🙋 🙎 🙍')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"👾 🙇 💁 🙅 🙆 🙋 🙎 🙍"
+      output: "👾 🙇 💁 🙅 🙆 🙋 🙎 🙍"
     }
   },
   {
-    name:"upper valid cases{in:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\",result:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\"}",
-    statement:"upper('🐵 🙈 🙉 🙊')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\",result:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\"}",
+    statement: "upper('🐵 🙈 🙉 🙊')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🐵 🙈 🙉 🙊"
+      output: "🐵 🙈 🙉 🙊"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\",result:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\"}",
-    statement:"upper('❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\",result:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\"}",
+    statement: "upper('❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙"
+      output: "❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙"
     }
   },
   {
-    name:"upper valid cases{in:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\",result:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\"}",
-    statement:"upper('✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\",result:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\"}",
+    statement: "upper('✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿"
+      output: "✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿"
     }
   },
   {
-    name:"upper valid cases{in:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\",result:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\"}",
-    statement:"upper('🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\",result:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\"}",
+    statement: "upper('🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧"
+      output: "🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧"
     }
   },
   {
-    name:"upper valid cases{in:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\",result:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\"}",
-    statement:"upper('0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\",result:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\"}",
+    statement: "upper('0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟"
+      output: "0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟"
     }
   },
   {
-    name:"upper valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\"}",
-    statement:"upper('🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\"}",
+    statement: "upper('🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
+      output: "🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
     }
   },
   {
-    name:"upper valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\"}",
-    statement:"upper('🇺🇸🇷🇺🇸🇦🇫🇦🇲')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\"}",
+    statement: "upper('🇺🇸🇷🇺🇸🇦🇫🇦🇲')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🇺🇸🇷🇺🇸🇦🇫🇦🇲"
+      output: "🇺🇸🇷🇺🇸🇦🇫🇦🇲"
     }
   },
   {
-    name:"upper valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\"}",
-    statement:"upper('🇺🇸🇷🇺🇸🇦')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\",result:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\"}",
+    statement: "upper('🇺🇸🇷🇺🇸🇦')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"🇺🇸🇷🇺🇸🇦"
+      output: "🇺🇸🇷🇺🇸🇦"
     }
   },
   {
-    name:"upper valid cases{in:\"\\uff34\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff2f\\uff36\\uff25\\uff32 \\uff34\\uff28\\uff25 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\",result:\"\\uff34\\uff28\\uff25 \\uff31\\uff35\\uff29\\uff23\\uff2b \\uff22\\uff32\\uff2f\\uff37\\uff2e \\uff26\\uff2f\\uff38 \\uff2a\\uff35\\uff2d\\uff30\\uff33 \\uff2f\\uff36\\uff25\\uff32 \\uff34\\uff28\\uff25 \\uff2c\\uff21\\uff3a\\uff39 \\uff24\\uff2f\\uff27\"}",
-    statement:"upper('Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ＯＶＥＲ ＴＨＥ ｌａｚｙ ｄｏｇ')",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper valid cases{in:\"\\uff34\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff2f\\uff36\\uff25\\uff32 \\uff34\\uff28\\uff25 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\",result:\"\\uff34\\uff28\\uff25 \\uff31\\uff35\\uff29\\uff23\\uff2b \\uff22\\uff32\\uff2f\\uff37\\uff2e \\uff26\\uff2f\\uff38 \\uff2a\\uff35\\uff2d\\uff30\\uff33 \\uff2f\\uff36\\uff25\\uff32 \\uff34\\uff28\\uff25 \\uff2c\\uff21\\uff3a\\uff39 \\uff24\\uff2f\\uff27\"}",
+    statement: "upper('Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ＯＶＥＲ ＴＨＥ ｌａｚｙ ｄｏｇ')",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ＴＨＥ ＱＵＩＣＫ ＢＲＯＷＮ ＦＯＸ ＪＵＭＰＳ ＯＶＥＲ ＴＨＥ ＬＡＺＹ ＤＯＧ"
+      output: "ＴＨＥ ＱＵＩＣＫ ＢＲＯＷＮ ＦＯＸ ＪＵＭＰＳ ＯＶＥＲ ＴＨＥ ＬＡＺＹ ＤＯＧ"
     }
   },
   {
-    name:"upper null and missing propagation{param:\"null\"}",
-    statement:"upper(null)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "upper null and missing propagation{param:\"null\"}",
+    statement: "upper(null)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"upper null and missing propagation{param:\"missing\"}",
-    statement:"upper(missing)",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+    name: "upper null and missing propagation{param:\"missing\"}",
+    statement: "upper(missing)",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
   },
 ]

--- a/partiql-tests-data/eval/primitives/operators/concat.ion
+++ b/partiql-tests-data/eval/primitives/operators/concat.ion
@@ -1,146 +1,165 @@
 concat::[
   {
-    name:"|| valid cases{lparam:\"'a'\",rparam:\"'b'\",result:\"ab\"}",
-    statement:"'a' || 'b'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"'a'\",rparam:\"'b'\",result:\"ab\"}",
+    statement: "'a' || 'b'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ab"
+      output: "ab"
     }
   },
   {
-    name:"|| valid cases{lparam:\"`'a'`\",rparam:\"`'b'`\",result:\"ab\"}",
-    statement:"`'a'` || `'b'`",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"`'a'`\",rparam:\"`'b'`\",result:\"ab\"}",
+    statement: "`'a'` || `'b'`",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ab"
+      output: "ab"
     }
   },
   {
-    name:"|| valid cases{lparam:\"`'a'`\",rparam:\"'b'\",result:\"ab\"}",
-    statement:"`'a'` || 'b'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"`'a'`\",rparam:\"'b'\",result:\"ab\"}",
+    statement: "`'a'` || 'b'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ab"
+      output: "ab"
     }
   },
   {
-    name:"|| valid cases{lparam:\"'a'\",rparam:\"`'b'`\",result:\"ab\"}",
-    statement:"'a' || `'b'`",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"'a'\",rparam:\"`'b'`\",result:\"ab\"}",
+    statement: "'a' || `'b'`",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:"ab"
+      output: "ab"
     }
   },
   {
-    name:"|| valid cases{lparam:\"null\",rparam:\"'b'\",result:null}",
-    statement:"null || 'b'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"null\",rparam:\"'b'\",result:null}",
+    statement: "null || 'b'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"|| valid cases{lparam:\"'a'\",rparam:\"null\",result:null}",
-    statement:"'a' || null",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"'a'\",rparam:\"null\",result:null}",
+    statement: "'a' || null",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"|| valid cases{lparam:\"null\",rparam:\"null\",result:null}",
-    statement:"null || null",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"null\",rparam:\"null\",result:null}",
+    statement: "null || null",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"|| valid cases{lparam:\"null\",rparam:\"missing\",result:missing::null}",
-    statement:"null || missing",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"null\",rparam:\"missing\",result:missing::null}",
+    statement: "null || missing",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
         EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
   },
   {
-    name:"|| valid cases{lparam:\"missing\",rparam:\"null\",result:missing::null}",
-    statement:"missing || null",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"missing\",rparam:\"null\",result:missing::null}",
+    statement: "missing || null",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
         EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
   },
   {
-    name:"|| valid cases{lparam:\"missing\",rparam:\"'b'\",result:missing::null}",
-    statement:"missing || 'b'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+    name: "|| valid cases{lparam:\"missing\",rparam:\"'b'\",result:missing::null}",
+    statement: "missing || 'b'",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
   },
   {
-    name:"|| valid cases{lparam:\"'a'\",rparam:\"missing\",result:missing::null}",
-    statement:"'a' || missing",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"'a'\",rparam:\"missing\",result:missing::null}",
+    statement: "'a' || missing",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
         EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
   },
   {
-    name:"|| valid cases{lparam:\"missing\",rparam:\"missing\",result:missing::null}",
-    statement:"missing || missing",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "|| valid cases{lparam:\"missing\",rparam:\"missing\",result:missing::null}",
+    statement: "missing || missing",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
         EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
   }
 ]

--- a/partiql-tests-data/eval/primitives/operators/like.ion
+++ b/partiql-tests-data/eval/primitives/operators/like.ion
@@ -1,1590 +1,1546 @@
 like::[
   envs::{
-    course:[
+    course: [
       {
-        sid:"S1",
-        grade:"90%"
+        sid: "S1",
+        grade: "90%"
       },
       {
-        sid:"S2",
-        grade:"80%"
+        sid: "S2",
+        grade: "80%"
       }
     ]
   },
   {
-    name:"null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE null ESCAPE null \"}",
-    statement:"SELECT * FROM course AS d WHERE null LIKE null ESCAPE null",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE null ESCAPE null \"}",
+    statement: "SELECT * FROM course AS d WHERE null LIKE null ESCAPE null",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"null value on any of the 3 inputs returns false{likeExpr:\" d.sid LIKE null ESCAPE null \"}",
-    statement:"SELECT * FROM course AS d WHERE d.sid LIKE null ESCAPE null",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "null value on any of the 3 inputs returns false{likeExpr:\" d.sid LIKE null ESCAPE null \"}",
+    statement: "SELECT * FROM course AS d WHERE d.sid LIKE null ESCAPE null",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE 'S1' ESCAPE null \"}",
-    statement:"SELECT * FROM course AS d WHERE null LIKE 'S1' ESCAPE null",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE 'S1' ESCAPE null \"}",
+    statement: "SELECT * FROM course AS d WHERE null LIKE 'S1' ESCAPE null",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE null ESCAPE '['  \"}",
-    statement:"SELECT * FROM course AS d WHERE null LIKE null ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE null ESCAPE '['  \"}",
+    statement: "SELECT * FROM course AS d WHERE null LIKE null ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE 'S1' ESCAPE '['  \"}",
-    statement:"SELECT * FROM course AS d WHERE null LIKE 'S1' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE 'S1' ESCAPE '['  \"}",
+    statement: "SELECT * FROM course AS d WHERE null LIKE 'S1' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"null value on any of the 3 inputs returns false{likeExpr:\" d.sid LIKE null ESCAPE '['  \"}",
-    statement:"SELECT * FROM course AS d WHERE d.sid LIKE null ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "null value on any of the 3 inputs returns false{likeExpr:\" d.sid LIKE null ESCAPE '['  \"}",
+    statement: "SELECT * FROM course AS d WHERE d.sid LIKE null ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"null value on any of the 3 inputs returns false{likeExpr:\" d.sid LIKE 'S1' ESCAPE null \"}",
-    statement:"SELECT * FROM course AS d WHERE d.sid LIKE 'S1' ESCAPE null",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "null value on any of the 3 inputs returns false{likeExpr:\" d.sid LIKE 'S1' ESCAPE null \"}",
+    statement: "SELECT * FROM course AS d WHERE d.sid LIKE 'S1' ESCAPE null",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE null \"}",
-    statement:"SELECT * FROM course AS d WHERE null LIKE null",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE null \"}",
+    statement: "SELECT * FROM course AS d WHERE null LIKE null",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"null value on any of the 3 inputs returns false{likeExpr:\" d.sid LIKE null \"}",
-    statement:"SELECT * FROM course AS d WHERE d.sid LIKE null",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "null value on any of the 3 inputs returns false{likeExpr:\" d.sid LIKE null \"}",
+    statement: "SELECT * FROM course AS d WHERE d.sid LIKE null",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE 'S1' \"}",
-    statement:"SELECT * FROM course AS d WHERE null LIKE 'S1'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "null value on any of the 3 inputs returns false{likeExpr:\" null  LIKE 'S1' \"}",
+    statement: "SELECT * FROM course AS d WHERE null LIKE 'S1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" ''    LIKE null \",result:(bag)}",
-    statement:"SELECT * FROM course AS d WHERE '' LIKE null",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" ''    LIKE null \",result:(bag)}",
+    statement: "SELECT * FROM course AS d WHERE '' LIKE null",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" null  LIKE ''   \",result:(bag)}",
-    statement:"SELECT * FROM course AS d WHERE null LIKE ''",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" null  LIKE ''   \",result:(bag)}",
+    statement: "SELECT * FROM course AS d WHERE null LIKE ''",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" d.sid LIKE ''   \",result:(bag)}",
-    statement:"SELECT * FROM course AS d WHERE d.sid LIKE ''",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" d.sid LIKE ''   \",result:(bag)}",
+    statement: "SELECT * FROM course AS d WHERE d.sid LIKE ''",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" ''    LIKE 'S1' \",result:(bag)}",
-    statement:"SELECT * FROM course AS d WHERE '' LIKE 'S1'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" ''    LIKE 'S1' \",result:(bag)}",
+    statement: "SELECT * FROM course AS d WHERE '' LIKE 'S1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" ''    LIKE '_'  \",result:(bag)}",
-    statement:"SELECT * FROM course AS d WHERE '' LIKE '_'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" ''    LIKE '_'  \",result:(bag)}",
+    statement: "SELECT * FROM course AS d WHERE '' LIKE '_'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" ''    LIKE '%' \",result:(bag {sid:\"S1\",grade:\"90%\"} {sid:\"S2\",grade:\"80%\"})}",
-    statement:"SELECT * FROM course AS d WHERE '' LIKE '%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" ''    LIKE '%' \",result:(bag {sid:\"S1\",grade:\"90%\"} {sid:\"S2\",grade:\"80%\"})}",
+    statement: "SELECT * FROM course AS d WHERE '' LIKE '%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          sid:"S1",
-          grade:"90%"
+          sid: "S1",
+          grade: "90%"
         },
         {
-          sid:"S2",
-          grade:"80%"
+          sid: "S2",
+          grade: "80%"
         }
       ]
     }
   },
   {
-    name:"empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" ''    LIKE '' \",result:(bag {sid:\"S1\",grade:\"90%\"} {sid:\"S2\",grade:\"80%\"})}",
-    statement:"SELECT * FROM course AS d WHERE '' LIKE ''",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "empty string value on any of the 2 inputs (text and/or pattern){likeExpr:\" ''    LIKE '' \",result:(bag {sid:\"S1\",grade:\"90%\"} {sid:\"S2\",grade:\"80%\"})}",
+    statement: "SELECT * FROM course AS d WHERE '' LIKE ''",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          sid:"S1",
-          grade:"90%"
+          sid: "S1",
+          grade: "90%"
         },
         {
-          sid:"S2",
-          grade:"80%"
+          sid: "S2",
+          grade: "80%"
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" '_'         \",pattern:\" '_'          \"}",
-    statement:"SELECT * FROM `[true]` WHERE '_' LIKE '_'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" '_'         \",pattern:\" '_'          \"}",
+    statement: "SELECT * FROM `[true]` WHERE '_' LIKE '_'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" '_'         \",pattern:\" '%'          \"}",
-    statement:"SELECT * FROM `[true]` WHERE '_' LIKE '%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" '_'         \",pattern:\" '%'          \"}",
+    statement: "SELECT * FROM `[true]` WHERE '_' LIKE '%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" '%'         \",pattern:\" '_'          \"}",
-    statement:"SELECT * FROM `[true]` WHERE '%' LIKE '_'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" '%'         \",pattern:\" '_'          \"}",
+    statement: "SELECT * FROM `[true]` WHERE '%' LIKE '_'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" '%'         \",pattern:\" '%'          \"}",
-    statement:"SELECT * FROM `[true]` WHERE '%' LIKE '%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" '%'         \",pattern:\" '%'          \"}",
+    statement: "SELECT * FROM `[true]` WHERE '%' LIKE '%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'A'         \",pattern:\" 'A'          \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'A' LIKE 'A'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'A'         \",pattern:\" 'A'          \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'A' LIKE 'A'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" '\\\\'        \",pattern:\" '\\\\'         \"}",
-    statement:"SELECT * FROM `[true]` WHERE '\\' LIKE '\\'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" '\\\\'        \",pattern:\" '\\\\'         \"}",
+    statement: "SELECT * FROM `[true]` WHERE '\\' LIKE '\\'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" ''        \",pattern:\" ''         \"}",
-    statement:"SELECT * FROM `[true]` WHERE '$$' LIKE '$$'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" ''        \",pattern:\" ''         \"}",
+    statement: "SELECT * FROM `[true]` WHERE '$$' LIKE '$$'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '_BC'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '_BC'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '_BC'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '_BC'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'A_C'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A_C'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'A_C'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A_C'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'AB_'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'AB_'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'AB_'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'AB_'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '___'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '___'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '___'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '___'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'A__'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A__'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'A__'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A__'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '__C'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '__C'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '__C'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '__C'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%'          \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%'          \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%%%%'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '%%%%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%%%%'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '%%%%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%ABC'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '%ABC'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%ABC'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '%ABC'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%BC'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '%BC'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%BC'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '%BC'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%C'         \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '%C'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%C'         \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '%C'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'ABC%'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'ABC%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'ABC%'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'ABC%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'AB%'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'AB%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'AB%'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'AB%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'A%'         \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'A%'         \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'A%%%'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A%%%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'A%%%'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A%%%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'A%C'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A%C'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" 'A%C'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A%C'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%c'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%c'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%c'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%c'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%B%c'      \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%B%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%B%c'      \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%B%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%B%%c'    \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%B%%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%B%%c'    \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%B%%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%A%c'      \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%A%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%A%c'      \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%A%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%%A%%%%c' \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%%A%%%%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%%A%%%%c' \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%%A%%%%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%Aa%c'     \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%Aa%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%Aa%c'     \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%Aa%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" '%B%C%'      \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE '%B%C%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" '%B%C%'      \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE '%B%C%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" '%B%C%%'     \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE '%B%C%%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" '%B%C%%'     \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE '%B%C%%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" '%bC%'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE '%bC%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" '%bC%'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE '%bC%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" '%b%C%'      \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE '%b%C%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" '%b%C%'      \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE '%b%C%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%_%_%_%'    \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '%_%_%_%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%_%_%_%'    \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '%_%_%_%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '_%_%_%'     \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '_%_%_%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '_%_%_%'     \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '_%_%_%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%_%_%_'     \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '%_%_%_'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '%_%_%_'     \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '%_%_%_'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '_%_%_'      \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '_%_%_'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '_%_%_'      \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '_%_%_'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '_%%_%%%_'   \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '_%%_%%%_'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '_%%_%%%_'   \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '_%%_%%%_'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '_%%B%%%_'   \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '_%%B%%%_'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'ABC'       \",pattern:\" '_%%B%%%_'   \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '_%%B%%%_'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" '%__b%C_%'   \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE '%__b%C_%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that match{text:\" 'AAaBBbCCc' \",pattern:\" '%__b%C_%'   \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE '%__b%C_%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'A'         \",pattern:\" 'a'          \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'A' LIKE 'a'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'A'         \",pattern:\" 'a'          \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'A' LIKE 'a'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" '\\\\'        \",pattern:\" '/'         \"}",
-    statement:"SELECT * FROM `[true]` WHERE '\\' LIKE '/'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" '\\\\'        \",pattern:\" '/'         \"}",
+    statement: "SELECT * FROM `[true]` WHERE '\\' LIKE '/'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" ''        \",pattern:\" '^'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE '$$' LIKE '^$$'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" ''        \",pattern:\" '^'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE '$$' LIKE '^$$'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '_AC'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '_AC'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '_AC'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '_AC'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" 'A_B'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A_B'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" 'A_B'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'A_B'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" 'AB_C'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'AB_C'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" 'AB_C'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'AB_C'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '_ABC'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '_ABC'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '_ABC'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '_ABC'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" 'ABC_'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'ABC_'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" 'ABC_'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'ABC_'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '__'         \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '__'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '__'         \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '__'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '____'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '____'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '____'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '____'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" 'B%'         \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'B%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" 'B%'         \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'B%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '%B'         \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '%B'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '%B'         \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '%B'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '%BCD'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '%BCD'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '%BCD'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '%BCD'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" 'B%C'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE 'B%C'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" 'B%C'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE 'B%C'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%Xc'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%Xc'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%Xc'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%Xc'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'AX%c'       \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'AX%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'AX%c'       \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'AX%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%X%c'      \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%X%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%X%c'      \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%X%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%X%%c'    \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%X%%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%X%%c'    \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%X%%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%%X%%%%c' \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%%X%%%%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%%%X%%%%c' \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%%%X%%%%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%Aba%c'    \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%Aba%c'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'A%Aba%c'    \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'A%Aba%c'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'X%%'        \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'X%%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'AAaBBbCCc' \",pattern:\" 'X%%'        \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'AAaBBbCCc' LIKE 'X%%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '%_%_%_%_%'  \"}",
-    statement:"SELECT * FROM `[true]` WHERE 'ABC' LIKE '%_%_%_%_%'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "non-empty strings for text and pattern that DO NOT match{text:\" 'ABC'       \",pattern:\" '%_%_%_%_%'  \"}",
+    statement: "SELECT * FROM `[true]` WHERE 'ABC' LIKE '%_%_%_%_%'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '_'          \",pattern:\" '[_'            \"}",
-    statement:"SELECT * FROM `[true]` WHERE '_' LIKE '[_' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '_'          \",pattern:\" '[_'            \"}",
+    statement: "SELECT * FROM `[true]` WHERE '_' LIKE '[_' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '%'          \",pattern:\" '[%'            \"}",
-    statement:"SELECT * FROM `[true]` WHERE '%' LIKE '[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '%'          \",pattern:\" '[%'            \"}",
+    statement: "SELECT * FROM `[true]` WHERE '%' LIKE '[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '100%'       \",pattern:\" '100[%'         \"}",
-    statement:"SELECT * FROM `[true]` WHERE '100%' LIKE '100[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '100%'       \",pattern:\" '100[%'         \"}",
+    statement: "SELECT * FROM `[true]` WHERE '100%' LIKE '100[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '100%'       \",pattern:\" '%[%'           \"}",
-    statement:"SELECT * FROM `[true]` WHERE '100%' LIKE '%[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '100%'       \",pattern:\" '%[%'           \"}",
+    statement: "SELECT * FROM `[true]` WHERE '100%' LIKE '%[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '100%'       \",pattern:\" '1__[%'         \"}",
-    statement:"SELECT * FROM `[true]` WHERE '100%' LIKE '1__[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '100%'       \",pattern:\" '1__[%'         \"}",
+    statement: "SELECT * FROM `[true]` WHERE '100%' LIKE '1__[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '100%'       \",pattern:\" '1%[%'          \"}",
-    statement:"SELECT * FROM `[true]` WHERE '100%' LIKE '1%[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '100%'       \",pattern:\" '1%[%'          \"}",
+    statement: "SELECT * FROM `[true]` WHERE '100%' LIKE '1%[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '11%22%33%'  \",pattern:\" '1%[%2%[%3%[%'  \"}",
-    statement:"SELECT * FROM `[true]` WHERE '11%22%33%' LIKE '1%[%2%[%3%[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '11%22%33%'  \",pattern:\" '1%[%2%[%3%[%'  \"}",
+    statement: "SELECT * FROM `[true]` WHERE '11%22%33%' LIKE '1%[%2%[%3%[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '11%22%33%'  \",pattern:\" '1_[%2%[%3_[%'  \"}",
-    statement:"SELECT * FROM `[true]` WHERE '11%22%33%' LIKE '1_[%2%[%3_[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '11%22%33%'  \",pattern:\" '1_[%2%[%3_[%'  \"}",
+    statement: "SELECT * FROM `[true]` WHERE '11%22%33%' LIKE '1_[%2%[%3_[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '11%22%33%'  \",pattern:\" '%[%%[%%[%'     \"}",
-    statement:"SELECT * FROM `[true]` WHERE '11%22%33%' LIKE '%[%%[%%[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '11%22%33%'  \",pattern:\" '%[%%[%%[%'     \"}",
+    statement: "SELECT * FROM `[true]` WHERE '11%22%33%' LIKE '%[%%[%%[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '11%22%33%'  \",pattern:\" '__[%__[%__[%'  \"}",
-    statement:"SELECT * FROM `[true]` WHERE '11%22%33%' LIKE '__[%__[%__[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '11%22%33%'  \",pattern:\" '__[%__[%__[%'  \"}",
+    statement: "SELECT * FROM `[true]` WHERE '11%22%33%' LIKE '__[%__[%__[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '1[_000[_000[%' \"}",
-    statement:"SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '1[_000[_000[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '1[_000[_000[%' \"}",
+    statement: "SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '1[_000[_000[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '_[_000[_000[%' \"}",
-    statement:"SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '_[_000[_000[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '_[_000[_000[%' \"}",
+    statement: "SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '_[_000[_000[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '%[_000[_000[%' \"}",
-    statement:"SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '%[_000[_000[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '%[_000[_000[%' \"}",
+    statement: "SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '%[_000[_000[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '%[_0_0[_000[%' \"}",
-    statement:"SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '%[_0_0[_000[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '%[_0_0[_000[%' \"}",
+    statement: "SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '%[_0_0[_000[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '%[_0%0[_000[%' \"}",
-    statement:"SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '%[_0%0[_000[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '%[_0%0[_000[%' \"}",
+    statement: "SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '%[_0%0[_000[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '%[_0%0[__%_[%' \"}",
-    statement:"SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '%[_0%0[__%_[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '1_000_000%' \",pattern:\" '%[_0%0[__%_[%' \"}",
+    statement: "SELECT * FROM `[true]` WHERE '1_000_000%' LIKE '%[_0%0[__%_[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that match{text:\" '100%'       \",pattern:\" '1_%'           \"}",
-    statement:"SELECT * FROM `[true]` WHERE '100%' LIKE '1_%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that match{text:\" '100%'       \",pattern:\" '1_%'           \"}",
+    statement: "SELECT * FROM `[true]` WHERE '100%' LIKE '1_%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          _1:true
+          _1: true
         }
       ]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that DO NOT match{text:\" '_'    \",pattern:\" '[_[_'   \"}",
-    statement:"SELECT * FROM `[true]` WHERE '_' LIKE '[_[_' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that DO NOT match{text:\" '_'    \",pattern:\" '[_[_'   \"}",
+    statement: "SELECT * FROM `[true]` WHERE '_' LIKE '[_[_' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that DO NOT match{text:\" '_'    \",pattern:\" '_[_'    \"}",
-    statement:"SELECT * FROM `[true]` WHERE '_' LIKE '_[_' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that DO NOT match{text:\" '_'    \",pattern:\" '_[_'    \"}",
+    statement: "SELECT * FROM `[true]` WHERE '_' LIKE '_[_' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that DO NOT match{text:\" '%'    \",pattern:\" '[%[%'   \"}",
-    statement:"SELECT * FROM `[true]` WHERE '%' LIKE '[%[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that DO NOT match{text:\" '%'    \",pattern:\" '[%[%'   \"}",
+    statement: "SELECT * FROM `[true]` WHERE '%' LIKE '[%[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that DO NOT match{text:\" '100%' \",pattern:\" '1000[%' \"}",
-    statement:"SELECT * FROM `[true]` WHERE '100%' LIKE '1000[%' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that DO NOT match{text:\" '100%' \",pattern:\" '1000[%' \"}",
+    statement: "SELECT * FROM `[true]` WHERE '100%' LIKE '1000[%' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that DO NOT match{text:\" '100%' \",pattern:\" '[%100'  \"}",
-    statement:"SELECT * FROM `[true]` WHERE '100%' LIKE '[%100' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that DO NOT match{text:\" '100%' \",pattern:\" '[%100'  \"}",
+    statement: "SELECT * FROM `[true]` WHERE '100%' LIKE '[%100' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that DO NOT match{text:\" '100%' \",pattern:\" '1_[%_'  \"}",
-    statement:"SELECT * FROM `[true]` WHERE '100%' LIKE '1_[%_' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that DO NOT match{text:\" '100%' \",pattern:\" '1_[%_'  \"}",
+    statement: "SELECT * FROM `[true]` WHERE '100%' LIKE '1_[%_' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"like-expression with ESCAPE specified that DO NOT match{text:\" '100%' \",pattern:\" '1%_[%1' \"}",
-    statement:"SELECT * FROM `[true]` WHERE '100%' LIKE '1%_[%1' ESCAPE '['",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "like-expression with ESCAPE specified that DO NOT match{text:\" '100%' \",pattern:\" '1%_[%1' \"}",
+    statement: "SELECT * FROM `[true]` WHERE '100%' LIKE '1%_[%1' ESCAPE '['",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"like expression value, pattern, and escape as variable references",
-    statement:'''
+    name: "like expression value, pattern, and escape as variable references",
+    statement: '''
       SELECT v LIKE p ESCAPE e as is_like FROM [
         {'v': 'abc%', 'p': 'abc/%', 'e': '/'},
         {'v': 'abcd', 'p': 'abc%', 'e': '/'},
         {'v': 'abcd', 'p': 'abc', 'e': '/'}
       ] AS tbl
       ''',
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
           is_like: true
         },
@@ -1601,54 +1557,53 @@ like::[
 
 'empty-string-for-like-pattern'::[
   envs::{
-    people:[
+    people: [
       {
-        first_name:"John",
-        last_name:"Doe"
+        first_name: "John",
+        last_name: "Doe"
       }
     ]
   },
   {
-    name:"Empty String for LIKE pattern evaluates to false",
-    statement:"SELECT * FROM people AS p WHERE p.first_name LIKE ''",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "Empty String for LIKE pattern evaluates to false",
+    statement: "SELECT * FROM people AS p WHERE p.first_name LIKE ''",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"Empty String for LIKE pattern and text evaluates to true",
-    statement:"SELECT * FROM people AS p WHERE '' LIKE ''",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "Empty String for LIKE pattern and text evaluates to true",
+    statement: "SELECT * FROM people AS p WHERE '' LIKE ''",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          first_name:"John",
-          last_name:"Doe"
+          first_name: "John",
+          last_name: "Doe"
         }
       ]
     }
   },
   {
-      name:"More than one character given for ESCAPE",
-      statement:"SELECT * FROM `[true]` WHERE 'a' LIKE 'a' ESCAPE 'aa'",
-      assert:{
-        evalMode:[
-          EvalModeError,
-          EvalModeCoerce
-        ],
-        result:EvaluationFail
-      },
-    }
+    name: "More than one character given for ESCAPE",
+    statement: "SELECT * FROM `[true]` WHERE 'a' LIKE 'a' ESCAPE 'aa'",
+    assert: {
+      evalMode: [
+        EvalModeError,
+        EvalModeCoerce
+      ],
+      result: EvaluationFail
+    },
+  }
 ]
 
 // Unknown propagation rules follow from section 8.5 of the SQL-92 spec
@@ -1665,239 +1620,272 @@ like::[
 // (https://partiql.org/assets/PartiQL-Specification.pdf#section.7)
 'null-missing-mistyped-for-like'::[
   {
-    name:"NULL LIKE 'some pattern'",
-    statement:"NULL LIKE 'some pattern'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "NULL LIKE 'some pattern'",
+    statement: "NULL LIKE 'some pattern'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"'some value' LIKE NULL",
-    statement:"'some value' LIKE NULL",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "'some value' LIKE NULL",
+    statement: "'some value' LIKE NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"NULL LIKE NULL",
-    statement:"NULL LIKE NULL",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "NULL LIKE NULL",
+    statement: "NULL LIKE NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"MISSING LIKE 'some pattern'",
-    statement:"MISSING LIKE 'some pattern'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"'some value' LIKE MISSING",
-    statement:"'some value' LIKE MISSING",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"MISSING LIKE MISSING",
-    statement:"MISSING LIKE MISSING",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"NULL LIKE MISSING",
-    statement:"NULL LIKE MISSING",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"MISSING LIKE NULL",
-    statement:"MISSING LIKE NULL",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"NULL LIKE 'some pattern' ESCAPE '/'",
-    statement:"NULL LIKE 'some pattern' ESCAPE '/'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"'some value' LIKE NULL ESCAPE '/'",
-    statement:"'some value' LIKE NULL ESCAPE '/'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"'some value' LIKE 'some pattern' ESCAPE NULL",
-    statement:"'some value' LIKE 'some pattern' ESCAPE NULL",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"MISSING LIKE 'some pattern' ESCAPE '/'",
-    statement:"MISSING LIKE 'some pattern' ESCAPE '/'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"'some value' LIKE MISSING ESCAPE '/'",
-    statement:"'some value' LIKE MISSING ESCAPE '/'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"'some value' LIKE 'some pattern' ESCAPE MISSING",
-    statement:"'some value' LIKE 'some pattern' ESCAPE MISSING",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"NULL LIKE 'some pattern' ESCAPE MISSING",
-    statement:"NULL LIKE 'some pattern' ESCAPE MISSING",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"'some value' LIKE NULL ESCAPE MISSING",
-    statement:"'some value' LIKE NULL ESCAPE MISSING",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"LIKE bad value type",
-    statement:"123 LIKE 'some pattern' ESCAPE '/'",
-    assert:[
+    name: "MISSING LIKE 'some pattern'",
+    statement: "MISSING LIKE 'some pattern'",
+    assert: [
       {
-        evalMode:EvalModeError,
-        result:EvaluationFail
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "'some value' LIKE MISSING",
+    statement: "'some value' LIKE MISSING",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "MISSING LIKE MISSING",
+    statement: "MISSING LIKE MISSING",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "NULL LIKE MISSING",
+    statement: "NULL LIKE MISSING",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "MISSING LIKE NULL",
+    statement: "MISSING LIKE NULL",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "NULL LIKE 'some pattern' ESCAPE '/'",
+    statement: "NULL LIKE 'some pattern' ESCAPE '/'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "'some value' LIKE NULL ESCAPE '/'",
+    statement: "'some value' LIKE NULL ESCAPE '/'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "'some value' LIKE 'some pattern' ESCAPE NULL",
+    statement: "'some value' LIKE 'some pattern' ESCAPE NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output: null
+    }
+  },
+  {
+    name: "MISSING LIKE 'some pattern' ESCAPE '/'",
+    statement: "MISSING LIKE 'some pattern' ESCAPE '/'",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "'some value' LIKE MISSING ESCAPE '/'",
+    statement: "'some value' LIKE MISSING ESCAPE '/'",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "'some value' LIKE 'some pattern' ESCAPE MISSING",
+    statement: "'some value' LIKE 'some pattern' ESCAPE MISSING",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
+        EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "NULL LIKE 'some pattern' ESCAPE MISSING",
+    statement: "NULL LIKE 'some pattern' ESCAPE MISSING",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
+        EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "'some value' LIKE NULL ESCAPE MISSING",
+    statement: "'some value' LIKE NULL ESCAPE MISSING",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode:
+        EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "LIKE bad value type",
+    statement: "123 LIKE 'some pattern' ESCAPE '/'",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ],
   },
   {
-    name:"LIKE bad pattern type",
-    statement:"'some value' LIKE 123 ESCAPE '/'",
-    assert:[
+    name: "LIKE bad pattern type",
+    statement: "'some value' LIKE 123 ESCAPE '/'",
+    assert: [
       {
-        evalMode:EvalModeError,
-        result:EvaluationFail
+        evalMode: EvalModeError,
+        result: EvaluationFail
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ],
   },
   {
-    name:"LIKE bad escape type",
-    statement:"'some value' LIKE '/' ESCAPE 123",
-    assert:[
+    name: "LIKE bad escape type",
+    statement: "'some value' LIKE '/' ESCAPE 123",
+    assert: [
       {
-        evalMode:EvalModeError,
-        result:EvaluationFail
+        evalMode: EvalModeError,
+        result: EvaluationFail
       },
       {
-        result:EvaluationSuccess,
-        evalMode:EvalModeCoerce,
-        output:$missing::null
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
       }
     ],
   },

--- a/partiql-tests-data/eval/primitives/string.ion
+++ b/partiql-tests-data/eval/primitives/string.ion
@@ -1,350 +1,365 @@
 string::[
   {
-    name:"concatenation with non-nulls{left:\"\",right:\"\",result:\"\"}",
-    statement:"{ `concatenated_literals`: '' || '', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"",
-      env_right:""
+    name: "concatenation with non-nulls{left:\"\",right:\"\",result:\"\"}",
+    statement: "{ `concatenated_literals`: '' || '', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "",
+      env_right: ""
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"",
-        concatenated_variables:""
+      output: {
+        concatenated_literals: "",
+        concatenated_variables: ""
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"left\",right:\"\",result:\"left\"}",
-    statement:"{ `concatenated_literals`: 'left' || '', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"left",
-      env_right:""
+    name: "concatenation with non-nulls{left:\"left\",right:\"\",result:\"left\"}",
+    statement: "{ `concatenated_literals`: 'left' || '', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "left",
+      env_right: ""
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"left",
-        concatenated_variables:"left"
+      output: {
+        concatenated_literals: "left",
+        concatenated_variables: "left"
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"\",right:\"right\",result:\"right\"}",
-    statement:"{ `concatenated_literals`: '' || 'right', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"",
-      env_right:"right"
+    name: "concatenation with non-nulls{left:\"\",right:\"right\",result:\"right\"}",
+    statement: "{ `concatenated_literals`: '' || 'right', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "",
+      env_right: "right"
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"right",
-        concatenated_variables:"right"
+      output: {
+        concatenated_literals: "right",
+        concatenated_variables: "right"
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"a\",right:\"b\",result:\"ab\"}",
-    statement:"{ `concatenated_literals`: 'a' || 'b', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"a",
-      env_right:"b"
+    name: "concatenation with non-nulls{left:\"a\",right:\"b\",result:\"ab\"}",
+    statement: "{ `concatenated_literals`: 'a' || 'b', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "a",
+      env_right: "b"
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"ab",
-        concatenated_variables:"ab"
+      output: {
+        concatenated_literals: "ab",
+        concatenated_variables: "ab"
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"hello\",right:\"world\",result:\"helloworld\"}",
-    statement:"{ `concatenated_literals`: 'hello' || 'world', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"hello",
-      env_right:"world"
+    name: "concatenation with non-nulls{left:\"hello\",right:\"world\",result:\"helloworld\"}",
+    statement: "{ `concatenated_literals`: 'hello' || 'world', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "hello",
+      env_right: "world"
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"helloworld",
-        concatenated_variables:"helloworld"
+      output: {
+        concatenated_literals: "helloworld",
+        concatenated_variables: "helloworld"
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"o\",right:\"\\u0300\",result:\"o\\u0300\"}",
-    statement:"{ `concatenated_literals`: 'o' || '̀', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"o",
-      env_right:"̀"
+    name: "concatenation with non-nulls{left:\"o\",right:\"\\u0300\",result:\"o\\u0300\"}",
+    statement: "{ `concatenated_literals`: 'o' || '̀', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "o",
+      env_right: "̀"
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"ò",
-        concatenated_variables:"ò"
+      output: {
+        concatenated_literals: "ò",
+        concatenated_variables: "ò"
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\",right:\"\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",result:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
-    statement:"{ `concatenated_literals`: '話家身圧費谷' || '料村能計税金', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"話家身圧費谷",
-      env_right:"料村能計税金"
+    name: "concatenation with non-nulls{left:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\",right:\"\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",result:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
+    statement: "{ `concatenated_literals`: '話家身圧費谷' || '料村能計税金', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "話家身圧費谷",
+      env_right: "料村能計税金"
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"話家身圧費谷料村能計税金",
-        concatenated_variables:"話家身圧費谷料村能計税金"
+      output: {
+        concatenated_literals: "話家身圧費谷料村能計税金",
+        concatenated_variables: "話家身圧費谷料村能計税金"
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\",right:\"\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
-    statement:"{ `concatenated_literals`: 'ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРС' || 'ТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРС",
-      env_right:"ТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
+    name: "concatenation with non-nulls{left:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\",right:\"\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
+    statement: "{ `concatenated_literals`: 'ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРС' || 'ТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРС",
+      env_right: "ТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя",
-        concatenated_variables:"ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
+      output: {
+        concatenated_literals: "ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя",
+        concatenated_variables: "ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \",right:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",result:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
-    statement:"{ `concatenated_literals`: '𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 ' || '𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 ",
-      env_right:"𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
+    name: "concatenation with non-nulls{left:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \",right:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",result:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
+    statement: "{ `concatenated_literals`: '𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 ' || '𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 ",
+      env_right: "𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫",
-        concatenated_variables:"𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
+      output: {
+        concatenated_literals: "𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫",
+        concatenated_variables: "𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce\",right:\"( \\xba _ \\xba\\u30ce)\",result:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\"}",
-    statement:"{ `concatenated_literals`: '( ͡° ͜ʖ ͡°)┬─┬ノ' || '( º _ ºノ)', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"( ͡° ͜ʖ ͡°)┬─┬ノ",
-      env_right:"( º _ ºノ)"
+    name: "concatenation with non-nulls{left:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce\",right:\"( \\xba _ \\xba\\u30ce)\",result:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\"}",
+    statement: "{ `concatenated_literals`: '( ͡° ͜ʖ ͡°)┬─┬ノ' || '( º _ ºノ)', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "( ͡° ͜ʖ ͡°)┬─┬ノ",
+      env_right: "( º _ ºノ)"
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)",
-        concatenated_variables:"( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)"
+      output: {
+        concatenated_literals: "( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)",
+        concatenated_variables: "( ͡° ͜ʖ ͡°)┬─┬ノ( º _ ºノ)"
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"\\U0001f60d\",right:\"\\U0001f60d\",result:\"\\U0001f60d\\U0001f60d\"}",
-    statement:"{ `concatenated_literals`: '😍' || '😍', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"😍",
-      env_right:"😍"
+    name: "concatenation with non-nulls{left:\"\\U0001f60d\",right:\"\\U0001f60d\",result:\"\\U0001f60d\\U0001f60d\"}",
+    statement: "{ `concatenated_literals`: '😍' || '😍', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "😍",
+      env_right: "😍"
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"😍😍",
-        concatenated_variables:"😍😍"
+      output: {
+        concatenated_literals: "😍😍",
+        concatenated_variables: "😍😍"
       }
     }
   },
   {
-    name:"concatenation with non-nulls{left:\"\\U0001f4a9\\U0001f4a9\",right:\"\\U0001f4a9\\U0001f4a9\",result:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\"}",
-    statement:"{ `concatenated_literals`: '💩💩' || '💩💩', `concatenated_variables`: env_left || env_right }",
-    env:{
-      env_left:"💩💩",
-      env_right:"💩💩"
+    name: "concatenation with non-nulls{left:\"\\U0001f4a9\\U0001f4a9\",right:\"\\U0001f4a9\\U0001f4a9\",result:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\"}",
+    statement: "{ `concatenated_literals`: '💩💩' || '💩💩', `concatenated_variables`: env_left || env_right }",
+    env: {
+      env_left: "💩💩",
+      env_right: "💩💩"
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:{
-        concatenated_literals:"💩💩💩💩",
-        concatenated_variables:"💩💩💩💩"
+      output: {
+        concatenated_literals: "💩💩💩💩",
+        concatenated_variables: "💩💩💩💩"
       }
     }
   },
   {
-    name:"concatenation with null values{left:\"NULL\",right:\"NULL\"}",
-    statement:"NULL || NULL",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "concatenation with null values{left:\"NULL\",right:\"NULL\"}",
+    statement: "NULL || NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"concatenation with null values{left:\"MISSING\",right:\"MISSING\"}",
-    statement:"MISSING || MISSING",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "concatenation with null values{left:\"MISSING\",right:\"MISSING\"}",
+    statement: "MISSING || MISSING",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "concatenation with null values{left:\"''\",right:\"NULL\"}",
+    statement: "'' || NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output: null
     }
   },
   {
-    name:"concatenation with null values{left:\"''\",right:\"NULL\"}",
-    statement:"'' || NULL",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "concatenation with null values{left:\"NULL\",right:\"''\"}",
+    statement: "NULL || ''",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"concatenation with null values{left:\"NULL\",right:\"''\"}",
-    statement:"NULL || ''",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "concatenation with null values{left:\"''\",right:\"MISSING\"}",
+    statement: "'' || MISSING",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "concatenation with null values{left:\"MISSING\",right:\"''\"}",
+    statement: "MISSING || ''",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "concatenation with null values{left:\"'a'\",right:\"NULL\"}",
+    statement: "'a' || NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:null
+      output: null
     }
   },
   {
-    name:"concatenation with null values{left:\"''\",right:\"MISSING\"}",
-    statement:"'' || MISSING",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    name: "concatenation with null values{left:\"NULL\",right:\"'b'\"}",
+    statement: "NULL || 'b'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output: null
     }
   },
   {
-    name:"concatenation with null values{left:\"MISSING\",right:\"''\"}",
-    statement:"MISSING || ''",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+    name: "concatenation with null values{left:\"'a'\",right:\"MISSING\"}",
+    statement: "'a' || MISSING",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
   },
   {
-    name:"concatenation with null values{left:\"'a'\",right:\"NULL\"}",
-    statement:"'a' || NULL",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"concatenation with null values{left:\"NULL\",right:\"'b'\"}",
-    statement:"NULL || 'b'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:null
-    }
-  },
-  {
-    name:"concatenation with null values{left:\"'a'\",right:\"MISSING\"}",
-    statement:"'a' || MISSING",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
-  },
-  {
-    name:"concatenation with null values{left:\"MISSING\",right:\"'b'\"}",
-    statement:"MISSING || 'b'",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$missing::null
-    }
+    name: "concatenation with null values{left:\"MISSING\",right:\"'b'\"}",
+    statement: "MISSING || 'b'",
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
   },
 ]

--- a/partiql-tests-data/eval/query/select/select.ion
+++ b/partiql-tests-data/eval/query/select/select.ion
@@ -1,260 +1,307 @@
 envs::{
   sensors: [
-    {readings: [{v: 1.3}, {v: 2}]},
-    {readings: [{v: 0.7}, {v: 0.8}, {v: 0.9}]}
-  ],
-  stores:[
     {
-      id:"5",
-      books:[
+      readings: [
         {
-          title:"A",
-          price:5.0,
-          categories:[
+          v: 1.3
+        },
+        {
+          v: 2
+        }
+      ]
+    },
+    {
+      readings: [
+        {
+          v: 0.7
+        },
+        {
+          v: 0.8
+        },
+        {
+          v: 0.9
+        }
+      ]
+    }
+  ],
+  stores: [
+    {
+      id: "5",
+      books: [
+        {
+          title: "A",
+          price: 5.0,
+          categories: [
             "sci-fi",
             "action"
           ]
         },
         {
-          title:"B",
-          price:2.0,
-          categories:[
+          title: "B",
+          price: 2.0,
+          categories: [
             "sci-fi",
             "comedy"
           ]
         },
         {
-          title:"C",
-          price:7.0,
-          categories:[
+          title: "C",
+          price: 7.0,
+          categories: [
             "action",
             "suspense"
           ]
         },
         {
-          title:"D",
-          price:9.0,
-          categories:[
+          title: "D",
+          price: 9.0,
+          categories: [
             "suspense"
           ]
         }
       ]
     },
     {
-      id:"6",
-      books:[
+      id: "6",
+      books: [
         {
-          title:"A",
-          price:5.0,
-          categories:[
+          title: "A",
+          price: 5.0,
+          categories: [
             "sci-fi",
             "action"
           ]
         },
         {
-          title:"E",
-          price:9.5,
-          categories:[
+          title: "E",
+          price: 9.5,
+          categories: [
             "fantasy",
             "comedy"
           ]
         },
         {
-          title:"F",
-          price:10.0,
-          categories:[
+          title: "F",
+          price: 10.0,
+          categories: [
             "history"
           ]
         }
       ]
     },
     {
-      id:"7",
-      books:[
-      ]
+      id: "7",
+      books: []
     }
   ],
-  animals:[
+  animals: [
     {
-      name:"Kumo",
-      type:"dog"
+      name: "Kumo",
+      type: "dog"
     },
     {
-      name:"Mochi",
-      type:"dog"
+      name: "Mochi",
+      type: "dog"
     },
     {
-      name:"Lilikoi",
-      type:"unicorn"
+      name: "Lilikoi",
+      type: "unicorn"
     }
   ],
-  animal_types:[
+  animal_types: [
     {
-      id:"dog",
-      is_magic:false
+      id: "dog",
+      is_magic: false
     },
     {
-      id:"cat",
-      is_magic:false
+      id: "cat",
+      is_magic: false
     },
     {
-      id:"unicorn",
-      is_magic:true
+      id: "unicorn",
+      is_magic: true
     }
   ],
-  a:{
-    b:{
-      c:{
-        d:{
-          e:5,
-          f:6
+  a: {
+    b: {
+      c: {
+        d: {
+          e: 5,
+          f: 6
         }
       }
     }
   },
-  b:{
-    c:100
+  b: {
+    c: 100
   },
-  d:3.,
-  someAlias:"hello",
+  d: 3.,
+  someAlias: "hello",
 }
 
 {
-    name: "SELECT path",
-    statement: "SELECT r.v FROM sensors AS s, s.readings AS r",
-    assert: {
-        evalMode: [EvalModeCoerce, EvalModeError],
-        result: EvaluationSuccess,
-        output: $bag::[
-            {
-                v: 1.3
-            },
-            {
-                v: 2
-            },
-            {
-                v: 0.7
-            },
-            {
-                v: 0.8
-            },
-            {
-                v: 0.9
-            }
-        ]
-    }
+  name: "SELECT path",
+  statement: "SELECT r.v FROM sensors AS s, s.readings AS r",
+  assert: {
+    evalMode: [
+      EvalModeCoerce,
+      EvalModeError
+    ],
+    result: EvaluationSuccess,
+    output: $bag::[
+      {
+        v: 1.3
+      },
+      {
+        v: 2
+      },
+      {
+        v: 0.7
+      },
+      {
+        v: 0.8
+      },
+      {
+        v: 0.9
+      }
+    ]
+  }
 }
 
 {
-    name: "SELECT path with inline environment",
-    statement: "SELECT r.v FROM sensors AS s, s.readings AS r",
-    env: {
-        sensors: [
-            {readings: [{v: 5.0}, {v: 78.2}]}
+  name: "SELECT path with inline environment",
+  statement: "SELECT r.v FROM sensors AS s, s.readings AS r",
+  env: {
+    sensors: [
+      {
+        readings: [
+          {
+            v: 5.0
+          },
+          {
+            v: 78.2
+          }
         ]
-    },
-    assert: {
-        evalMode: [EvalModeCoerce, EvalModeError],
-        result: EvaluationSuccess,
-        output: $bag::[
-            {
-                v: 5.0
-            },
-            {
-                v: 78.2
-            }
-        ]
-    }
+      }
+    ]
+  },
+  assert: {
+    evalMode: [
+      EvalModeCoerce,
+      EvalModeError
+    ],
+    result: EvaluationSuccess,
+    output: $bag::[
+      {
+        v: 5.0
+      },
+      {
+        v: 78.2
+      }
+    ]
+  }
 }
 
 'select list item'::[
   {
-    name:"explicitAliasSelectSingleSource",
-    statement:"SELECT id AS name FROM stores",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "explicitAliasSelectSingleSource",
+    statement: "SELECT id AS name FROM stores",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          name:"5"
+          name: "5"
         },
         {
-          name:"6"
+          name: "6"
         },
         {
-          name:"7"
+          name: "7"
         }
       ]
     }
   },
   {
-    name:"selectImplicitAndExplicitAliasSingleSourceHoisted",
-    statement:"SELECT title AS name, price FROM stores[*].books[*] AS b WHERE b.price >= 9.0",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectImplicitAndExplicitAliasSingleSourceHoisted",
+    statement: "SELECT title AS name, price FROM stores[*].books[*] AS b WHERE b.price >= 9.0",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          name:"D",
-          price:9.0
+          name: "D",
+          price: 9.0
         },
         {
-          name:"E",
-          price:9.5
+          name: "E",
+          price: 9.5
         },
         {
-          name:"F",
-          price:10.0
+          name: "F",
+          price: 10.0
         }
       ]
     }
   },
   {
-    name:"syntheticColumnNameInSelect",
-    statement:"SELECT i+1 FROM <<100>> i",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "syntheticColumnNameInSelect",
+    statement: "SELECT i+1 FROM <<100>> i",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          _1:101
+          _1: 101
         }
       ]
     }
   },
   {
-    name:"properAliasFromPathInSelect",
-    statement:"SELECT s.id, s.books[1].title FROM stores AS s WHERE s.id = '5'",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "properAliasFromPathInSelect",
+    statement: "SELECT s.id, s.books[1].title FROM stores AS s WHERE s.id = '5'",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          id:"5",
-          title:"B"
+          id: "5",
+          title: "B"
         }
       ]
     }
   },
   {
-    name:"selectListWithMissing",
-    statement:"SELECT a.x AS x, a.y AS y FROM `[{x:5}, {y:6}]` AS a",
+    name: "selectListWithMissing",
+    statement: "SELECT a.x AS x, a.y AS y FROM `[{x:5}, {y:6}]` AS a",
     assert: [
       {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
           {
-            x:5
+            x: 5
           },
           {
-            y:6
+            y: 6
           }
         ]
       },
       {
-        evalMode:EvalModeError,
-        result:EvaluationFail
+        evalMode: EvalModeError,
+        result: EvaluationFail
       },
     ]
   }
@@ -262,130 +309,151 @@ envs::{
 
 select_where::[
   {
-    name:"selectWhereStringEqualsSameCase",
-    statement:"SELECT * FROM animals as a WHERE a.name = 'Kumo'",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectWhereStringEqualsSameCase",
+    statement: "SELECT * FROM animals as a WHERE a.name = 'Kumo'",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          name:"Kumo",
-          type:"dog"
+          name: "Kumo",
+          type: "dog"
         }
       ]
     }
   },
   {
-    name:"selectWhereStrinEqualsDifferentCase",
-    statement:"SELECT * FROM animals as a WHERE a.name = 'KUMO'",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-      ]
+    name: "selectWhereStrinEqualsDifferentCase",
+    statement: "SELECT * FROM animals as a WHERE a.name = 'KUMO'",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[]
     }
   }
 ]
 
 select_join::[
   {
-    name:"selectJoin",
-    statement:"SELECT * FROM animals AS a, animal_types AS t WHERE a.type = t.id",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectJoin",
+    statement: "SELECT * FROM animals AS a, animal_types AS t WHERE a.type = t.id",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          name:"Kumo",
-          type:"dog",
-          id:"dog",
-          is_magic:false
+          name: "Kumo",
+          type: "dog",
+          id: "dog",
+          is_magic: false
         },
         {
-          name:"Mochi",
-          type:"dog",
-          id:"dog",
-          is_magic:false
+          name: "Mochi",
+          type: "dog",
+          id: "dog",
+          is_magic: false
         },
         {
-          name:"Lilikoi",
-          type:"unicorn",
-          id:"unicorn",
-          is_magic:true
+          name: "Lilikoi",
+          type: "unicorn",
+          id: "unicorn",
+          is_magic: true
         }
       ]
     }
   },
   {
-    name:"selectCorrelatedJoin",
-    statement:"SELECT s.id AS id, b.title AS title FROM stores AS s, @s.books AS b WHERE b IS NULL OR b.price > 5",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectCorrelatedJoin",
+    statement: "SELECT s.id AS id, b.title AS title FROM stores AS s, @s.books AS b WHERE b IS NULL OR b.price > 5",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          id:"5",
-          title:"C"
+          id: "5",
+          title: "C"
         },
         {
-          id:"5",
-          title:"D"
+          id: "5",
+          title: "D"
         },
         {
-          id:"6",
-          title:"E"
+          id: "6",
+          title: "E"
         },
         {
-          id:"6",
-          title:"F"
+          id: "6",
+          title: "F"
         }
       ]
     }
   },
   {
-    name:"selectCorrelatedLeftJoin",
-    statement:"SELECT s.id AS id, b.title AS title FROM stores AS s LEFT CROSS JOIN @s.books AS b WHERE b IS NULL",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectCorrelatedLeftJoin",
+    statement: "SELECT s.id AS id, b.title AS title FROM stores AS s LEFT CROSS JOIN @s.books AS b WHERE b IS NULL",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          id:"7"
+          id: "7"
         }
       ]
     }
   },
   {
-    name:"selectCorrelatedLeftJoinOnClause",
-    statement:"SELECT s.id AS id, b.title AS title FROM stores AS s LEFT OUTER JOIN @s.books AS b ON b.price > 9",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectCorrelatedLeftJoinOnClause",
+    statement: "SELECT s.id AS id, b.title AS title FROM stores AS s LEFT OUTER JOIN @s.books AS b ON b.price > 9",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          id:"5"
+          id: "5"
         },
         {
-          id:"6",
-          title:"E"
+          id: "6",
+          title: "E"
         },
         {
-          id:"6",
-          title:"F"
+          id: "6",
+          title: "F"
         },
         {
-          id:"7"
+          id: "7"
         }
       ]
     }
   },
   {
-    name:"selectJoinOnClauseScoping", // note that d is a global which should be shadowed by the last from source
-    statement:"SELECT VALUE [a, b, d] FROM [1, 3] AS a INNER JOIN [1, 2, 3] AS b ON b < d LEFT JOIN [1.1, 2.1] AS d ON b < d AND a <= d",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectJoinOnClauseScoping",
+    // note that d is a global which should be shadowed by the last from source
+    statement: "SELECT VALUE [a, b, d] FROM [1, 3] AS a INNER JOIN [1, 2, 3] AS b ON b < d LEFT JOIN [1.1, 2.1] AS d ON b < d AND a <= d",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         [
           1,
           1,
@@ -415,153 +483,176 @@ select_join::[
     }
   },
   {
-    name:"selectNonCorrelatedJoin", // Note that the joined someAlias is coming from the global scope without @-operator
-    statement:"SELECT someAlias.id AS id, v AS title FROM stores AS someAlias, someAlias AS v",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectNonCorrelatedJoin",
+    // Note that the joined someAlias is coming from the global scope without @-operator
+    statement: "SELECT someAlias.id AS id, v AS title FROM stores AS someAlias, someAlias AS v",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          id:"5",
-          title:"hello"
+          id: "5",
+          title: "hello"
         },
         {
-          id:"6",
-          title:"hello"
+          id: "6",
+          title: "hello"
         },
         {
-          id:"7",
-          title:"hello"
+          id: "7",
+          title: "hello"
         }
       ]
     }
   },
   {
-    name:"selectCorrelatedUnpivot",
-    statement:"SELECT n1, n2, n3, n4, val FROM UNPIVOT a AS b AT n1, UNPIVOT @b AS c AT n2, UNPIVOT @c AS d AT n3, UNPIVOT @d AS val AT n4",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectCorrelatedUnpivot",
+    statement: "SELECT n1, n2, n3, n4, val FROM UNPIVOT a AS b AT n1, UNPIVOT @b AS c AT n2, UNPIVOT @c AS d AT n3, UNPIVOT @d AS val AT n4",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          n1:"b",
-          n2:"c",
-          n3:"d",
-          n4:"e",
-          val:5
+          n1: "b",
+          n2: "c",
+          n3: "d",
+          n4: "e",
+          val: 5
         },
         {
-          n1:"b",
-          n2:"c",
-          n3:"d",
-          n4:"f",
-          val:6
+          n1: "b",
+          n2: "c",
+          n3: "d",
+          n4: "f",
+          val: 6
         }
       ]
     }
   },
   {
-    name:"nestedSelectJoinWithUnpivot",
-    statement:"SELECT col, val FROM (SELECT * FROM animals AS aa, animal_types AS tt WHERE aa.type = tt.id) AS a, UNPIVOT @a AS val AT col WHERE col != 'id'",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "nestedSelectJoinWithUnpivot",
+    statement: "SELECT col, val FROM (SELECT * FROM animals AS aa, animal_types AS tt WHERE aa.type = tt.id) AS a, UNPIVOT @a AS val AT col WHERE col != 'id'",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          col:"name",
-          val:"Kumo"
+          col: "name",
+          val: "Kumo"
         },
         {
-          col:"type",
-          val:"dog"
+          col: "type",
+          val: "dog"
         },
         {
-          col:"is_magic",
-          val:false
+          col: "is_magic",
+          val: false
         },
         {
-          col:"name",
-          val:"Mochi"
+          col: "name",
+          val: "Mochi"
         },
         {
-          col:"type",
-          val:"dog"
+          col: "type",
+          val: "dog"
         },
         {
-          col:"is_magic",
-          val:false
+          col: "is_magic",
+          val: false
         },
         {
-          col:"name",
-          val:"Lilikoi"
+          col: "name",
+          val: "Lilikoi"
         },
         {
-          col:"type",
-          val:"unicorn"
+          col: "type",
+          val: "unicorn"
         },
         {
-          col:"is_magic",
-          val:true
+          col: "is_magic",
+          val: true
         }
       ]
     }
   },
   {
-    name:"nestedSelectJoinLimit",
-    statement:"SELECT col, val FROM (SELECT * FROM animals AS aa, animal_types AS tt WHERE aa.type = tt.id) AS a, UNPIVOT @a AS val AT col WHERE col != 'id' LIMIT 6 - 3",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "nestedSelectJoinLimit",
+    statement: "SELECT col, val FROM (SELECT * FROM animals AS aa, animal_types AS tt WHERE aa.type = tt.id) AS a, UNPIVOT @a AS val AT col WHERE col != 'id' LIMIT 6 - 3",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          col:"name",
-          val:"Kumo"
+          col: "name",
+          val: "Kumo"
         },
         {
-          col:"type",
-          val:"dog"
+          col: "type",
+          val: "dog"
         },
         {
-          col:"is_magic",
-          val:false
+          col: "is_magic",
+          val: false
         }
       ]
     }
   },
   {
-    name:"correlatedJoinWithShadowedAttributes",
-    statement:"SELECT VALUE v FROM `[{v:5}]` AS item, @item.v AS v",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "correlatedJoinWithShadowedAttributes",
+    statement: "SELECT VALUE v FROM `[{v:5}]` AS item, @item.v AS v",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         5
       ]
     }
   },
   {
-    name:"correlatedJoinWithoutLexicalScope",
-    statement:"SELECT VALUE b FROM `[{b:5}]` AS item, item.b AS b",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "correlatedJoinWithoutLexicalScope",
+    statement: "SELECT VALUE b FROM `[{b:5}]` AS item, item.b AS b",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         5
       ]
     }
   },
   {
-    name:"joinWithShadowedGlobal", // 'a' is a global variable
-    statement:"SELECT VALUE b FROM `[{b:5}]` AS a, a.b AS b",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "joinWithShadowedGlobal",
+    // 'a' is a global variable
+    statement: "SELECT VALUE b FROM `[{b:5}]` AS a, a.b AS b",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          c:{
-            d:{
-              e:5,
-              f:6
+          c: {
+            d: {
+              e: 5,
+              f: 6
             }
           }
         }
@@ -572,58 +663,70 @@ select_join::[
 
 'ordered names'::[
   {
-    name:"wildcardOrderedNames",
-    statement:"SELECT * FROM <<{'a': 1, 'b': 2 }>> AS f",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "wildcardOrderedNames",
+    statement: "SELECT * FROM <<{'a': 1, 'b': 2 }>> AS f",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:1,
-          b:2
+          a: 1,
+          b: 2
         }
       ]
     }
   },
   {
-    name:"aliasWildcardOrderedNames",
-    statement:"SELECT f.* FROM <<{'a': 1, 'b': 2 }>> AS f",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "aliasWildcardOrderedNames",
+    statement: "SELECT f.* FROM <<{'a': 1, 'b': 2 }>> AS f",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:1,
-          b:2
+          a: 1,
+          b: 2
         }
       ]
     }
   },
   {
-    name:"aliasWildcardOrderedNamesSelectList",
-    statement:"SELECT f.a, f.* FROM <<{'a': 1, 'b': 2 }>> AS f",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "aliasWildcardOrderedNamesSelectList",
+    statement: "SELECT f.a, f.* FROM <<{'a': 1, 'b': 2 }>> AS f",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:1,
-          a:1,
-          b:2
+          a: 1,
+          a: 1,
+          b: 2
         }
       ]
     }
   },
   {
-    name:"aliasOrderedNamesSelectList",
-    statement:"SELECT f.a, f.b FROM <<{'a': 1, 'b': 2 }>> AS f",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "aliasOrderedNamesSelectList",
+    statement: "SELECT f.a, f.b FROM <<{'a': 1, 'b': 2 }>> AS f",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:1,
-          b:2
+          a: 1,
+          b: 2
         }
       ]
     }
@@ -632,241 +735,276 @@ select_join::[
 
 'select distinct'::[
   {
-    name:"selectDistinct",
-    statement:"SELECT DISTINCT t.a FROM `[{a: 1}, {a: 2}, {a: 1}]` t",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinct",
+    statement: "SELECT DISTINCT t.a FROM `[{a: 1}, {a: 2}, {a: 1}]` t",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:1
+          a: 1
         },
         {
-          a:2
+          a: 2
         }
       ]
     }
   },
   {
-    name:"selectDistinctWithAggregate",
-    statement:"SELECT SUM(DISTINCT t.a) AS a FROM `[{a:10}, {a:1}, {a:10}, {a:3}]` t",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctWithAggregate",
+    statement: "SELECT SUM(DISTINCT t.a) AS a FROM `[{a:10}, {a:1}, {a:10}, {a:3}]` t",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:14
+          a: 14
         }
       ]
     }
   },
   {
-    name:"selectDistinctSubQuery",
-    statement:"SELECT * FROM (SELECT DISTINCT t.a FROM `[{a: 1}, {a: 2}, {a: 1}]` t)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctSubQuery",
+    statement: "SELECT * FROM (SELECT DISTINCT t.a FROM `[{a: 1}, {a: 2}, {a: 1}]` t)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:1
+          a: 1
         },
         {
-          a:2
+          a: 2
         }
       ]
     }
   },
   {
-    name:"selectDistinctWithSubQuery",
-    statement:"SELECT DISTINCT * FROM (SELECT t.a FROM `[{a: 1}, {a: 2}, {a: 1}]` t)",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctWithSubQuery",
+    statement: "SELECT DISTINCT * FROM (SELECT t.a FROM `[{a: 1}, {a: 2}, {a: 1}]` t)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:1
+          a: 1
         },
         {
-          a:2
+          a: 2
         }
       ]
     }
   },
   {
-    name:"selectDistinctAggregationWithGroupBy",
-    statement:"SELECT t.a, COUNT(DISTINCT t.b) AS c FROM `[{a:1, b:10}, {a:1, b:10}, {a:1, b:20}, {a:2, b:10}, {a:2, b:10}]` t GROUP by t.a",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctAggregationWithGroupBy",
+    statement: "SELECT t.a, COUNT(DISTINCT t.b) AS c FROM `[{a:1, b:10}, {a:1, b:10}, {a:1, b:20}, {a:2, b:10}, {a:2, b:10}]` t GROUP by t.a",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:1,
-          c:2
+          a: 1,
+          c: 2
         },
         {
-          a:2,
-          c:1
+          a: 2,
+          c: 1
         }
       ]
     }
   },
   {
-    name:"selectDistinctWithGroupBy",
-    statement:"SELECT DISTINCT t.a, COUNT(t.b) AS c FROM `[{a:1, b:10}, {a:1, b:10}, {a:1, b:20}, {a:2, b:10}, {a:2, b:10}]` t GROUP by t.a",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctWithGroupBy",
+    statement: "SELECT DISTINCT t.a, COUNT(t.b) AS c FROM `[{a:1, b:10}, {a:1, b:10}, {a:1, b:20}, {a:2, b:10}, {a:2, b:10}]` t GROUP by t.a",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:1,
-          c:3
+          a: 1,
+          c: 3
         },
         {
-          a:2,
-          c:2
+          a: 2,
+          c: 2
         }
       ]
     }
   },
   {
-    name:"selectDistinctWithJoin",
-    statement:"SELECT DISTINCT * FROM `[1, 1, 1, 1, 2]` t1, `[2, 2, 2, 2, 1]` t2",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctWithJoin",
+    statement: "SELECT DISTINCT * FROM `[1, 1, 1, 1, 2]` t1, `[2, 2, 2, 2, 1]` t2",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          _1:1,
-          _2:2
+          _1: 1,
+          _2: 2
         },
         {
-          _1:1,
-          _2:1
+          _1: 1,
+          _2: 1
         },
         {
-          _1:2,
-          _2:2
+          _1: 2,
+          _2: 2
         },
         {
-          _1:2,
-          _2:1
+          _1: 2,
+          _2: 1
         }
       ]
     }
   },
   {
-    name:"selectDistinctStarMixed",
-    statement:"SELECT DISTINCT * FROM [ 1, 1, 2, [1], [1], [1, 2], <<>>, <<>>, MISSING, NULL, NULL, MISSING, {'a':1}, {'a':1}, {'a':2}]",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctStarMixed",
+    statement: "SELECT DISTINCT * FROM [ 1, 1, 2, [1], [1], [1, 2], <<>>, <<>>, MISSING, NULL, NULL, MISSING, {'a':1}, {'a':1}, {'a':2}]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          _1:1
+          _1: 1
         },
         {
-          _1:2
+          _1: 2
         },
         {
-          _1:[
+          _1: [
             1
           ]
         },
         {
-          _1:[
+          _1: [
             1,
             2
           ]
         },
         {
-          _1:$bag::[
-          ]
+          _1: $bag::[]
+        },
+        {},
+        {
+          _1: null
         },
         {
+          a: 1
         },
         {
-          _1:null
-        },
-        {
-          a:1
-        },
-        {
-          a:2
+          a: 2
         }
       ]
     }
   },
   {
-    name:"selectDistinctStarScalars",
-    statement:"SELECT DISTINCT * FROM [1, 1, 2]",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctStarScalars",
+    statement: "SELECT DISTINCT * FROM [1, 1, 2]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          _1:1
+          _1: 1
         },
         {
-          _1:2
+          _1: 2
         }
       ]
     }
   },
   {
-    name:"selectDistinctStarStructs",
-    statement:"SELECT DISTINCT * FROM [ {'a':1}, {'a':1}, {'a':2} ]",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctStarStructs",
+    statement: "SELECT DISTINCT * FROM [ {'a':1}, {'a':1}, {'a':2} ]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          a:1
+          a: 1
         },
         {
-          a:2
+          a: 2
         }
       ]
     }
   },
   {
-    name:"selectDistinctStarUnknowns",
-    statement:"SELECT DISTINCT * FROM [MISSING, NULL, NULL, MISSING]",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-        },
-        {
-          _1:null
-        }
-      ]
-    }
+    name: "selectDistinctStarUnknowns",
+    statement: "SELECT DISTINCT * FROM [MISSING, NULL, NULL, MISSING]",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {},
+          {
+            _1: null
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
-    name:"selectDistinctStarBags",
-    statement:"SELECT DISTINCT * FROM [ <<>>, <<>>, <<1>>, <<1>>, <<1, 2>>, <<2, 1>>, <<3, 4>>]",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctStarBags",
+    statement: "SELECT DISTINCT * FROM [ <<>>, <<>>, <<1>>, <<1>>, <<1, 2>>, <<2, 1>>, <<3, 4>>]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          _1:$bag::[
-          ]
+          _1: $bag::[]
         },
         {
-          _1:$bag::[
+          _1: $bag::[
             1
           ]
         },
         {
-          _1:$bag::[
+          _1: $bag::[
             1,
             2
           ]
         },
         {
-          _1:$bag::[
+          _1: $bag::[
             3,
             4
           ]
@@ -875,19 +1013,22 @@ select_join::[
     }
   },
   {
-    name:"selectDistinctStarLists",
-    statement:"SELECT DISTINCT * FROM [[1], [1], [1, 2]]",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctStarLists",
+    statement: "SELECT DISTINCT * FROM [[1], [1], [1, 2]]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          _1:[
+          _1: [
             1
           ]
         },
         {
-          _1:[
+          _1: [
             1,
             2
           ]
@@ -896,28 +1037,34 @@ select_join::[
     }
   },
   {
-    name:"selectDistinctStarIntegers",
-    statement:"SELECT DISTINCT * FROM [ 1, 1, 2 ]",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctStarIntegers",
+    statement: "SELECT DISTINCT * FROM [ 1, 1, 2 ]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          _1:1
+          _1: 1
         },
         {
-          _1:2
+          _1: 2
         }
       ]
     }
   },
   {
-    name:"selectDistinctValue",
-    statement:"SELECT DISTINCT VALUE t FROM [1,2,3,1,1,1,1,1] t",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctValue",
+    statement: "SELECT DISTINCT VALUE t FROM [1,2,3,1,1,1,1,1] t",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         1,
         2,
         3
@@ -925,33 +1072,39 @@ select_join::[
     }
   },
   {
-    name:"selectDistinctExpressionAndWhere",
-    statement:"SELECT DISTINCT (t.a + t.b) as c FROM `[{a: 1, b: 1}, {a: 2, b: 0}, {a: 0, b: 2}, {a: 2, b: 2}, {a: 0, b: 99}]` t WHERE t.a > 0",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctExpressionAndWhere",
+    statement: "SELECT DISTINCT (t.a + t.b) as c FROM `[{a: 1, b: 1}, {a: 2, b: 0}, {a: 0, b: 2}, {a: 2, b: 2}, {a: 0, b: 99}]` t WHERE t.a > 0",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          c:2
+          c: 2
         },
         {
-          c:4
+          c: 4
         }
       ]
     }
   },
   {
-    name:"selectDistinctExpression",
-    statement:"SELECT DISTINCT (t.a || t.b) as c FROM `[{a: \"1\", b: \"1\"}, {a: \"11\", b: \"\"}, {a: \"\", b: \"11\"}, {a: \"2\", b: \"2\"}]` t",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
+    name: "selectDistinctExpression",
+    statement: "SELECT DISTINCT (t.a || t.b) as c FROM `[{a: \"1\", b: \"1\"}, {a: \"11\", b: \"\"}, {a: \"\", b: \"11\"}, {a: \"2\", b: \"2\"}]` t",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
         {
-          c:"11"
+          c: "11"
         },
         {
-          c:"22"
+          c: "22"
         }
       ]
     }
@@ -960,203 +1113,201 @@ select_join::[
 
 select_bugs::[
   {
-    name:"MYSQL_SELECT_BUG_01",
-    statement:"select * from t1 left join t2 on t1.a = t2.c where t2.d in (4)",
-    env:{
-      t1:[
+    name: "MYSQL_SELECT_BUG_01",
+    statement: "select * from t1 left join t2 on t1.a = t2.c where t2.d in (4)",
+    env: {
+      t1: [
         {
-          a:1,
-          b:2
+          a: 1,
+          b: 2
         },
         {
-          a:2,
-          b:2
+          a: 2,
+          b: 2
         },
         {
-          a:3,
-          b:2
+          a: 3,
+          b: 2
         },
         {
-          a:4,
-          b:2
+          a: 4,
+          b: 2
         }
       ],
-      t2:[
+      t2: [
         {
-          c:1,
-          d:3
+          c: 1,
+          d: 3
         },
         {
-          c:2,
-          d:3
+          c: 2,
+          d: 3
         },
         {
-          c:3,
-          d:4
+          c: 3,
+          d: 4
         },
         {
-          c:4,
-          d:4
+          c: 4,
+          d: 4
         }
       ]
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          a:3,
-          b:2,
-          c:3,
-          d:4
+          a: 3,
+          b: 2,
+          c: 3,
+          d: 4
         },
         {
-          a:4,
-          b:2,
-          c:4,
-          d:4
+          a: 4,
+          b: 2,
+          c: 4,
+          d: 4
         }
       ]
     }
   },
   {
-    name:"MYSQL_SELECT_BUG_02",
-    statement:"select * from t1 left join t2 on t1.a = t2.c where t2.d = 4",
-    env:{
-      t1:[
+    name: "MYSQL_SELECT_BUG_02",
+    statement: "select * from t1 left join t2 on t1.a = t2.c where t2.d = 4",
+    env: {
+      t1: [
         {
-          a:1,
-          b:2
+          a: 1,
+          b: 2
         },
         {
-          a:2,
-          b:2
+          a: 2,
+          b: 2
         },
         {
-          a:3,
-          b:2
+          a: 3,
+          b: 2
         },
         {
-          a:4,
-          b:2
+          a: 4,
+          b: 2
         }
       ],
-      t2:[
+      t2: [
         {
-          c:1,
-          d:3
+          c: 1,
+          d: 3
         },
         {
-          c:2,
-          d:3
+          c: 2,
+          d: 3
         },
         {
-          c:3,
-          d:4
+          c: 3,
+          d: 4
         },
         {
-          c:4,
-          d:4
+          c: 4,
+          d: 4
         }
       ]
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
+      output: $bag::[
         {
-          a:3,
-          b:2,
-          c:3,
-          d:4
+          a: 3,
+          b: 2,
+          c: 3,
+          d: 4
         },
         {
-          a:4,
-          b:2,
-          c:4,
-          d:4
+          a: 4,
+          b: 2,
+          c: 4,
+          d: 4
         }
       ]
     }
   },
   {
-    name:"MYSQL_SELECT_BUG_03",
-    statement:"SELECT kunde_id ,FK_firma_id ,aktuell, vorname, nachname, geloescht FROM t1 WHERE ( ( ( '' != '' AND firma LIKE ('%' || '' || '%') ) OR ( vorname LIKE ('%' || 'Vorname1' || '%') AND nachname LIKE ('%' || '1Nachname' || '%') AND 'Vorname1' != '' AND 'xxxx' != '' ) ) AND ( aktuell = 'Ja' AND geloescht = 'Nein' AND FK_firma_id = 2 ) )",
-    env:{
-      t1:[
+    name: "MYSQL_SELECT_BUG_03",
+    statement: "SELECT kunde_id ,FK_firma_id ,aktuell, vorname, nachname, geloescht FROM t1 WHERE ( ( ( '' != '' AND firma LIKE ('%' || '' || '%') ) OR ( vorname LIKE ('%' || 'Vorname1' || '%') AND nachname LIKE ('%' || '1Nachname' || '%') AND 'Vorname1' != '' AND 'xxxx' != '' ) ) AND ( aktuell = 'Ja' AND geloescht = 'Nein' AND FK_firma_id = 2 ) )",
+    env: {
+      t1: [
         {
-          kunde_intern_id:3964,
-          kunde_id:3051,
-          FK_firma_id:1,
-          aktuell:"Ja",
-          vorname:"Vorname1",
-          nachname:"1Nachname",
-          geloescht:"Nein",
-          firma:"Print Schau XXXX"
+          kunde_intern_id: 3964,
+          kunde_id: 3051,
+          FK_firma_id: 1,
+          aktuell: "Ja",
+          vorname: "Vorname1",
+          nachname: "1Nachname",
+          geloescht: "Nein",
+          firma: "Print Schau XXXX"
         },
         {
-          kunde_intern_id:3965,
-          kunde_id:3051111,
-          FK_firma_id:1,
-          aktuell:"Ja",
-          vorname:"Vorname1111",
-          nachname:"1111Nachname",
-          geloescht:"Nein",
-          firma:"Print Schau XXXX"
+          kunde_intern_id: 3965,
+          kunde_id: 3051111,
+          FK_firma_id: 1,
+          aktuell: "Ja",
+          vorname: "Vorname1111",
+          nachname: "1111Nachname",
+          geloescht: "Nein",
+          firma: "Print Schau XXXX"
         }
       ]
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   },
   {
-    name:"MYSQL_SELECT_BUG_04",
-    statement:"SELECT kunde_id ,FK_firma_id ,aktuell, vorname, nachname, geloescht FROM t1 WHERE ( ( aktuell = 'Ja' AND geloescht = 'Nein' AND FK_firma_id = 2 ) AND ( ( '' != '' AND firma LIKE ('%' || '' || '%') ) OR ( vorname LIKE ('%' || 'Vorname1' || '%') AND nachname LIKE ('%' || '1Nachname' || '%') AND 'Vorname1' != '' AND 'xxxx' != '' ) ) )",
-    env:{
-      t1:[
+    name: "MYSQL_SELECT_BUG_04",
+    statement: "SELECT kunde_id ,FK_firma_id ,aktuell, vorname, nachname, geloescht FROM t1 WHERE ( ( aktuell = 'Ja' AND geloescht = 'Nein' AND FK_firma_id = 2 ) AND ( ( '' != '' AND firma LIKE ('%' || '' || '%') ) OR ( vorname LIKE ('%' || 'Vorname1' || '%') AND nachname LIKE ('%' || '1Nachname' || '%') AND 'Vorname1' != '' AND 'xxxx' != '' ) ) )",
+    env: {
+      t1: [
         {
-          kunde_intern_id:3964,
-          kunde_id:3051,
-          FK_firma_id:1,
-          aktuell:"Ja",
-          vorname:"Vorname1",
-          nachname:"1Nachname",
-          geloescht:"Nein",
-          firma:"Print Schau XXXX"
+          kunde_intern_id: 3964,
+          kunde_id: 3051,
+          FK_firma_id: 1,
+          aktuell: "Ja",
+          vorname: "Vorname1",
+          nachname: "1Nachname",
+          geloescht: "Nein",
+          firma: "Print Schau XXXX"
         },
         {
-          kunde_intern_id:3965,
-          kunde_id:3051111,
-          FK_firma_id:1,
-          aktuell:"Ja",
-          vorname:"Vorname1111",
-          nachname:"1111Nachname",
-          geloescht:"Nein",
-          firma:"Print Schau XXXX"
+          kunde_intern_id: 3965,
+          kunde_id: 3051111,
+          FK_firma_id: 1,
+          aktuell: "Ja",
+          vorname: "Vorname1111",
+          nachname: "1111Nachname",
+          geloescht: "Nein",
+          firma: "Print Schau XXXX"
         }
       ]
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$bag::[
-      ]
+      output: $bag::[]
     }
   }
 ]

--- a/partiql-tests-data/eval/spec-tests.ion
+++ b/partiql-tests-data/eval/spec-tests.ion
@@ -1,793 +1,1255 @@
 'section-4'::[
-    {
-        name: "array navigation",
-        statement: "[2, 4, 6][1 + 1]",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: 6
-        }
+  {
+    name: "array navigation",
+    statement: "[2, 4, 6][1 + 1]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 6
+    }
+  },
+  {
+    name: "tuple navigation with array notation with explicit CAST to string",
+    statement: "{'attr': 1, 'b':2}[CAST('at' || 'tr' AS STRING)]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 1
+    }
+  },
+  {
+    name: "tuple navigation with array notation without explicit CAST to string",
+    statement: "{'attr': 1, 'b': 2}[v || w]",
+    env: {
+      v: "at",
+      w: "tr"
     },
-    {
-        name: "tuple navigation with array notation with explicit CAST to string",
-        statement: "{'attr': 1, 'b':2}[CAST('at' || 'tr' AS STRING)]",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: 1
-        }
-    },
-    {
-        name: "tuple navigation with array notation without explicit CAST to string",
-        statement: "{'attr': 1, 'b': 2}[v || w]",
-        env: {
-            v: "at",
-            w: "tr"
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
+  },
+  {
+    name: "path on string",
+    statement: "'not a tuple'.a",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
+  },
+  {
+    name: "tuple navigation missing attribute dot notation",
+    statement: "{'a':1, 'b':2}.noSuchAttribute",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "tuple navigation missing attribute array notation",
+    statement: "{'a': 1, 'b': 2}['noSuchAttribute']",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "array navigation with wrongly typed array index",
+    statement: "[1, 2, 3][1.0]",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "wildcard steps in SELECT clause item",
+    statement: "SELECT t.* FROM <<{'a':1, 'b':1}, {'a':2, 'b':2}>> AS t",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          a: 1,
+          b: 1
         },
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $missing::null
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            },
-        ]
-    },
-    {
-        name: "path on string",
-        statement: "'not a tuple'.a",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $missing::null
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            },
-        ]
-    },
-    {
-        name: "tuple navigation missing attribute dot notation",
-        statement: "{'a':1, 'b':2}.noSuchAttribute",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $missing::null
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            }
-        ]
-    },
-    {
-        name: "tuple navigation missing attribute array notation",
-        statement: "{'a': 1, 'b': 2}['noSuchAttribute']",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $missing::null
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            }
-        ]
-    },
-    {
-        name: "array navigation with wrongly typed array index",
-        statement: "[1, 2, 3][1.0]",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $missing::null
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            }
-        ]
-    },
-    {
-        name: "wildcard steps in SELECT clause item",
-        statement: "SELECT t.* FROM <<{'a':1, 'b':1}, {'a':2, 'b':2}>> AS t",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{a: 1, b: 1}, {a: 2, b: 2}]
+        {
+          a: 2,
+          b: 2
         }
-    },
+      ]
+    }
+  },
 ]
 
 'section-5'::[
-    envs::{
-        someOrderedTable: [
-            {a: 0, b: 0},
-            {a: 1, b: 1}
-        ],
-        someUnorderedTable: $bag::[
-            {a: 0, b: 0},
-            {a: 1, b: 1}
-        ]
-    },
-    {
-        name: "single source FROM with list and AT clause",
-        statement: "SELECT x, y FROM someOrderedTable AS x AT y",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{x: {a: 0, b: 0}, y: 0}, {x: {a: 1, b: 1}, y: 1}]
+  envs::{
+    someOrderedTable: [
+      {
+        a: 0,
+        b: 0
+      },
+      {
+        a: 1,
+        b: 1
+      }
+    ],
+    someUnorderedTable: $bag::[
+      {
+        a: 0,
+        b: 0
+      },
+      {
+        a: 1,
+        b: 1
+      }
+    ]
+  },
+  {
+    name: "single source FROM with list and AT clause",
+    statement: "SELECT x, y FROM someOrderedTable AS x AT y",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          x: {
+            a: 0,
+            b: 0
+          },
+          y: 0
+        },
+        {
+          x: {
+            a: 1,
+            b: 1
+          },
+          y: 1
         }
-    },
-    {
-        name: "single source FROM with bag and AT clause",
-        statement: "SELECT x, y FROM someUnorderedTable AS x AT y",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{x: {a: 0, b: 0}}, {x: {a: 1, b: 1}}]
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            }
-        ]
-    },
-    {
-        name: "single source FROM with scalar",
-        statement: "SELECT x FROM someOrderedTable[0].a AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{x: 0}]
-        }
-    },
-    {
-        name: "single source FROM with scalar and AT clause",
-        statement: "SELECT x, p FROM someOrderedTable[0].a AS x AT p",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{x: 0}]
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            },
-        ]
-    },
-    {
-        name: "single source FROM with tuple",
-        statement: "SELECT x FROM {'someKey': 'someValue' } AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{x: {someKey: "someValue"}}]
-        }
-    },
-    {
-        name: "single source FROM with tuple and AT clause",
-        statement: "SELECT x, p FROM {'someKey': 'someValue' } AS x AT p",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{x: {someKey: "someValue"}}]
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            },
-        ]
-    },
-    {
-        name: "single source FROM with absent value null",
-        statement: "SELECT x FROM NULL AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{x: null}]
-        }
-    },
-    {
-        name: "single source FROM with absent value null and AT clause",
-        statement: "SELECT x, p FROM NULL AS x AT p",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{x: null}]
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            },
-        ]
-    },
-    {
-        name: "single source FROM with absent value missing",
-        statement: "SELECT x FROM MISSING AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{}]
-        }
-    },
-    {
-        name: "single source FROM with absent value missing and AT clause",
-        statement: "SELECT x, p FROM MISSING AS x AT p",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{}]
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            },
-        ]
-    },
-    {
-        name: "ranging over attribute value pairs with UNPIVOT",
-        statement: "SELECT price, \"symbol\" FROM UNPIVOT justATuple AS price AT \"symbol\"",
-        env: { justATuple: {amzn: 840.05, tdc: 31.06} },
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{price: 840.05, symbol: "amzn"}, {price: 31.06, symbol: "tdc"}]
-        }
+      ]
     }
+  },
+  {
+    name: "single source FROM with bag and AT clause",
+    statement: "SELECT x, y FROM someUnorderedTable AS x AT y",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            x: {
+              a: 0,
+              b: 0
+            }
+          },
+          {
+            x: {
+              a: 1,
+              b: 1
+            }
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
+  },
+  {
+    name: "single source FROM with scalar",
+    statement: "SELECT x FROM someOrderedTable[0].a AS x",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          x: 0
+        }
+      ]
+    }
+  },
+  {
+    name: "single source FROM with scalar and AT clause",
+    statement: "SELECT x, p FROM someOrderedTable[0].a AS x AT p",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            x: 0
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
+  },
+  {
+    name: "single source FROM with tuple",
+    statement: "SELECT x FROM {'someKey': 'someValue' } AS x",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          x: {
+            someKey: "someValue"
+          }
+        }
+      ]
+    }
+  },
+  {
+    name: "single source FROM with tuple and AT clause",
+    statement: "SELECT x, p FROM {'someKey': 'someValue' } AS x AT p",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            x: {
+              someKey: "someValue"
+            }
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
+  },
+  {
+    name: "single source FROM with absent value null",
+    statement: "SELECT x FROM NULL AS x",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          x: null
+        }
+      ]
+    }
+  },
+  {
+    name: "single source FROM with absent value null and AT clause",
+    statement: "SELECT x, p FROM NULL AS x AT p",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            x: null
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
+  },
+  {
+    name: "single source FROM with absent value missing",
+    statement: "SELECT x FROM MISSING AS x",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {}
+      ]
+    }
+  },
+  {
+    name: "single source FROM with absent value missing and AT clause",
+    statement: "SELECT x, p FROM MISSING AS x AT p",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {}
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
+  },
+  {
+    name: "ranging over attribute value pairs with UNPIVOT",
+    statement: "SELECT price, \"symbol\" FROM UNPIVOT justATuple AS price AT \"symbol\"",
+    env: {
+      justATuple: {
+        amzn: 840.05,
+        tdc: 31.06
+      }
+    },
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          price: 840.05,
+          symbol: "amzn"
+        },
+        {
+          price: 31.06,
+          symbol: "tdc"
+        }
+      ]
+    }
+  }
 ]
 
 'section-6'::[
-    {
-        name: "select value",
-        statement: "SELECT VALUE 2*x.a FROM [{'a':1}, {'a':2}, {'a':3}] as x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[2, 4, 6]
+  {
+    name: "select value",
+    statement: "SELECT VALUE 2*x.a FROM [{'a':1}, {'a':2}, {'a':3}] as x",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        2,
+        4,
+        6
+      ]
+    }
+  },
+  {
+    name: "select value with tuple constructor",
+    statement: "SELECT VALUE {'a':v.a, 'b':v.b} FROM [{'a':1, 'b':1}, {'a':2, 'b':2}] AS v",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          a: 1,
+          b: 1
+        },
+        {
+          a: 2,
+          b: 2
         }
-    },
-    {
-        name: "select value with tuple constructor",
-        statement: "SELECT VALUE {'a':v.a, 'b':v.b} FROM [{'a':1, 'b':1}, {'a':2, 'b':2}] AS v",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{a:1, b:1}, {a:2, b:2}]
-        }
-    },
-    {
-        name: "tuple constructor and mistyped attribute name",
-        statement: "SELECT VALUE {v.a: v.b} FROM [{'a':'legit', 'b':1}, {'a':400, 'b':2}] AS v",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{legit:1}, {}]
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            },
+      ]
+    }
+  },
+  {
+    name: "tuple constructor and mistyped attribute name",
+    statement: "SELECT VALUE {v.a: v.b} FROM [{'a':'legit', 'b':1}, {'a':400, 'b':2}] AS v",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            legit: 1
+          },
+          {}
         ]
-    },
-    {
-        name: "duplicate attribute names",
-        statement: "SELECT VALUE {v.a: v.b, v.c: v.d} FROM [{'a':'same', 'b':1, 'c':'same', 'd':2}] AS v",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{same:1, same:2}]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
+  },
+  {
+    name: "duplicate attribute names",
+    statement: "SELECT VALUE {v.a: v.b, v.c: v.d} FROM [{'a':'same', 'b':1, 'c':'same', 'd':2}] AS v",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          same: 1,
+          same: 2
         }
-    },
-    {
-        name: "bag constructor",
-        statement: "SELECT VALUE <<v.a, v.b>> FROM [{'a':1, 'b':1}, {'a':2, 'b':2}] AS v",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[$bag::[1, 1], $bag::[2, 2]]
-        }
-    },
-    {
-        name: "attribute value evaluates to MISSING",
-        statement: "SELECT VALUE {'a':v.a, 'b':v.b} FROM [{'a':1, 'b':1}, {'a':2}] AS v",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{a:1, b:1}, {a:2}]
-            },
-            {
-                evalMode:EvalModeError,
-                result:EvaluationFail
-            },
+      ]
+    }
+  },
+  {
+    name: "bag constructor",
+    statement: "SELECT VALUE <<v.a, v.b>> FROM [{'a':1, 'b':1}, {'a':2, 'b':2}] AS v",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        $bag::[
+          1,
+          1
+        ],
+        $bag::[
+          2,
+          2
         ]
-    },
-    {
-        name: "array element evaluates to MISSING",
-        statement: "SELECT VALUE [v.a, v.b] FROM [{'a':1, 'b':1}, {'a':2}] AS v",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[[1, 1], [2, $missing::null]]
-            },
-            {
-                evalMode:EvalModeError,
-                result:EvaluationFail
-            },
+      ]
+    }
+  },
+  {
+    name: "attribute value evaluates to MISSING",
+    statement: "SELECT VALUE {'a':v.a, 'b':v.b} FROM [{'a':1, 'b':1}, {'a':2}] AS v",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            a: 1,
+            b: 1
+          },
+          {
+            a: 2
+          }
         ]
-    },
-    {
-        name: "bag element evaluates to MISSING",
-        statement: "SELECT VALUE v.b FROM [{'a':1, 'b':1}, {'a':2}] AS v",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[1, $missing::null]
-            },
-            {
-                evalMode:EvalModeError,
-                result:EvaluationFail
-            },
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+    ]
+  },
+  {
+    name: "array element evaluates to MISSING",
+    statement: "SELECT VALUE [v.a, v.b] FROM [{'a':1, 'b':1}, {'a':2}] AS v",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          [
+            1,
+            1
+          ],
+          [
+            2,
+            $missing::null
+          ]
         ]
-    },
-    {
-        name: "bag element evaluates to MISSING in bag constructor",
-        statement: "SELECT VALUE <<v.a, v.b>> FROM [{'a':1, 'b':1}, {'a':2}] AS v",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[$bag::[1, 1], $bag::[2, $missing::null]]
-            },
-            {
-                evalMode:EvalModeError,
-                result:EvaluationFail
-            },
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+    ]
+  },
+  {
+    name: "bag element evaluates to MISSING",
+    statement: "SELECT VALUE v.b FROM [{'a':1, 'b':1}, {'a':2}] AS v",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          1,
+          $missing::null
         ]
-    },
-    {
-        name: "pivot into a tuple",
-        statement: "PIVOT t.price AT t.sym FROM [{'sym':'tdc', 'price': 31.52}, {'sym': 'amzn', 'price': 840.05}] AS t",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: {tdc:31.52, amzn:840.05}
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+    ]
+  },
+  {
+    name: "bag element evaluates to MISSING in bag constructor",
+    statement: "SELECT VALUE <<v.a, v.b>> FROM [{'a':1, 'b':1}, {'a':2}] AS v",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          $bag::[
+            1,
+            1
+          ],
+          $bag::[
+            2,
+            $missing::null
+          ]
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+    ]
+  },
+  {
+    name: "pivot into a tuple",
+    statement: "PIVOT t.price AT t.sym FROM [{'sym':'tdc', 'price': 31.52}, {'sym': 'amzn', 'price': 840.05}] AS t",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: {
+        tdc: 31.52,
+        amzn: 840.05
+      }
+    }
+  },
+  {
+    name: "pivot into a tuple with invalid attribute name",
+    statement: "PIVOT t.price AT t.sym FROM [{'sym':25, 'price':31.52}, {'sym':'amzn', 'price':840.05}] AS t",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: {
+        amzn: 840.05
+      }
+    }
+  },
+  {
+    name: "select variable star with non tuples",
+    statement: "SELECT x.* FROM [{'a':1, 'b':1}, {'a':2}, 'foo'] AS x",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          a: 1,
+          b: 1
+        },
+        {
+          a: 2
+        },
+        {
+          _1: "foo"
         }
-    },
-    {
-        name: "pivot into a tuple with invalid attribute name",
-        statement: "PIVOT t.price AT t.sym FROM [{'sym':25, 'price':31.52}, {'sym':'amzn', 'price':840.05}] AS t",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: {amzn: 840.05}
-        }
-    },
-    {
-        name: "select variable star with non tuples",
-        statement: "SELECT x.* FROM [{'a':1, 'b':1}, {'a':2}, 'foo'] AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{a:1, b:1}, {a:2}, {_1:"foo"}]
-        }
-    },
-    {
-        name: "unpivot with pivot to analyze attribute names",
-        statement: '''SELECT VALUE (PIVOT v AT g
+      ]
+    }
+  },
+  {
+    name: "unpivot with pivot to analyze attribute names",
+    statement: '''SELECT VALUE (PIVOT v AT g
                                   FROM UNPIVOT r AS v AT g
                                   WHERE g LIKE 'co%')
                     FROM sensors AS r''',
-        env: {
-            sensors: [{no2:0.6, co:0.7, co2:0.5},
-                      {no2:0.5, co:0.4, co2:1.3}
-                     ]
+    env: {
+      sensors: [
+        {
+          no2: 0.6,
+          co: 0.7,
+          co2: 0.5
         },
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{co:0.7, co2:0.5}, {co:0.4, co2:1.3}]
+        {
+          no2: 0.5,
+          co: 0.4,
+          co2: 1.3
         }
+      ]
     },
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          co: 0.7,
+          co2: 0.5
+        },
+        {
+          co: 0.4,
+          co2: 1.3
+        }
+      ]
+    }
+  },
 ]
 
 'section-7'::[
-    {
-        name: "cast and operations with missing argument",
-        statement: "SELECT VALUE {'a':3*v.a, 'b':3*(CAST(v.b AS INTEGER))} FROM [{'a':1, 'b':'1'}, {'a':2}] v",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[{a:3, b:3}, {a:6}]
-            },
-            {
-                evalMode:EvalModeError,
-                result:EvaluationFail
-            },
+  {
+    name: "cast and operations with missing argument",
+    statement: "SELECT VALUE {'a':3*v.a, 'b':3*(CAST(v.b AS INTEGER))} FROM [{'a':1, 'b':'1'}, {'a':2}] v",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            a: 3,
+            b: 3
+          },
+          {
+            a: 6
+          }
         ]
-    },
-    {
-        name: "missing value in arithmetic expression",
-        statement: "5 + missing",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $missing::null
-        }
-    },
-    {
-        name: "data type mismatch in comparison expression",
-        statement: "5 > 'a'",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $missing::null
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            },
-        ]
-    },
-    {
-        name: "data type mismatch in logical expression",
-        statement: "NOT {a: 1}",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $missing::null
-            },
-            {
-                evalMode: EvalModeError,
-                result: EvaluationFail,
-            },
-        ]
-    },
-    {
-        name: "equality always returns boolean",
-        statement: "5 = 'a'",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: false
-        }
-    },
-    {
-        name: "equality of scalar null",
-        statement: "NULL = NULL",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: null
-        }
-    },
-    {
-        name: "equality of null in array",
-        statement: "[NULL] = [NULL]",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: true
-        }
-    },
-    {
-        name: "equality of scalar missing",
-        statement: "MISSING = MISSING",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $missing::null
-        }
-    },
-    {
-        name: "equality of missing in array",
-        statement: "[MISSING] = [MISSING]",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: true
-        }
-    },
-    {
-        name: "equality of arrays of different lengths",
-        statement: "[NULL, MISSING] = [NULL]",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: false
-        }
-    },
-    {
-        name: "equality of equal tuples",
-        statement: "{'a':1, 'b':2} = {'b':2, 'a':1}",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: true
-        }
-    },
-    {
-        name: "equality of different tuples",
-        statement: "{'a':1, 'b':2} = {'a':1}",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: false
-        }
-    },
-    {
-        name: "equality of different tuples with null attribute",
-        statement: "{'a':1, 'b':2} = {'a':1, 'b': null}",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: false
-        }
-    },
-    {
-        name: "equality of same element bags",
-        statement: "<<3, 2, 4, 2>> = <<2, 2, 3, 4>>",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: true
-        }
-    },
-    {
-        name: "equality of different element bags",
-        statement: "<<3, 4, 2>> = <<2, 2, 3, 4>>",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: false
-        }
-    },
-    {
-        name: "equality of mixed equal container types",
-        statement: "{'a':[0,1], 'b':2} = {'b':2, 'a':[0,1]}",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: true
-        }
-    },
-    {
-        name: "equality of mixed non equal container types",
-        statement: "{'a':[0,1], 'b':2} = {'b':2, 'a':[0,1,2]}",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: false
-        }
-    },
-    {
-        name: "equality of mixed non equal container types with null",
-        statement: "{'a':[0,1], 'b':2} = {'b':2, 'a':[null,1]}",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: false
-        }
-    },
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+    ]
+  },
+  {
+    name: "missing value in arithmetic expression",
+    statement: "5 + missing",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      },
+      {
+        result: EvaluationFail,
+        evalMode: EvalModeError
+      }
+    ]
+  },
+  {
+    name: "data type mismatch in comparison expression",
+    statement: "5 > 'a'",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
+  },
+  {
+    name: "data type mismatch in logical expression",
+    statement: "NOT {a: 1}",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
+  },
+  {
+    name: "equality always returns boolean",
+    statement: "5 = 'a'",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
+    }
+  },
+  {
+    name: "equality of scalar null",
+    statement: "NULL = NULL",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "equality of null in array",
+    statement: "[NULL] = [NULL]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
+    }
+  },
+  {
+    name: "equality of scalar missing",
+    statement: "MISSING = MISSING",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $missing::null
+    }
+  },
+  {
+    name: "equality of missing in array",
+    statement: "[MISSING] = [MISSING]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
+    }
+  },
+  {
+    name: "equality of arrays of different lengths",
+    statement: "[NULL, MISSING] = [NULL]",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
+    }
+  },
+  {
+    name: "equality of equal tuples",
+    statement: "{'a':1, 'b':2} = {'b':2, 'a':1}",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
+    }
+  },
+  {
+    name: "equality of different tuples",
+    statement: "{'a':1, 'b':2} = {'a':1}",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
+    }
+  },
+  {
+    name: "equality of different tuples with null attribute",
+    statement: "{'a':1, 'b':2} = {'a':1, 'b': null}",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
+    }
+  },
+  {
+    name: "equality of same element bags",
+    statement: "<<3, 2, 4, 2>> = <<2, 2, 3, 4>>",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
+    }
+  },
+  {
+    name: "equality of different element bags",
+    statement: "<<3, 4, 2>> = <<2, 2, 3, 4>>",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
+    }
+  },
+  {
+    name: "equality of mixed equal container types",
+    statement: "{'a':[0,1], 'b':2} = {'b':2, 'a':[0,1]}",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
+    }
+  },
+  {
+    name: "equality of mixed non equal container types",
+    statement: "{'a':[0,1], 'b':2} = {'b':2, 'a':[0,1,2]}",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
+    }
+  },
+  {
+    name: "equality of mixed non equal container types with null",
+    statement: "{'a':[0,1], 'b':2} = {'b':2, 'a':[null,1]}",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
+    }
+  },
 ]
 
 'section-8'::[
-    {
-        name: "missing and true",
-        statement: "MISSING AND TRUE",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: null
-        }
-    },
-    {
-        name: "null and true",
-        statement: "NULL AND TRUE",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: null
-        }
-    },
-    {
-        name: "WHERE clause eliminating absent values",
-        statement: "SELECT VALUE v.a FROM [{'a':1, 'b':true}, {'a':2, 'b':null}, {'a':3}] v WHERE v.b",
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[1]
-            },
-            {
-                evalMode:EvalModeError,
-                result:EvaluationFail
-            },
+  {
+    name: "missing and true",
+    statement: "MISSING AND TRUE",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "null and true",
+    statement: "NULL AND TRUE",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: null
+    }
+  },
+  {
+    name: "WHERE clause eliminating absent values",
+    statement: "SELECT VALUE v.a FROM [{'a':1, 'b':true}, {'a':2, 'b':null}, {'a':3}] v WHERE v.b",
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          1
         ]
-    },
-    {
-        name: "null is missing",
-        statement: "NULL IS MISSING",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: false
-        }
-    },
-    {
-        name: "missing is missing",
-        statement: "MISSING IS MISSING",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: true
-        }
-    },
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+    ]
+  },
+  {
+    name: "null is missing",
+    statement: "NULL IS MISSING",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: false
+    }
+  },
+  {
+    name: "missing is missing",
+    statement: "MISSING IS MISSING",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: true
+    }
+  },
 ]
 
 'section-9'::[
-    {
-        name: "inner select evaluating to collection with more than one element",
-        statement:
-            '''
+  {
+    name: "inner select evaluating to collection with more than one element",
+    statement:
+    '''
             SELECT o.name AS orderName,
                    (SELECT c.name FROM customers c WHERE c.id=o.custId) AS customerName
             FROM orders o
             ''',
-        env: {
-            customers : [{id:1, name: "Mary"},
-                         {id:2, name: "Helen"},
-                         {id:1, name: "John"}
-                        ],
-            orders : [{custId:1, name: "foo"},
-                      {custId:2, name: "bar"}
-                     ]
+    env: {
+      customers: [
+        {
+          id: 1,
+          name: "Mary"
         },
-        assert: {
-            evalMode: EvalModeCoerce,
-            result: EvaluationSuccess,
-            output: $bag::[{orderName:"foo"}, {orderName:"bar", customerName:"Helen"}]
+        {
+          id: 2,
+          name: "Helen"
+        },
+        {
+          id: 1,
+          name: "John"
         }
+      ],
+      orders: [
+        {
+          custId: 1,
+          name: "foo"
+        },
+        {
+          custId: 2,
+          name: "bar"
+        }
+      ]
     },
+    assert: {
+      evalMode: EvalModeCoerce,
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          orderName: "foo"
+        },
+        {
+          orderName: "bar",
+          customerName: "Helen"
+        }
+      ]
+    }
+  },
 ]
 
 'section-11'::[
-    envs::{
-        sensors: [{sensor:1}, {'sensor':2}],
-        logs: [{sensor:1, co:0.4}, {sensor:1, co:0.2}, {sensor:2, co:0.3}]
-    },
-    {
-        name: "group by without aggregates",
-        statement:
-            '''
+  envs::{
+    sensors: [
+      {
+        sensor: 1
+      },
+      {
+        'sensor': 2
+      }
+    ],
+    logs: [
+      {
+        sensor: 1,
+        co: 0.4
+      },
+      {
+        sensor: 1,
+        co: 0.2
+      },
+      {
+        sensor: 2,
+        co: 0.3
+      }
+    ]
+  },
+  {
+    name: "group by without aggregates",
+    statement:
+    '''
             SELECT VALUE {'sensor': sensor,
                           'readings': (SELECT VALUE v.l.co FROM g AS v) }
             FROM logs AS l
             GROUP BY l.sensor AS sensor GROUP AS g
         ''',
-        env: {
-            sensors: [{sensor:1}, {'sensor':2}],
-            logs: [{sensor:1, co:0.4}, {sensor:1, co:0.2}, {sensor:2, co:0.3}]
+    env: {
+      sensors: [
+        {
+          sensor: 1
         },
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{sensor:1, readings:$bag::[0.4, 0.2]},
-                           {sensor:2, readings:$bag::[0.3]}
-            ]
+        {
+          'sensor': 2
         }
-    },
-    {
-        name: "coll_count without group by",
-        statement: "COLL_COUNT([5, {a:2, b:3}])",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: 2
+      ],
+      logs: [
+        {
+          sensor: 1,
+          co: 0.4
+        },
+        {
+          sensor: 1,
+          co: 0.2
+        },
+        {
+          sensor: 2,
+          co: 0.3
         }
+      ]
     },
-    {
-        name: "coll_count with result of subquery",
-        statement: "COLL_COUNT(SELECT VALUE x FROM logs x WHERE x.sensor=1)",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: 2
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          sensor: 1,
+          readings: $bag::[
+            0.4,
+            0.2
+          ]
+        },
+        {
+          sensor: 2,
+          readings: $bag::[
+            0.3
+          ]
         }
-    },
-    {
-        name: "group by with absent values",
-        statement:
-            '''
+      ]
+    }
+  },
+  {
+    name: "coll_count without group by",
+    statement: "COLL_COUNT([5, {a:2, b:3}])",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 2
+    }
+  },
+  {
+    name: "coll_count with result of subquery",
+    statement: "COLL_COUNT(SELECT VALUE x FROM logs x WHERE x.sensor=1)",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: 2
+    }
+  },
+  {
+    name: "group by with absent values",
+    statement:
+    '''
             SELECT VALUE {'sensor': sensor,
                           'readings': (SELECT VALUE v.l.co FROM g AS v) }
             FROM logs AS l
             GROUP BY l.sensor AS sensor GROUP AS g
         ''',
-        env: {
-            logs:[
-                {sensor: 1, co:0.4},
-                {sensor: 2, co:0.3},
-                {sensor: null, co:0.1},
-                {sensor: 1, co:0.2},
-                {co:0.5}
-            ]
+    env: {
+      logs: [
+        {
+          sensor: 1,
+          co: 0.4
         },
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[
-                    {sensor:1, readings:$bag::[0.4, 0.2]},
-                    {sensor:2, readings:$bag::[0.3]},
-                    {sensor:null, readings:$bag::[0.1, 0.5]}
-                ]
-            },
-            {
-                evalMode:EvalModeError,
-                result:EvaluationFail
-            },
+        {
+          sensor: 2,
+          co: 0.3
+        },
+        {
+          sensor: null,
+          co: 0.1
+        },
+        {
+          sensor: 1,
+          co: 0.2
+        },
+        {
+          co: 0.5
+        }
+      ]
+    },
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            sensor: 1,
+            readings: $bag::[
+              0.4,
+              0.2
+            ]
+          },
+          {
+            sensor: 2,
+            readings: $bag::[
+              0.3
+            ]
+          },
+          {
+            sensor: null,
+            readings: $bag::[
+              0.1,
+              0.5
+            ]
+          }
         ]
-    },
-    {
-        name: "group by with differenciated absent values",
-        statement:
-            '''
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+    ]
+  },
+  {
+    name: "group by with differenciated absent values",
+    statement:
+    '''
             SELECT VALUE {'sensor': CASE WHEN missingFlag THEN MISSING ELSE sensor END,
                           'readings': (SELECT VALUE v.l.co FROM g AS v) }
             FROM logs AS l
             GROUP BY l.sensor IS MISSING AS missingFlag, l.sensor AS sensor GROUP AS g
         ''',
-        env: {
-            logs:[
-                {sensor: 1, co:0.4},
-                {sensor: 2, co:0.3},
-                {sensor: null, co:0.1},
-                {sensor: 1, co:0.2},
-                {co:0.5}
-            ]
+    env: {
+      logs: [
+        {
+          sensor: 1,
+          co: 0.4
         },
-        assert: [
-            {
-                evalMode: EvalModeCoerce,
-                result: EvaluationSuccess,
-                output: $bag::[
-                    {sensor:1, readings:$bag::[0.4, 0.2]},
-                    {sensor:2, readings:$bag::[0.3]},
-                    {sensor:null, readings:$bag::[0.1]},
-                    {readings:$bag::[0.5]}
-                ]
-            },
-            {
-                evalMode:EvalModeError,
-                result:EvaluationFail
-            },
-        ]
+        {
+          sensor: 2,
+          co: 0.3
+        },
+        {
+          sensor: null,
+          co: 0.1
+        },
+        {
+          sensor: 1,
+          co: 0.2
+        },
+        {
+          co: 0.5
+        }
+      ]
     },
-    {
-        name: "windowing simplified with grouping",
-        statement:
-            '''
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            sensor: 1,
+            readings: $bag::[
+              0.4,
+              0.2
+            ]
+          },
+          {
+            sensor: 2,
+            readings: $bag::[
+              0.3
+            ]
+          },
+          {
+            sensor: null,
+            readings: $bag::[
+              0.1
+            ]
+          },
+          {
+            readings: $bag::[
+              0.5
+            ]
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+    ]
+  },
+  {
+    name: "windowing simplified with grouping",
+    statement:
+    '''
             SELECT sensor AS sensor,
                    (WITH orderedReadings
                          AS (SELECT v FROM oneSensorsReadings v ORDER BY v.timestamp)
@@ -799,37 +1261,76 @@
             FROM logs l
             GROUP BY l.sensor AS sensor GROUP AS oneSensorsReadings
             ''',
-        env: {
-            logs: [{sensor:1, co:0.4, timestamp: $time::"04:05:06"},    // ex in spec used an undocumented timestamp
-                   {sensor:1, co:0.2, timestamp: $time::"04:05:07"},    // syntax. changed to use time annotation
-                   {sensor:1, co:0.5, timestamp: $time::"04:05:10"},    // in the test suite
-                   {sensor:2, co:0.3}
-            ]
+    env: {
+      logs: [
+        {
+          sensor: 1,
+          co: 0.4,
+          timestamp: $time::"04:05:06"
         },
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[
-                {sensor:1, jumpReadings:[{co:0.4, timestamp: $time::"04:05:06"}]},
-                {sensor:2, jumpReadings:[]}
-            ]
+        // ex in spec used an undocumented timestamp
+        {
+          sensor: 1,
+          co: 0.2,
+          timestamp: $time::"04:05:07"
+        },
+        // syntax. changed to use time annotation
+        {
+          sensor: 1,
+          co: 0.5,
+          timestamp: $time::"04:05:10"
+        },
+        // in the test suite
+        {
+          sensor: 2,
+          co: 0.3
         }
+      ]
     },
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: $bag::[
+        {
+          sensor: 1,
+          jumpReadings: [
+            {
+              co: 0.4,
+              timestamp: $time::"04:05:06"
+            }
+          ]
+        },
+        {
+          sensor: 2,
+          jumpReadings: []
+        }
+      ]
+    }
+  },
 ]
 
 'section-13'::[
-    // TODO: RFC#0007 bag operators (https://github.com/partiql/partiql-docs/blob/main/RFCs/0007-rfc-bag-operators.md)
-    // TODO: once added to spec, port tests in eval/rfc/0007.ion
+  // TODO: RFC#0007 bag operators (https://github.com/partiql/partiql-docs/blob/main/RFCs/0007-rfc-bag-operators.md)
+  // TODO: once added to spec, port tests in eval/rfc/0007.ion
 ]
 
 'section-14'::[
-    {
-        name: "pivot to tuple from collection of tuples",
-        statement: "PIVOT x.v AT x.a FROM << {'a': 'first', 'v': 'john'}, {'a': 'last', 'v': 'doe'} >> AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: {first:"john", last:"doe"}
-        }
-    },
+  {
+    name: "pivot to tuple from collection of tuples",
+    statement: "PIVOT x.v AT x.a FROM << {'a': 'first', 'v': 'john'}, {'a': 'last', 'v': 'doe'} >> AS x",
+    assert: {
+      evalMode: [
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      result: EvaluationSuccess,
+      output: {
+        first: "john",
+        last: "doe"
+      }
+    }
+  },
 ]


### PR DESCRIPTION
# Description

Fixes around 100 missing arguments tests. Previous ones didn't fail in EvalModeError when inputs were the missing value.

Example of one of the tests:
```
MOD(MISSING, 3)
```

From the PartiQL Specification ([Section 7.1: Inputs with wrong types](https://partiql.org/partiql-lang/#sec:fns-with-wrong-inputs)):
> Unlike SQL where typing issues can be detected during query compilation, the permissive option of PartiQL has to define semantics for the case where the inputs of a function are not compatible with the function/predicate arguments. Furthermore, PartiQL facilitates propagating missing input attributes to respective missing output attributes.
> Alike SQL, all functions have input argument types that they conform to. For example, the function log expects numbers. All functions return MISSING when they input data whose types do not conform to the input argument types. Since no function (other than IS MISSING) has MISSING as an input argument type, it follows that all functions return MISSING when one of their inputs is MISSING.

An important thing to note is the use of "the permissive option of PartiQL has to define semantics for the case where the inputs of a function are not compatible with the function/predicate arguments." It goes on to describe the missing value as inputs, and it defines the behavior in permissive mode. It doesn't explicitly specify what happens in strict mode, however, we may assume the same behavior seen in all other sections of the Specification. See [Section 5.1.1 Mistyping Cases](https://partiql.org/partiql-lang/#sec:bag-array-mistypings), [Section 5.2.1 Mistyping cases](https://partiql.org/partiql-lang/#sec:unpivot-mistypings), [Section 4.1 Tuple path evaluation on wrongly typed data](https://partiql.org/partiql-lang/#sec:tuple-path-on-wrong), etc.

Another example of throwing errors comes down to the role of schema in type checking. From [Section 4.1.1](https://partiql.org/partiql-lang/#sec:schema-in-tuple-path):
> In a more important and common case, an PartiQL implementation can utilize the input data schema to prove that a path expression always returns MISSING and thus throw a compile-time error.

**NOTE**: You should review using "Ignore whitespace". I used auto-formatting on fixed test files using the IDE since the formatting was poor.

# License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.