### PR TITLE
Fixes several tests

### DIFF
--- a/partiql-tests-data/eval-equiv/spec-tests.ion
+++ b/partiql-tests-data/eval-equiv/spec-tests.ion
@@ -107,11 +107,17 @@
                 ]
             }
         },
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[1, 2]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[1, 2]
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail,
+            }
+        ]
     },
 ]
 'section-5'::[

--- a/partiql-tests-data/eval/misc.ion
+++ b/partiql-tests-data/eval/misc.ion
@@ -95,17 +95,23 @@ uncategorized::[
   {
     name:"variableShadow",  // Note that i, f, d, and s are defined in the global environment
     statement:"SELECT f, d, s FROM i AS f, f AS d, @f AS s WHERE f = 1 AND d = 2e0 and s = 1",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          f:1,
-          d:2e0,
-          s:1
-        }
-      ]
-    }
+    assert:[
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            f: 1,
+            d: 2e0,
+            s: 1
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      }
+    ]
   },
   {
     name:"selectValueStructConstructorWithMissing",
@@ -132,15 +138,21 @@ uncategorized::[
   {
     name:"selectIndexStruct",
     statement:"SELECT VALUE x[0] FROM (SELECT s.id FROM stores AS s) AS x",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        "5",
-        "6",
-        "7"
-      ]
-    }
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          $missing::null,
+          $missing::null,
+          $missing::null
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      }
+    ]
   },
   {
     name:"selectStarSingleSource",
@@ -212,27 +224,39 @@ uncategorized::[
   {
     name:"emptySymbol",
     statement:"SELECT \"\" FROM `{'': 1}`",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
           '':1
-        }
-      ]
-    }
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      }
+    ]
   },
   {
     name:"emptySymbolInGlobals",
     statement:"SELECT * FROM \"\"",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          _1:1
-        }
-      ]
-    }
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
+            _1:1
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      }
+    ]
   }
 ]

--- a/partiql-tests-data/eval/primitives/date-time.ion
+++ b/partiql-tests-data/eval/primitives/date-time.ion
@@ -2,20 +2,26 @@ regression::[
   {
     name:"dateTimePartsAsVariableNames",
     statement:"SELECT VALUE [year, month, day, hour, minute, second] FROM 1968 AS year, 4 AS month, 3 as day, 12 as hour, 31 as minute, 59 as second",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          1968,
-          4,
-          3,
-          12,
-          31,
-          59
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            1968,
+            4,
+            3,
+            12,
+            31,
+            59
+          ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"dateTimePartsAsStructFieldNames",

--- a/partiql-tests-data/eval/primitives/operators/bag-operators.ion
+++ b/partiql-tests-data/eval/primitives/operators/bag-operators.ion
@@ -146,40 +146,60 @@ bagOperators::[
   {
     name:"outerUnionCoerceScalar",
     statement:"1 OUTER UNION 2",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        1,
-        2
-      ]
-    }
+    assert:[
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          1,
+          2
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      }
+    ]
   },
   {
     name:"outerUnionCoerceStruct",
     statement:"{'a': 1} OUTER UNION {'b': 2}",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          a:1
-        },
-        {
-          b:2
-        }
-      ]
-    }
+    assert:[
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            a: 1
+          },
+          {
+            b: 2
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      }
+    ]
   },
   {
     name:"outerUnionCoerceNullMissing",
     statement:"NULL OUTER UNION MISSING",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-      ]
-    }
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          null,
+          $missing::null
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
     name:"outerUnionCoerceList",

--- a/partiql-tests-data/eval/primitives/path.ion
+++ b/partiql-tests-data/eval/primitives/path.ion
@@ -550,14 +550,17 @@ pathUnpivotMissing::[
   {
     name: "unpivotMissing",
     statement: "SELECT * FROM UNPIVOT MISSING",
-    assert: {
-      evalMode: [
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      result: EvaluationSuccess,
-      output: $bag::[]
-    }
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
     name: "unpivotEmptyStruct",
@@ -586,26 +589,32 @@ pathUnpivotMissing::[
   {
     name: "unpivotMissingWithAsAndAt",
     statement: "SELECT unnestIndex, unnestValue FROM UNPIVOT MISSING AS unnestValue AT unnestIndex",
-    assert: {
-      evalMode: [
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      result: EvaluationSuccess,
-      output: $bag::[]
-    }
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
     name: "unpivotMissingCrossJoinWithAsAndAt",
     statement: "SELECT unnestIndex, unnestValue FROM MISSING, UNPIVOT MISSING AS unnestValue AT unnestIndex",
-    assert: {
-      evalMode: [
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      result: EvaluationSuccess,
-      output: $bag::[]
-    }
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
     name: "pathUnpivotEmptyStruct1",

--- a/partiql-tests-data/eval/primitives/symbol.ion
+++ b/partiql-tests-data/eval/primitives/symbol.ion
@@ -2,18 +2,21 @@
   {
     name:"Empty Symbol in table",
     statement:"SELECT \"\" FROM `{'': 1}`",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          '':1
-        }
-      ]
-    }
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $bag::[
+          {
+          '': 1
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      }
+    ]
   },
   {
     name:"Empty Symbol in globals",
@@ -21,18 +24,22 @@
     env:{
       '':1
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          _1:1
-        }
-      ]
-    }
+    assert:[
+
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $bag::[
+          {
+            _1: 1
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      }
+    ]
   },
   {
     name:"Empty Symbol in alias",
@@ -42,17 +49,20 @@
         v:1
       }
     },
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          '':1
-        }
-      ]
-    }
+    assert: [
+      {
+        result: EvaluationSuccess,
+        evalMode: EvalModeCoerce,
+        output: $bag::[
+          {
+          '': 1
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      }
+    ]
   }
 ]

--- a/partiql-tests-data/eval/query/group-by/group-by.ion
+++ b/partiql-tests-data/eval/query/group-by/group-by.ion
@@ -982,9 +982,8 @@
         result:EvaluationFail
       },
       {
-        result:EvaluationSuccess,
+        result:EvaluationFail,
         evalMode:EvalModeCoerce,
-        output:$bag::[]
       }
     ]
   },
@@ -997,9 +996,8 @@
         result:EvaluationFail
       },
       {
-        result:EvaluationSuccess,
+        result:EvaluationFail,
         evalMode:EvalModeCoerce,
-        output:$bag::[]
       }
     ]
   },
@@ -1012,9 +1010,8 @@
         result:EvaluationFail
       },
       {
-        result:EvaluationSuccess,
+        result:EvaluationFail,
         evalMode:EvalModeCoerce,
-        output:$bag::[]
       }
     ]
   },
@@ -1027,9 +1024,8 @@
         result:EvaluationFail
       },
       {
-        result:EvaluationSuccess,
+        result:EvaluationFail,
         evalMode:EvalModeCoerce,
-        output:$bag::[]
       }
     ]
   }
@@ -7530,8 +7526,8 @@
     }
   },
   {
-    name:"GROUP BY with JOIN : SELECT supplierName, COUNT(*) as the_count FROM suppliers AS s INNER JOIN products AS p ON s.supplierId = p.supplierId GROUP BY supplierName",
-    statement:"SELECT supplierName, COUNT(*) as the_count FROM suppliers AS s INNER JOIN products AS p ON s.supplierId = p.supplierId GROUP BY supplierName",
+    name:"GROUP BY with JOIN : SELECT supplierName, COUNT(*) as the_count FROM suppliers AS s INNER JOIN products AS p ON s.supplierId = p.supplierId GROUP BY s.supplierName",
+    statement:"SELECT supplierName, COUNT(*) as the_count FROM suppliers AS s INNER JOIN products AS p ON s.supplierId = p.supplierId GROUP BY s.supplierName",
     assert:{
       result:EvaluationSuccess,
       evalMode:[
@@ -8166,8 +8162,8 @@
     }
   },
   {
-    name:"SELECT col1, g FROM simple_1_col_1_group, join_me GROUP BY col1 GROUP AS g",
-    statement:"SELECT col1, g FROM simple_1_col_1_group, join_me GROUP BY col1 GROUP AS g",
+    name:"SELECT col1, g FROM simple_1_col_1_group, join_me GROUP BY simple_1_col_1_group.col1 GROUP AS g",
+    statement:"SELECT col1, g FROM simple_1_col_1_group, join_me GROUP BY simple_1_col_1_group.col1 GROUP AS g",
     assert:{
       result:EvaluationSuccess,
       evalMode:[
@@ -8216,8 +8212,8 @@
     }
   },
   {
-    name:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, join_me GROUP BY col1 GROUP AS g",
-    statement:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, join_me GROUP BY col1 GROUP AS g",
+    name:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, join_me GROUP BY simple_1_col_1_group.col1 GROUP AS g",
+    statement:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, join_me GROUP BY simple_1_col_1_group.col1 GROUP AS g",
     assert:{
       result:EvaluationSuccess,
       evalMode:[
@@ -8266,8 +8262,8 @@
     }
   },
   {
-    name:"SELECT col1, g FROM simple_1_col_1_group, different_types_per_row GROUP BY col1 GROUP AS g",
-    statement:"SELECT col1, g FROM simple_1_col_1_group, different_types_per_row GROUP BY col1 GROUP AS g",
+    name:"SELECT col1, g FROM simple_1_col_1_group, different_types_per_row GROUP BY simple_1_col_1_group.col1 GROUP AS g",
+    statement:"SELECT col1, g FROM simple_1_col_1_group, different_types_per_row GROUP BY simple_1_col_1_group.col1 GROUP AS g",
     assert:{
       result:EvaluationSuccess,
       evalMode:[
@@ -8324,8 +8320,8 @@
     }
   },
   {
-    name:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, different_types_per_row GROUP BY col1 GROUP AS g",
-    statement:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, different_types_per_row GROUP BY col1 GROUP AS g",
+    name:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, different_types_per_row GROUP BY simple_1_col_1_group.col1 GROUP AS g",
+    statement:"SELECT VALUE { 'col1': col1, 'g': g } FROM simple_1_col_1_group, different_types_per_row GROUP BY simple_1_col_1_group.col1 GROUP AS g",
     assert:{
       result:EvaluationSuccess,
       evalMode:[

--- a/partiql-tests-data/eval/query/join/joins.ion
+++ b/partiql-tests-data/eval/query/join/joins.ion
@@ -593,7 +593,7 @@ join::[
         {
           name:"ee",
           n:42,
-          _3:null
+          _2:null
         }
       ]
     }
@@ -657,7 +657,9 @@ join::[
           name:"ee",
           s2_n:42,
           s2_2:2,
-          _4:null
+          name:null,
+          s3_n:null,
+          s3_2:null
         }
       ]
     }

--- a/partiql-tests-data/eval/query/pivot.ion
+++ b/partiql-tests-data/eval/query/pivot.ion
@@ -45,12 +45,17 @@ pivot::[
   {
     name:"pivotBadFieldType",
     statement:"PIVOT a.name AT i FROM animals AS a AT i",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:{
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output:{}
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
       }
-    }
+    ]
   },
   {
     name:"pivotUnpivotWithWhereOrderByLimit",

--- a/partiql-tests-data/eval/query/select/from-clause.ion
+++ b/partiql-tests-data/eval/query/select/from-clause.ion
@@ -86,82 +86,104 @@ envs::{
   {
     name:"selectFromScalarAndAtUnpivotWildCardOverScalar",
     statement:"SELECT VALUE [n, v] FROM (100).* AS v AT n",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          "_1",
-          100
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            $missing::null,
+            100
+          ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"selectFromListAndAtUnpivotWildCardOverScalar",
     statement:"SELECT VALUE [n, (SELECT VALUE [i, x] FROM @v AS x AT i)] FROM [100, 200].*.*.* AS v AT n",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          "_1",
-          $bag::[
-            [
-              0,
-              100
-            ],
-            [
-              1,
-              200
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            $missing::null,
+            $bag::[
+              [
+                0,
+                100
+              ],
+              [
+                1,
+                200
+              ]
             ]
           ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"selectFromBagAndAtUnpivotWildCardOverScalar",
     statement:"SELECT VALUE [n, (SELECT VALUE [i IS MISSING, i, x] FROM @v AS x AT i)] FROM <<100, 200>>.* AS v AT n",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          "_1",
-          $bag::[
-            [
-              true,
-              $missing::null,
-              100
-            ],
-            [
-              true,
-              $missing::null,
-              200
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            $missing::null,
+            $bag::[
+              [
+                true,
+                $missing::null,
+                100
+              ],
+              [
+                true,
+                $missing::null,
+                200
+              ]
             ]
           ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"selectPathUnpivotWildCardOverStructMultiple",
     statement:"SELECT name, val FROM a.*.*.*.* AS val AT name",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          name:"e",
-          val:5
-        },
-        {
-          name:"f",
-          val:6
-        }
-      ]
-    }
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
+            val:5
+          },
+          {
+            val:6
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
     name:"selectStarSingleSourceHoisted",
@@ -231,27 +253,37 @@ envs::{
   {
     name:"rangeOverScalar",
     statement:"SELECT VALUE v FROM 1 AS v",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        1
-      ]
-    }
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[ 1 ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"rangeTwiceOverScalar",
     statement:"SELECT VALUE [v1, v2] FROM 1 AS v1, @v1 AS v2",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        [
-          1,
-          1
+    assert:[
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          [
+            1,
+            1
+          ]
         ]
-      ]
-    }
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"rangeOverSexp",
@@ -269,15 +301,21 @@ envs::{
   {
     name:"rangeOverStruct",
     statement:"SELECT VALUE v FROM `{a:5}` AS v",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          a:5
-        }
-      ]
-    }
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
+            a:5
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      },
+    ]
   },
   {
     name:"rangeOverList",

--- a/partiql-tests-data/eval/query/select/projection.ion
+++ b/partiql-tests-data/eval/query/select/projection.ion
@@ -24,11 +24,17 @@
   {
     name:"projectionIterationBehaviorUnfiltered_select_list",
     statement:"select x.someColumn from <<{'someColumn': MISSING}>> AS x",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[{}]
-    }
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[{}]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      }
+    ]
   },
   {
     name:"projectionIterationBehaviorUnfiltered_select_star",
@@ -36,11 +42,7 @@
     assert:{
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
-      output:$bag::[
-        {
-          _1:{}
-        }
-      ]
+      output:$bag::[ { } ]
     }
   }
 ]
@@ -118,10 +120,10 @@
       result:EvaluationSuccess,
       output:$bag::[
         {
-          _1:(
-            1
-            2
-          )
+          _1: 1
+        },
+        {
+          _1: 2
         }
       ]
     }
@@ -129,21 +131,27 @@
   {
     name:"projectOfUnpivotPath",
     statement:"SELECT * FROM <<{'name': 'Marrowstone Brewing'}, {'name': 'Tesla'}>>.*",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          _1:$bag::[
-            {
-              name:"Marrowstone Brewing"
-            },
-            {
-              name:"Tesla"
-            }
-          ]
-        }
-      ]
-    }
+    assert: [
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $bag::[
+          {
+            _1:$bag::[
+              {
+                name:"Marrowstone Brewing"
+              },
+              {
+                name:"Tesla"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   }
 ]

--- a/partiql-tests-data/eval/query/select/select-mysql.ion
+++ b/partiql-tests-data/eval/query/select/select-mysql.ion
@@ -11373,7 +11373,7 @@ select::[
   },
   {
     name:"MYSQL_SELECT_20",
-    statement:"select fld3,period from t1,t2 where fld1 = 011401",
+    statement:"select t2.fld3,t1.period from t1,t2 where t2.fld1 = 011401",
     assert:{
       result:EvaluationSuccess,
       evalMode:[
@@ -11390,7 +11390,7 @@ select::[
   },
   {
     name:"MYSQL_SELECT_21",
-    statement:"select fld3,period from t2,t1 where companynr*10 = 37*10",
+    statement:"select t2.fld3,t1.period from t2,t1 where t2.companynr*10 = 37*10",
     assert:{
       result:EvaluationSuccess,
       evalMode:[

--- a/partiql-tests-data/eval/query/select/select-star.ion
+++ b/partiql-tests-data/eval/query/select/select-star.ion
@@ -170,18 +170,21 @@
   {
     name:"alias1.alias2.*",
     statement:"SELECT r.commander.* FROM ranks as r",
-    assert:{
-      result:EvaluationSuccess,
-      evalMode:[
-        EvalModeCoerce,
-        EvalModeError
-      ],
-      output:$bag::[
-        {
-          first_name:"William",
-          last_name:"Riker"
-        }
-      ]
-    }
+    assert: [
+      {
+        result:EvaluationSuccess,
+        evalMode:EvalModeCoerce,
+        output:$bag::[
+          {
+            first_name:"William",
+            last_name:"Riker"
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
 ]

--- a/partiql-tests-data/eval/query/select/select.ion
+++ b/partiql-tests-data/eval/query/select/select.ion
@@ -350,7 +350,8 @@ select_join::[
       result:EvaluationSuccess,
       output:$bag::[
         {
-          id:"7"
+          id:"7",
+          title: null
         }
       ]
     }
@@ -363,7 +364,8 @@ select_join::[
       result:EvaluationSuccess,
       output:$bag::[
         {
-          id:"5"
+          id:"5",
+          title: null
         },
         {
           id:"6",
@@ -374,7 +376,8 @@ select_join::[
           title:"F"
         },
         {
-          id:"7"
+          id:"7",
+          title: null
         }
       ]
     }
@@ -417,24 +420,30 @@ select_join::[
   {
     name:"selectNonCorrelatedJoin", // Note that the joined someAlias is coming from the global scope without @-operator
     statement:"SELECT someAlias.id AS id, v AS title FROM stores AS someAlias, someAlias AS v",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          id:"5",
-          title:"hello"
-        },
-        {
-          id:"6",
-          title:"hello"
-        },
-        {
-          id:"7",
-          title:"hello"
-        }
-      ]
-    }
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
+            id:"5",
+            title:"hello"
+          },
+          {
+            id:"6",
+            title:"hello"
+          },
+          {
+            id:"7",
+            title:"hello"
+          }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
     name:"selectCorrelatedUnpivot",
@@ -531,42 +540,60 @@ select_join::[
   {
     name:"correlatedJoinWithShadowedAttributes",
     statement:"SELECT VALUE v FROM `[{v:5}]` AS item, @item.v AS v",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        5
-      ]
-    }
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          5
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
     name:"correlatedJoinWithoutLexicalScope",
     statement:"SELECT VALUE b FROM `[{b:5}]` AS item, item.b AS b",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        5
-      ]
-    }
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          5
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   },
   {
     name:"joinWithShadowedGlobal", // 'a' is a global variable
     statement:"SELECT VALUE b FROM `[{b:5}]` AS a, a.b AS b",
-    assert:{
-      evalMode:[EvalModeCoerce, EvalModeError],
-      result:EvaluationSuccess,
-      output:$bag::[
-        {
-          c:{
-            d:{
-              e:5,
-              f:6
+    assert: [
+      {
+        evalMode:EvalModeCoerce,
+        result:EvaluationSuccess,
+        output:$bag::[
+          {
+            c:{
+              d:{
+                e:5,
+                f:6
+              }
             }
           }
-        }
-      ]
-    }
+        ]
+      },
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail,
+      }
+    ]
   }
 ]
 

--- a/partiql-tests-data/eval/query/undefined-variable-behavior.ion
+++ b/partiql-tests-data/eval/query/undefined-variable-behavior.ion
@@ -9,8 +9,7 @@ undefined_variable_behavior::[
     assert:[
       {
         evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$missing::null
+        result:EvaluationFail,
       },
       {
         evalMode:EvalModeError,
@@ -24,8 +23,7 @@ undefined_variable_behavior::[
     assert:[
       {
         evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:true
+        result:EvaluationFail,
       },
       {
         evalMode:EvalModeError,
@@ -39,8 +37,7 @@ undefined_variable_behavior::[
     assert:[
       {
         evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:true
+        result:EvaluationFail,
       },
       {
         evalMode:EvalModeError,

--- a/partiql-tests-data/eval/rfc/0007.ion
+++ b/partiql-tests-data/eval/rfc/0007.ion
@@ -174,14 +174,20 @@ bag::[
     {
         name: "Example 6 — Value Coercion; Coercion of single value",
         statement: '''SELECT * FROM << 1 >> OUTER UNION 'A' ''',
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[
-                { "_1": 1 },
-                "A",
-            ]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[
+                    { "_1": 1 },
+                    "A",
+                ]
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail
+            }
+        ]
     },
     {
         name: "Example 6 — Value Coercion",

--- a/partiql-tests-data/eval/spec-tests.ion
+++ b/partiql-tests-data/eval/spec-tests.ion
@@ -145,11 +145,17 @@
     {
         name: "single source FROM with scalar",
         statement: "SELECT x FROM someOrderedTable[0].a AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{x: 0}]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[{x: 0}]
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail,
+            }
+        ]
     },
     {
         name: "single source FROM with scalar and AT clause",
@@ -169,11 +175,17 @@
     {
         name: "single source FROM with tuple",
         statement: "SELECT x FROM {'someKey': 'someValue' } AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{x: {someKey: "someValue"}}]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[{x: {someKey: "someValue"}}]
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail,
+            }
+        ]
     },
     {
         name: "single source FROM with tuple and AT clause",
@@ -193,11 +205,17 @@
     {
         name: "single source FROM with absent value null",
         statement: "SELECT x FROM NULL AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{x: null}]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[{x: null}]
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail,
+            }
+        ]
     },
     {
         name: "single source FROM with absent value null and AT clause",
@@ -217,11 +235,17 @@
     {
         name: "single source FROM with absent value missing",
         statement: "SELECT x FROM MISSING AS x",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: $bag::[{}]
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: $bag::[{}]
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail,
+            },
+        ]
     },
     {
         name: "single source FROM with absent value missing and AT clause",
@@ -374,11 +398,17 @@
     {
         name: "pivot into a tuple with invalid attribute name",
         statement: "PIVOT t.price AT t.sym FROM [{'sym':25, 'price':31.52}, {'sym':'amzn', 'price':840.05}] AS t",
-        assert: {
-            evalMode: [EvalModeCoerce, EvalModeError],
-            result: EvaluationSuccess,
-            output: {amzn: 840.05}
-        }
+        assert: [
+            {
+                evalMode: EvalModeCoerce,
+                result: EvaluationSuccess,
+                output: {amzn: 840.05}
+            },
+            {
+                evalMode: EvalModeError,
+                result: EvaluationFail,
+            }
+        ]
     },
     {
         name: "select variable star with non tuples",


### PR DESCRIPTION
# Description

In the below sections, I'll elaborate on the tests fixed.

## Fixes FROM Mistyping Cases

> In the following cases the expression in the FROM clause item has the wrong type. Under the type checking option, all of these cases raise an error and the query fails. Under the permissive option, the cases proceed as follows:
> Iteration over a scalar value: Consider the query:
>    FROM s AS v AT p
>    or the query:
>    FROM s AS v
>    where s is a scalar value. Then s coerces into the bag << s >>, i.e., the bag that has a single element, the s. The
>    rest of the semantics is identical to what happens when the lhs of the FROM item is a bag.
>
> -- PartiQL Specification [Section 5.1.1](https://partiql.org/partiql-lang/#sec:bag-array-mistypings)

## Fixes UNPIVOT Mistyping Cases
> In the following cases the expression in the FROM UNPIVOT clause item has the “wrong” type, i.e., it is not a tuple. Under the type checking option, all of these cases raise an error and the query fails. Under the permissive option, the cases proceed as follows:
> ...
>
> -- PartiQL Specification [Section 5.2.1](https://partiql.org/partiql-lang/#sec:unpivot-mistypings)

## Fixes undefined variable tests
> Similarly, for a given 𝑞 at compile (i.e. planning) time, a database type environment... and variables type environment ... are defined. The type environment is a binding tuple ... where each 𝑥𝑖 is a name that is unique and binds to the PartiQL type𝜏𝑖. For schema-less values, 𝜏 can be considered the union of any possible type (for which all operations are potentially applicable).
>
> -- PartiQL Specification [Section 3.2](https://partiql.org/partiql-lang/#sec:environments-and-bindings)

## Fixes Join Null Output Cases

For example, LEFT JOIN should make the RHS null if the LHS is not matched.

## Fixes Outer Union Mistyping Cases

See https://github.com/partiql/partiql-lang/issues/76

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.