### PR TITLE
Change struct keys from ion to strings for string tests

### DIFF
--- a/partiql-tests-data/eval/primitives/naughty-strings.ion
+++ b/partiql-tests-data/eval/primitives/naughty-strings.ion
@@ -1,7 +1,7 @@
 'naughty-strings'::[
   {
     name:"big list of naughty strings{str:\"\"}",
-    statement:"{ `literal`: '', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:""
     },
@@ -20,7 +20,7 @@
   },
   {
     name:"big list of naughty strings{str:\"undefined\"}",
-    statement:"{ `literal`: 'undefined', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'undefined', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"undefined"
     },
@@ -39,7 +39,7 @@
   },
   {
     name:"big list of naughty strings{str:\"undef\"}",
-    statement:"{ `literal`: 'undef', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'undef', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"undef"
     },
@@ -58,7 +58,7 @@
   },
   {
     name:"big list of naughty strings{str:\"null\"}",
-    statement:"{ `literal`: 'null', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'null', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"null"
     },
@@ -77,7 +77,7 @@
   },
   {
     name:"big list of naughty strings{str:\"NULL\"}",
-    statement:"{ `literal`: 'NULL', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'NULL', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"NULL"
     },
@@ -96,7 +96,7 @@
   },
   {
     name:"big list of naughty strings{str:\"(null)\"}",
-    statement:"{ `literal`: '(null)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '(null)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"(null)"
     },
@@ -115,7 +115,7 @@
   },
   {
     name:"big list of naughty strings{str:\"nil\"}",
-    statement:"{ `literal`: 'nil', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'nil', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"nil"
     },
@@ -134,7 +134,7 @@
   },
   {
     name:"big list of naughty strings{str:\"NIL\"}",
-    statement:"{ `literal`: 'NIL', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'NIL', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"NIL"
     },
@@ -153,7 +153,7 @@
   },
   {
     name:"big list of naughty strings{str:\"true\"}",
-    statement:"{ `literal`: 'true', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'true', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"true"
     },
@@ -172,7 +172,7 @@
   },
   {
     name:"big list of naughty strings{str:\"false\"}",
-    statement:"{ `literal`: 'false', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'false', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"false"
     },
@@ -191,7 +191,7 @@
   },
   {
     name:"big list of naughty strings{str:\"True\"}",
-    statement:"{ `literal`: 'True', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'True', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"True"
     },
@@ -210,7 +210,7 @@
   },
   {
     name:"big list of naughty strings{str:\"False\"}",
-    statement:"{ `literal`: 'False', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'False', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"False"
     },
@@ -229,7 +229,7 @@
   },
   {
     name:"big list of naughty strings{str:\"TRUE\"}",
-    statement:"{ `literal`: 'TRUE', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'TRUE', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"TRUE"
     },
@@ -248,7 +248,7 @@
   },
   {
     name:"big list of naughty strings{str:\"FALSE\"}",
-    statement:"{ `literal`: 'FALSE', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'FALSE', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"FALSE"
     },
@@ -267,7 +267,7 @@
   },
   {
     name:"big list of naughty strings{str:\"None\"}",
-    statement:"{ `literal`: 'None', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'None', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"None"
     },
@@ -286,7 +286,7 @@
   },
   {
     name:"big list of naughty strings{str:\"hasOwnProperty\"}",
-    statement:"{ `literal`: 'hasOwnProperty', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'hasOwnProperty', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"hasOwnProperty"
     },
@@ -305,7 +305,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\\\\"}",
-    statement:"{ `literal`: '\\', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\\', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\\"
     },
@@ -324,7 +324,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\\\\\\\\"}",
-    statement:"{ `literal`: '\\\\', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\\\\', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\\\\"
     },
@@ -343,7 +343,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0\"}",
-    statement:"{ `literal`: '0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0"
     },
@@ -362,7 +362,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1\"}",
-    statement:"{ `literal`: '1', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1"
     },
@@ -381,7 +381,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1.00\"}",
-    statement:"{ `literal`: '1.00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1.00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1.00"
     },
@@ -400,7 +400,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1.00\"}",
-    statement:"{ `literal`: '$1.00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '$1.00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"$1.00"
     },
@@ -419,7 +419,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1/2\"}",
-    statement:"{ `literal`: '1/2', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1/2', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1/2"
     },
@@ -438,7 +438,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1E2\"}",
-    statement:"{ `literal`: '1E2', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1E2', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1E2"
     },
@@ -457,7 +457,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1E02\"}",
-    statement:"{ `literal`: '1E02', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1E02', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1E02"
     },
@@ -476,7 +476,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1E+02\"}",
-    statement:"{ `literal`: '1E+02', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1E+02', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1E+02"
     },
@@ -495,7 +495,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-1\"}",
-    statement:"{ `literal`: '-1', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-1', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-1"
     },
@@ -514,7 +514,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-1.00\"}",
-    statement:"{ `literal`: '-1.00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-1.00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-1.00"
     },
@@ -533,7 +533,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-1.00\"}",
-    statement:"{ `literal`: '-$1.00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-$1.00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-$1.00"
     },
@@ -552,7 +552,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-1/2\"}",
-    statement:"{ `literal`: '-1/2', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-1/2', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-1/2"
     },
@@ -571,7 +571,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-1E2\"}",
-    statement:"{ `literal`: '-1E2', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-1E2', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-1E2"
     },
@@ -590,7 +590,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-1E02\"}",
-    statement:"{ `literal`: '-1E02', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-1E02', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-1E02"
     },
@@ -609,7 +609,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-1E+02\"}",
-    statement:"{ `literal`: '-1E+02', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-1E+02', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-1E+02"
     },
@@ -628,7 +628,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1/0\"}",
-    statement:"{ `literal`: '1/0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1/0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1/0"
     },
@@ -647,7 +647,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0/0\"}",
-    statement:"{ `literal`: '0/0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0/0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0/0"
     },
@@ -666,7 +666,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-2147483648/-1\"}",
-    statement:"{ `literal`: '-2147483648/-1', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-2147483648/-1', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-2147483648/-1"
     },
@@ -685,7 +685,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-9223372036854775808/-1\"}",
-    statement:"{ `literal`: '-9223372036854775808/-1', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-9223372036854775808/-1', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-9223372036854775808/-1"
     },
@@ -704,7 +704,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-0\"}",
-    statement:"{ `literal`: '-0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-0"
     },
@@ -723,7 +723,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-0.0\"}",
-    statement:"{ `literal`: '-0.0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-0.0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-0.0"
     },
@@ -742,7 +742,7 @@
   },
   {
     name:"big list of naughty strings{str:\"+0\"}",
-    statement:"{ `literal`: '+0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '+0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"+0"
     },
@@ -761,7 +761,7 @@
   },
   {
     name:"big list of naughty strings{str:\"+0.0\"}",
-    statement:"{ `literal`: '+0.0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '+0.0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"+0.0"
     },
@@ -780,7 +780,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0.00\"}",
-    statement:"{ `literal`: '0.00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0.00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0.00"
     },
@@ -799,7 +799,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0..0\"}",
-    statement:"{ `literal`: '0..0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0..0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0..0"
     },
@@ -818,7 +818,7 @@
   },
   {
     name:"big list of naughty strings{str:\".\"}",
-    statement:"{ `literal`: '.', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '.', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"."
     },
@@ -837,7 +837,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0.0.0\"}",
-    statement:"{ `literal`: '0.0.0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0.0.0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0.0.0"
     },
@@ -856,7 +856,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0,00\"}",
-    statement:"{ `literal`: '0,00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0,00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0,00"
     },
@@ -875,7 +875,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0,,0\"}",
-    statement:"{ `literal`: '0,,0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0,,0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0,,0"
     },
@@ -894,7 +894,7 @@
   },
   {
     name:"big list of naughty strings{str:\",\"}",
-    statement:"{ `literal`: ',', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': ',', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:","
     },
@@ -913,7 +913,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0,0,0\"}",
-    statement:"{ `literal`: '0,0,0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0,0,0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0,0,0"
     },
@@ -932,7 +932,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0.0/0\"}",
-    statement:"{ `literal`: '0.0/0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0.0/0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0.0/0"
     },
@@ -951,7 +951,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1.0/0.0\"}",
-    statement:"{ `literal`: '1.0/0.0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1.0/0.0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1.0/0.0"
     },
@@ -970,7 +970,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0.0/0.0\"}",
-    statement:"{ `literal`: '0.0/0.0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0.0/0.0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0.0/0.0"
     },
@@ -989,7 +989,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1,0/0,0\"}",
-    statement:"{ `literal`: '1,0/0,0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1,0/0,0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1,0/0,0"
     },
@@ -1008,7 +1008,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0,0/0,0\"}",
-    statement:"{ `literal`: '0,0/0,0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0,0/0,0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0,0/0,0"
     },
@@ -1027,7 +1027,7 @@
   },
   {
     name:"big list of naughty strings{str:\"--1\"}",
-    statement:"{ `literal`: '--1', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '--1', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"--1"
     },
@@ -1046,7 +1046,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-.\"}",
-    statement:"{ `literal`: '-.', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-.', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-."
     },
@@ -1065,7 +1065,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-,\"}",
-    statement:"{ `literal`: '-,', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-,', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-,"
     },
@@ -1084,7 +1084,7 @@
   },
   {
     name:"big list of naughty strings{str:\"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999\"}",
-    statement:"{ `literal`: '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"
     },
@@ -1103,7 +1103,7 @@
   },
   {
     name:"big list of naughty strings{str:\"NaN\"}",
-    statement:"{ `literal`: 'NaN', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'NaN', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"NaN"
     },
@@ -1122,7 +1122,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Infinity\"}",
-    statement:"{ `literal`: 'Infinity', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Infinity', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Infinity"
     },
@@ -1141,7 +1141,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-Infinity\"}",
-    statement:"{ `literal`: '-Infinity', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-Infinity', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-Infinity"
     },
@@ -1160,7 +1160,7 @@
   },
   {
     name:"big list of naughty strings{str:\"INF\"}",
-    statement:"{ `literal`: 'INF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'INF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"INF"
     },
@@ -1179,7 +1179,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1#INF\"}",
-    statement:"{ `literal`: '1#INF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1#INF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1#INF"
     },
@@ -1198,7 +1198,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-1#IND\"}",
-    statement:"{ `literal`: '-1#IND', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-1#IND', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-1#IND"
     },
@@ -1217,7 +1217,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1#QNAN\"}",
-    statement:"{ `literal`: '1#QNAN', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1#QNAN', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1#QNAN"
     },
@@ -1236,7 +1236,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1#SNAN\"}",
-    statement:"{ `literal`: '1#SNAN', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1#SNAN', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1#SNAN"
     },
@@ -1255,7 +1255,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1#IND\"}",
-    statement:"{ `literal`: '1#IND', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1#IND', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1#IND"
     },
@@ -1274,7 +1274,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0x0\"}",
-    statement:"{ `literal`: '0x0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0x0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0x0"
     },
@@ -1293,7 +1293,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0xffffffff\"}",
-    statement:"{ `literal`: '0xffffffff', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0xffffffff', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0xffffffff"
     },
@@ -1312,7 +1312,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0xffffffffffffffff\"}",
-    statement:"{ `literal`: '0xffffffffffffffff', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0xffffffffffffffff', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0xffffffffffffffff"
     },
@@ -1331,7 +1331,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0xabad1dea\"}",
-    statement:"{ `literal`: '0xabad1dea', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0xabad1dea', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0xabad1dea"
     },
@@ -1350,7 +1350,7 @@
   },
   {
     name:"big list of naughty strings{str:\"123456789012345678901234567890123456789\"}",
-    statement:"{ `literal`: '123456789012345678901234567890123456789', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '123456789012345678901234567890123456789', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"123456789012345678901234567890123456789"
     },
@@ -1369,7 +1369,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1,000.00\"}",
-    statement:"{ `literal`: '1,000.00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1,000.00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1,000.00"
     },
@@ -1388,7 +1388,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1 000.00\"}",
-    statement:"{ `literal`: '1 000.00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1 000.00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1 000.00"
     },
@@ -1407,7 +1407,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1,000,000.00\"}",
-    statement:"{ `literal`: '1,000,000.00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1,000,000.00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1,000,000.00"
     },
@@ -1426,7 +1426,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1 000 000.00\"}",
-    statement:"{ `literal`: '1 000 000.00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1 000 000.00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1 000 000.00"
     },
@@ -1445,7 +1445,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1.000,00\"}",
-    statement:"{ `literal`: '1.000,00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1.000,00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1.000,00"
     },
@@ -1464,7 +1464,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1 000,00\"}",
-    statement:"{ `literal`: '1 000,00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1 000,00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1 000,00"
     },
@@ -1483,7 +1483,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1.000.000,00\"}",
-    statement:"{ `literal`: '1.000.000,00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1.000.000,00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1.000.000,00"
     },
@@ -1502,7 +1502,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1 000 000,00\"}",
-    statement:"{ `literal`: '1 000 000,00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1 000 000,00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1 000 000,00"
     },
@@ -1521,7 +1521,7 @@
   },
   {
     name:"big list of naughty strings{str:\"01000\"}",
-    statement:"{ `literal`: '01000', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '01000', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"01000"
     },
@@ -1540,7 +1540,7 @@
   },
   {
     name:"big list of naughty strings{str:\"08\"}",
-    statement:"{ `literal`: '08', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '08', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"08"
     },
@@ -1559,7 +1559,7 @@
   },
   {
     name:"big list of naughty strings{str:\"09\"}",
-    statement:"{ `literal`: '09', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '09', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"09"
     },
@@ -1578,7 +1578,7 @@
   },
   {
     name:"big list of naughty strings{str:\"2.2250738585072011e-308\"}",
-    statement:"{ `literal`: '2.2250738585072011e-308', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '2.2250738585072011e-308', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"2.2250738585072011e-308"
     },
@@ -1597,7 +1597,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<>?:\\\"{}|_+\"}",
-    statement:"{ `literal`: '<>?:\"{}|_+', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<>?:\"{}|_+', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<>?:\"{}|_+"
     },
@@ -1616,7 +1616,7 @@
   },
   {
     name:"big list of naughty strings{str:\"!@#%^&*()`~\"}",
-    statement:"{ `literal`: '!@#$%^&*()`~', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '!@#$%^&*()`~', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"!@#$%^&*()`~"
     },
@@ -1635,7 +1635,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\x01\\x02\\x03\\x04\\x05\\x06\\a\\b\\x0e\\x0f\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f\\x7f\"}",
-    statement:"{ `literal`: '\x01\x02\x03\x04\x05\x06\a\b\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\x01\x02\x03\x04\x05\x06\a\b\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\x01\x02\x03\x04\x05\x06\a\b\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f"
     },
@@ -1654,7 +1654,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\x80\\x81\\x82\\x83\\x84\\x86\\x87\\x88\\x89\\x8a\\x8b\\x8c\\x8d\\x8e\\x8f\\x90\\x91\\x92\\x93\\x94\\x95\\x96\\x97\\x98\\x99\\x9a\\x9b\\x9c\\x9d\\x9e\\x9f\"}",
-    statement:"{ `literal`: '\x80\x81\x82\x83\x84\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\x80\x81\x82\x83\x84\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\x80\x81\x82\x83\x84\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f"
     },
@@ -1673,7 +1673,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\t\\v\\f \\x85 \\u1680\\u2002\\u2003\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200a\\u200b\\u2028\\u2029\\u202f\\u205f\\u3000\"}",
-    statement:"{ `literal`: '\t\v\f \x85             ​    　', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\t\v\f \x85             ​    　', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\t\v\f \x85             ​    　"
     },
@@ -1692,7 +1692,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\xad\\u0600\\u0601\\u0602\\u0603\\u0604\\u0605\\u061c\\u06dd\\u070f\\u180e\\u200b\\u200c\\u200d\\u200e\\u200f\\u202a\\u202b\\u202c\\u202d\\u202e\\u2060\\u2061\\u2062\\u2063\\u2064\\u2066\\u2067\\u2068\\u2069\\u206a\\u206b\\u206c\\u206d\\u206e\\u206f\\ufeff\\ufff9\\ufffa\\ufffb\\U000110bd\\U0001bca0\\U0001bca1\\U0001bca2\\U0001bca3\\U0001d173\\U0001d174\\U0001d175\\U0001d176\\U0001d177\\U0001d178\\U0001d179\\U0001d17a\\U000e0001\\U000e0020\\U000e0021\\U000e0022\\U000e0023\\U000e0024\\U000e0025\\U000e0026\\U000e0027\\U000e0028\\U000e0029\\U000e002a\\U000e002b\\U000e002c\\U000e002d\\U000e002e\\U000e002f\\U000e0030\\U000e0031\\U000e0032\\U000e0033\\U000e0034\\U000e0035\\U000e0036\\U000e0037\\U000e0038\\U000e0039\\U000e003a\\U000e003b\\U000e003c\\U000e003d\\U000e003e\\U000e003f\\U000e0040\\U000e0041\\U000e0042\\U000e0043\\U000e0044\\U000e0045\\U000e0046\\U000e0047\\U000e0048\\U000e0049\\U000e004a\\U000e004b\\U000e004c\\U000e004d\\U000e004e\\U000e004f\\U000e0050\\U000e0051\\U000e0052\\U000e0053\\U000e0054\\U000e0055\\U000e0056\\U000e0057\\U000e0058\\U000e0059\\U000e005a\\U000e005b\\U000e005c\\U000e005d\\U000e005e\\U000e005f\\U000e0060\\U000e0061\\U000e0062\\U000e0063\\U000e0064\\U000e0065\\U000e0066\\U000e0067\\U000e0068\\U000e0069\\U000e006a\\U000e006b\\U000e006c\\U000e006d\\U000e006e\\U000e006f\\U000e0070\\U000e0071\\U000e0072\\U000e0073\\U000e0074\\U000e0075\\U000e0076\\U000e0077\\U000e0078\\U000e0079\\U000e007a\\U000e007b\\U000e007c\\U000e007d\\U000e007e\\U000e007f\"}",
-    statement:"{ `literal`: '­؀؁؂؃؄؅؜۝܏᠎​‌‍‎‏‪‫‬‭‮⁠⁡⁢⁣⁤⁦⁧⁨⁩⁪⁫⁬⁭⁮⁯﻿￹￺￻𑂽𛲠𛲡𛲢𛲣𝅳𝅴𝅵𝅶𝅷𝅸𝅹𝅺󠀁󠀠󠀡󠀢󠀣󠀤󠀥󠀦󠀧󠀨󠀩󠀪󠀫󠀬󠀭󠀮󠀯󠀰󠀱󠀲󠀳󠀴󠀵󠀶󠀷󠀸󠀹󠀺󠀻󠀼󠀽󠀾󠀿󠁀󠁁󠁂󠁃󠁄󠁅󠁆󠁇󠁈󠁉󠁊󠁋󠁌󠁍󠁎󠁏󠁐󠁑󠁒󠁓󠁔󠁕󠁖󠁗󠁘󠁙󠁚󠁛󠁜󠁝󠁞󠁟󠁠󠁡󠁢󠁣󠁤󠁥󠁦󠁧󠁨󠁩󠁪󠁫󠁬󠁭󠁮󠁯󠁰󠁱󠁲󠁳󠁴󠁵󠁶󠁷󠁸󠁹󠁺󠁻󠁼󠁽󠁾󠁿', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '­؀؁؂؃؄؅؜۝܏᠎​‌‍‎‏‪‫‬‭‮⁠⁡⁢⁣⁤⁦⁧⁨⁩⁪⁫⁬⁭⁮⁯﻿￹￺￻𑂽𛲠𛲡𛲢𛲣𝅳𝅴𝅵𝅶𝅷𝅸𝅹𝅺󠀁󠀠󠀡󠀢󠀣󠀤󠀥󠀦󠀧󠀨󠀩󠀪󠀫󠀬󠀭󠀮󠀯󠀰󠀱󠀲󠀳󠀴󠀵󠀶󠀷󠀸󠀹󠀺󠀻󠀼󠀽󠀾󠀿󠁀󠁁󠁂󠁃󠁄󠁅󠁆󠁇󠁈󠁉󠁊󠁋󠁌󠁍󠁎󠁏󠁐󠁑󠁒󠁓󠁔󠁕󠁖󠁗󠁘󠁙󠁚󠁛󠁜󠁝󠁞󠁟󠁠󠁡󠁢󠁣󠁤󠁥󠁦󠁧󠁨󠁩󠁪󠁫󠁬󠁭󠁮󠁯󠁰󠁱󠁲󠁳󠁴󠁵󠁶󠁷󠁸󠁹󠁺󠁻󠁼󠁽󠁾󠁿', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"­؀؁؂؃؄؅؜۝܏᠎​‌‍‎‏‪‫‬‭‮⁠⁡⁢⁣⁤⁦⁧⁨⁩⁪⁫⁬⁭⁮⁯﻿￹￺￻𑂽𛲠𛲡𛲢𛲣𝅳𝅴𝅵𝅶𝅷𝅸𝅹𝅺󠀁󠀠󠀡󠀢󠀣󠀤󠀥󠀦󠀧󠀨󠀩󠀪󠀫󠀬󠀭󠀮󠀯󠀰󠀱󠀲󠀳󠀴󠀵󠀶󠀷󠀸󠀹󠀺󠀻󠀼󠀽󠀾󠀿󠁀󠁁󠁂󠁃󠁄󠁅󠁆󠁇󠁈󠁉󠁊󠁋󠁌󠁍󠁎󠁏󠁐󠁑󠁒󠁓󠁔󠁕󠁖󠁗󠁘󠁙󠁚󠁛󠁜󠁝󠁞󠁟󠁠󠁡󠁢󠁣󠁤󠁥󠁦󠁧󠁨󠁩󠁪󠁫󠁬󠁭󠁮󠁯󠁰󠁱󠁲󠁳󠁴󠁵󠁶󠁷󠁸󠁹󠁺󠁻󠁼󠁽󠁾󠁿"
     },
@@ -1711,7 +1711,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\ufffe\"}",
-    statement:"{ `literal`: '￾', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '￾', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"￾"
     },
@@ -1730,7 +1730,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u03a9\\u2248\\xe7\\u221a\\u222b\\u02dc\\xb5\\u2264\\u2265\\xf7\"}",
-    statement:"{ `literal`: 'Ω≈ç√∫˜µ≤≥÷', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Ω≈ç√∫˜µ≤≥÷', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Ω≈ç√∫˜µ≤≥÷"
     },
@@ -1749,7 +1749,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\xe5\\xdf\\u2202\\u0192\\xa9\\u02d9\\u2206\\u02da\\xac\\u2026\\xe6\"}",
-    statement:"{ `literal`: 'åß∂ƒ©˙∆˚¬…æ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'åß∂ƒ©˙∆˚¬…æ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"åß∂ƒ©˙∆˚¬…æ"
     },
@@ -1768,7 +1768,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u0153\\u2211\\xb4\\xae\\u2020\\xa5\\xa8\\u02c6\\xf8\\u03c0\\u201c\\u2018\"}",
-    statement:"{ `literal`: 'œ∑´®†¥¨ˆøπ“‘', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'œ∑´®†¥¨ˆøπ“‘', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"œ∑´®†¥¨ˆøπ“‘"
     },
@@ -1787,7 +1787,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\xa1\\u2122\\xa3\\xa2\\u221e\\xa7\\xb6\\u2022\\xaa\\xba\\u2013\\u2260\"}",
-    statement:"{ `literal`: '¡™£¢∞§¶•ªº–≠', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '¡™£¢∞§¶•ªº–≠', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"¡™£¢∞§¶•ªº–≠"
     },
@@ -1806,7 +1806,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\xb8\\u02db\\xc7\\u25ca\\u0131\\u02dc\\xc2\\xaf\\u02d8\\xbf\"}",
-    statement:"{ `literal`: '¸˛Ç◊ı˜Â¯˘¿', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '¸˛Ç◊ı˜Â¯˘¿', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"¸˛Ç◊ı˜Â¯˘¿"
     },
@@ -1825,7 +1825,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\xc5\\xcd\\xce\\xcf\\u02dd\\xd3\\xd4\\uf8ff\\xd2\\xda\\xc6\\u2603\"}",
-    statement:"{ `literal`: 'ÅÍÎÏ˝ÓÔÒÚÆ☃', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ÅÍÎÏ˝ÓÔÒÚÆ☃', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ÅÍÎÏ˝ÓÔÒÚÆ☃"
     },
@@ -1844,7 +1844,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u0152\\u201e\\xb4\\u2030\\u02c7\\xc1\\xa8\\u02c6\\xd8\\u220f\\u201d\\u2019\"}",
-    statement:"{ `literal`: 'Œ„´‰ˇÁ¨ˆØ∏”’', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Œ„´‰ˇÁ¨ˆØ∏”’', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Œ„´‰ˇÁ¨ˆØ∏”’"
     },
@@ -1863,7 +1863,7 @@
   },
   {
     name:"big list of naughty strings{str:\"`\\u2044\\u20ac\\u2039\\u203a\\ufb01\\ufb02\\u2021\\xb0\\xb7\\u201a\\u2014\\xb1\"}",
-    statement:"{ `literal`: '`⁄€‹›ﬁﬂ‡°·‚—±', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '`⁄€‹›ﬁﬂ‡°·‚—±', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"`⁄€‹›ﬁﬂ‡°·‚—±"
     },
@@ -1882,7 +1882,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u215b\\u215c\\u215d\\u215e\"}",
-    statement:"{ `literal`: '⅛⅜⅝⅞', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '⅛⅜⅝⅞', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"⅛⅜⅝⅞"
     },
@@ -1901,7 +1901,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
-    statement:"{ `literal`: 'ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
     },
@@ -1920,7 +1920,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u0660\\u0661\\u0662\\u0663\\u0664\\u0665\\u0666\\u0667\\u0668\\u0669\"}",
-    statement:"{ `literal`: '٠١٢٣٤٥٦٧٨٩', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '٠١٢٣٤٥٦٧٨٩', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"٠١٢٣٤٥٦٧٨٩"
     },
@@ -1939,7 +1939,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u2070\\u2074\\u2075\"}",
-    statement:"{ `literal`: '⁰⁴⁵', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '⁰⁴⁵', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"⁰⁴⁵"
     },
@@ -1958,7 +1958,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u2080\\u2081\\u2082\"}",
-    statement:"{ `literal`: '₀₁₂', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '₀₁₂', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"₀₁₂"
     },
@@ -1977,7 +1977,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u2070\\u2074\\u2075\\u2080\\u2081\\u2082\"}",
-    statement:"{ `literal`: '⁰⁴⁵₀₁₂', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '⁰⁴⁵₀₁₂', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"⁰⁴⁵₀₁₂"
     },
@@ -1996,7 +1996,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u0e14\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47 \\u0e14\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47 \\u0e14\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\\u0e47\\u0e49\\u0e49\\u0e49\\u0e49\\u0e49\\u0e47\\u0e47\\u0e47\\u0e47\"}",
-    statement:"{ `literal`: 'ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็"
     },
@@ -2015,7 +2015,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\\"\"}",
-    statement:"{ `literal`: '\"', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\"', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\""
     },
@@ -2034,7 +2034,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\\"\\\"\"}",
-    statement:"{ `literal`: '\"\"', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\"\"', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\"\""
     },
@@ -2053,7 +2053,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<foo val=\\u201cbar\\u201d />\"}",
-    statement:"{ `literal`: '<foo val=“bar” />', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<foo val=“bar” />', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<foo val=“bar” />"
     },
@@ -2072,7 +2072,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<foo val=\\u201dbar\\u201c />\"}",
-    statement:"{ `literal`: '<foo val=”bar“ />', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<foo val=”bar“ />', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<foo val=”bar“ />"
     },
@@ -2091,7 +2091,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u7530\\u4e2d\\u3055\\u3093\\u306b\\u3042\\u3052\\u3066\\u4e0b\\u3055\\u3044\"}",
-    statement:"{ `literal`: '田中さんにあげて下さい', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '田中さんにあげて下さい', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"田中さんにあげて下さい"
     },
@@ -2110,7 +2110,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u30d1\\u30fc\\u30c6\\u30a3\\u30fc\\u3078\\u884c\\u304b\\u306a\\u3044\\u304b\"}",
-    statement:"{ `literal`: 'パーティーへ行かないか', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'パーティーへ行かないか', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"パーティーへ行かないか"
     },
@@ -2129,7 +2129,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u548c\\u88fd\\u6f22\\u8a9e\"}",
-    statement:"{ `literal`: '和製漢語', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '和製漢語', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"和製漢語"
     },
@@ -2148,7 +2148,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u90e8\\u843d\\u683c\"}",
-    statement:"{ `literal`: '部落格', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '部落格', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"部落格"
     },
@@ -2167,7 +2167,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\uc0ac\\ud68c\\uacfc\\ud559\\uc6d0 \\uc5b4\\ud559\\uc5f0\\uad6c\\uc18c\"}",
-    statement:"{ `literal`: '사회과학원 어학연구소', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '사회과학원 어학연구소', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"사회과학원 어학연구소"
     },
@@ -2186,7 +2186,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\ucc26\\ucc28\\ub97c \\ud0c0\\uace0 \\uc628 \\ud3b2\\uc2dc\\ub9e8\\uacfc \\uc45b\\ub2e4\\ub9ac \\ub620\\ubc29\\uac01\\ud558\"}",
-    statement:"{ `literal`: '찦차를 타고 온 펲시맨과 쑛다리 똠방각하', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '찦차를 타고 온 펲시맨과 쑛다리 똠방각하', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"찦차를 타고 온 펲시맨과 쑛다리 똠방각하"
     },
@@ -2205,7 +2205,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u793e\\u6703\\u79d1\\u5b78\\u9662\\u8a9e\\u5b78\\u7814\\u7a76\\u6240\"}",
-    statement:"{ `literal`: '社會科學院語學研究所', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '社會科學院語學研究所', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"社會科學院語學研究所"
     },
@@ -2224,7 +2224,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\uc6b8\\ub780\\ubc14\\ud1a0\\ub974\"}",
-    statement:"{ `literal`: '울란바토르', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '울란바토르', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"울란바토르"
     },
@@ -2243,7 +2243,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0002070e\\U00020731\\U00020779\\U00020c53\\U00020c78\\U00020c96\\U00020ccf\"}",
-    statement:"{ `literal`: '𠜎𠜱𠝹𠱓𠱸𠲖𠳏', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '𠜎𠜱𠝹𠱓𠱸𠲖𠳏', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"𠜎𠜱𠝹𠱓𠱸𠲖𠳏"
     },
@@ -2262,7 +2262,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u023a\"}",
-    statement:"{ `literal`: 'Ⱥ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Ⱥ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Ⱥ"
     },
@@ -2281,7 +2281,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u023e\"}",
-    statement:"{ `literal`: 'Ⱦ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Ⱦ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Ⱦ"
     },
@@ -2300,7 +2300,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \\u30fd\\u0f3c\\u0e88\\u0644\\u035c\\u0e88\\u0f3d\\uff89 \"}",
-    statement:"{ `literal`: 'ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ "
     },
@@ -2319,7 +2319,7 @@
   },
   {
     name:"big list of naughty strings{str:\"(\\uff61\\u25d5 \\u2200 \\u25d5\\uff61)\"}",
-    statement:"{ `literal`: '(｡◕ ∀ ◕｡)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '(｡◕ ∀ ◕｡)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"(｡◕ ∀ ◕｡)"
     },
@@ -2338,7 +2338,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\uff40\\uff68(\\xb4\\u2200\\uff40\\u2229\"}",
-    statement:"{ `literal`: '｀ｨ(´∀｀∩', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '｀ｨ(´∀｀∩', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"｀ｨ(´∀｀∩"
     },
@@ -2357,7 +2357,7 @@
   },
   {
     name:"big list of naughty strings{str:\"__\\uff9b(,_,*)\"}",
-    statement:"{ `literal`: '__ﾛ(,_,*)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '__ﾛ(,_,*)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"__ﾛ(,_,*)"
     },
@@ -2376,7 +2376,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u30fb(\\uffe3\\u2200\\uffe3)\\u30fb:*:\"}",
-    statement:"{ `literal`: '・(￣∀￣)・:*:', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '・(￣∀￣)・:*:', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"・(￣∀￣)・:*:"
     },
@@ -2395,7 +2395,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\uff9f\\uff65\\u273f\\u30fe\\u2572(\\uff61\\u25d5\\u203f\\u25d5\\uff61)\\u2571\\u273f\\uff65\\uff9f\"}",
-    statement:"{ `literal`: 'ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ"
     },
@@ -2414,7 +2414,7 @@
   },
   {
     name:"big list of naughty strings{str:\",\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019( \\u263b \\u03c9 \\u263b )\\u3002\\u30fb:*:\\u30fb\\u309c\\u2019\"}",
-    statement:"{ `literal`: ',。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': ',。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:",。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’"
     },
@@ -2433,7 +2433,7 @@
   },
   {
     name:"big list of naughty strings{str:\"(\\u256f\\xb0\\u25a1\\xb0\\uff09\\u256f\\ufe35 \\u253b\\u2501\\u253b)\"}",
-    statement:"{ `literal`: '(╯°□°）╯︵ ┻━┻)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '(╯°□°）╯︵ ┻━┻)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"(╯°□°）╯︵ ┻━┻)"
     },
@@ -2452,7 +2452,7 @@
   },
   {
     name:"big list of naughty strings{str:\"(\\uff89\\u0ca5\\u76ca\\u0ca5\\uff09\\uff89\\ufeff \\u253b\\u2501\\u253b\"}",
-    statement:"{ `literal`: '(ﾉಥ益ಥ）ﾉ﻿ ┻━┻', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '(ﾉಥ益ಥ）ﾉ﻿ ┻━┻', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"(ﾉಥ益ಥ）ﾉ﻿ ┻━┻"
     },
@@ -2471,7 +2471,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\"}",
-    statement:"{ `literal`: '┬─┬ノ( º _ ºノ)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '┬─┬ノ( º _ ºノ)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"┬─┬ノ( º _ ºノ)"
     },
@@ -2490,7 +2490,7 @@
   },
   {
     name:"big list of naughty strings{str:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\"}",
-    statement:"{ `literal`: '( ͡° ͜ʖ ͡°)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '( ͡° ͜ʖ ͡°)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"( ͡° ͜ʖ ͡°)"
     },
@@ -2509,7 +2509,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001f60d\"}",
-    statement:"{ `literal`: '😍', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '😍', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"😍"
     },
@@ -2528,7 +2528,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001f469\\U0001f3fd\"}",
-    statement:"{ `literal`: '👩🏽', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '👩🏽', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"👩🏽"
     },
@@ -2547,7 +2547,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001f47e \\U0001f647 \\U0001f481 \\U0001f645 \\U0001f646 \\U0001f64b \\U0001f64e \\U0001f64d\"}",
-    statement:"{ `literal`: '👾 🙇 💁 🙅 🙆 🙋 🙎 🙍', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '👾 🙇 💁 🙅 🙆 🙋 🙎 🙍', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"👾 🙇 💁 🙅 🙆 🙋 🙎 🙍"
     },
@@ -2566,7 +2566,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001f435 \\U0001f648 \\U0001f649 \\U0001f64a\"}",
-    statement:"{ `literal`: '🐵 🙈 🙉 🙊', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '🐵 🙈 🙉 🙊', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"🐵 🙈 🙉 🙊"
     },
@@ -2585,7 +2585,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u2764\\ufe0f \\U0001f494 \\U0001f48c \\U0001f495 \\U0001f49e \\U0001f493 \\U0001f497 \\U0001f496 \\U0001f498 \\U0001f49d \\U0001f49f \\U0001f49c \\U0001f49b \\U0001f49a \\U0001f499\"}",
-    statement:"{ `literal`: '❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙"
     },
@@ -2604,7 +2604,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u270b\\U0001f3ff \\U0001f4aa\\U0001f3ff \\U0001f450\\U0001f3ff \\U0001f64c\\U0001f3ff \\U0001f44f\\U0001f3ff \\U0001f64f\\U0001f3ff\"}",
-    statement:"{ `literal`: '✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿"
     },
@@ -2623,7 +2623,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001f6be \\U0001f192 \\U0001f193 \\U0001f195 \\U0001f196 \\U0001f197 \\U0001f199 \\U0001f3e7\"}",
-    statement:"{ `literal`: '🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧"
     },
@@ -2642,7 +2642,7 @@
   },
   {
     name:"big list of naughty strings{str:\"0\\ufe0f\\u20e3 1\\ufe0f\\u20e3 2\\ufe0f\\u20e3 3\\ufe0f\\u20e3 4\\ufe0f\\u20e3 5\\ufe0f\\u20e3 6\\ufe0f\\u20e3 7\\ufe0f\\u20e3 8\\ufe0f\\u20e3 9\\ufe0f\\u20e3 \\U0001f51f\"}",
-    statement:"{ `literal`: '0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟"
     },
@@ -2661,7 +2661,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8 \\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\\U0001f1f8\"}",
-    statement:"{ `literal`: '🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
     },
@@ -2680,7 +2680,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\\U0001f1eb\\U0001f1e6\\U0001f1f2\"}",
-    statement:"{ `literal`: '🇺🇸🇷🇺🇸🇦🇫🇦🇲', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '🇺🇸🇷🇺🇸🇦🇫🇦🇲', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"🇺🇸🇷🇺🇸🇦🇫🇦🇲"
     },
@@ -2699,7 +2699,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001f1fa\\U0001f1f8\\U0001f1f7\\U0001f1fa\\U0001f1f8\\U0001f1e6\"}",
-    statement:"{ `literal`: '🇺🇸🇷🇺🇸🇦', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '🇺🇸🇷🇺🇸🇦', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"🇺🇸🇷🇺🇸🇦"
     },
@@ -2718,7 +2718,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\uff11\\uff12\\uff13\"}",
-    statement:"{ `literal`: '１２３', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '１２３', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"１２３"
     },
@@ -2737,7 +2737,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u0661\\u0662\\u0663\"}",
-    statement:"{ `literal`: '١٢٣', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '١٢٣', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"١٢٣"
     },
@@ -2756,7 +2756,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u062b\\u0645 \\u0646\\u0641\\u0633 \\u0633\\u0642\\u0637\\u062a \\u0648\\u0628\\u0627\\u0644\\u062a\\u062d\\u062f\\u064a\\u062f\\u060c, \\u062c\\u0632\\u064a\\u0631\\u062a\\u064a \\u0628\\u0627\\u0633\\u062a\\u062e\\u062f\\u0627\\u0645 \\u0623\\u0646 \\u062f\\u0646\\u0648. \\u0625\\u0630 \\u0647\\u0646\\u0627\\u061f \\u0627\\u0644\\u0633\\u062a\\u0627\\u0631 \\u0648\\u062a\\u0646\\u0635\\u064a\\u0628 \\u0643\\u0627\\u0646. \\u0623\\u0647\\u0651\\u0644 \\u0627\\u064a\\u0637\\u0627\\u0644\\u064a\\u0627\\u060c \\u0628\\u0631\\u064a\\u0637\\u0627\\u0646\\u064a\\u0627-\\u0641\\u0631\\u0646\\u0633\\u0627 \\u0642\\u062f \\u0623\\u062e\\u0630. \\u0633\\u0644\\u064a\\u0645\\u0627\\u0646\\u060c \\u0625\\u062a\\u0641\\u0627\\u0642\\u064a\\u0629 \\u0628\\u064a\\u0646 \\u0645\\u0627, \\u064a\\u0630\\u0643\\u0631 \\u0627\\u0644\\u062d\\u062f\\u0648\\u062f \\u0623\\u064a \\u0628\\u0639\\u062f, \\u0645\\u0639\\u0627\\u0645\\u0644\\u0629 \\u0628\\u0648\\u0644\\u0646\\u062f\\u0627\\u060c \\u0627\\u0644\\u0625\\u0637\\u0644\\u0627\\u0642 \\u0639\\u0644 \\u0625\\u064a\\u0648.\"}",
-    statement:"{ `literal`: 'ثم نفس سقطت وبالتحديد،, جزيرتي باستخدام أن دنو. إذ هنا؟ الستار وتنصيب كان. أهّل ايطاليا، بريطانيا-فرنسا قد أخذ. سليمان، إتفاقية بين ما, يذكر الحدود أي بعد, معاملة بولندا، الإطلاق عل إيو.', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ثم نفس سقطت وبالتحديد،, جزيرتي باستخدام أن دنو. إذ هنا؟ الستار وتنصيب كان. أهّل ايطاليا، بريطانيا-فرنسا قد أخذ. سليمان، إتفاقية بين ما, يذكر الحدود أي بعد, معاملة بولندا، الإطلاق عل إيو.', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ثم نفس سقطت وبالتحديد،, جزيرتي باستخدام أن دنو. إذ هنا؟ الستار وتنصيب كان. أهّل ايطاليا، بريطانيا-فرنسا قد أخذ. سليمان، إتفاقية بين ما, يذكر الحدود أي بعد, معاملة بولندا، الإطلاق عل إيو."
     },
@@ -2775,7 +2775,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u05d1\\u05b0\\u05bc\\u05e8\\u05b5\\u05d0\\u05e9\\u05b4\\u05c1\\u05d9\\u05ea, \\u05d1\\u05b8\\u05bc\\u05e8\\u05b8\\u05d0 \\u05d0\\u05b1\\u05dc\\u05b9\\u05d4\\u05b4\\u05d9\\u05dd, \\u05d0\\u05b5\\u05ea \\u05d4\\u05b7\\u05e9\\u05b8\\u05bc\\u05c1\\u05de\\u05b7\\u05d9\\u05b4\\u05dd, \\u05d5\\u05b0\\u05d0\\u05b5\\u05ea \\u05d4\\u05b8\\u05d0\\u05b8\\u05e8\\u05b6\\u05e5\"}",
-    statement:"{ `literal`: 'בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ"
     },
@@ -2794,7 +2794,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u05d4\\u05b8\\u05d9\\u05b0\\u05ea\\u05b8\\u05d4test\\u0627\\u0644\\u0635\\u0641\\u062d\\u0627\\u062a \\u0627\\u0644\\u062a\\u0651\\u062d\\u0648\\u0644\"}",
-    statement:"{ `literal`: 'הָיְתָהtestالصفحات التّحول', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'הָיְתָהtestالصفحات التّحول', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"הָיְתָהtestالصفحات التّحول"
     },
@@ -2813,7 +2813,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\ufdfd\"}",
-    statement:"{ `literal`: '﷽', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '﷽', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"﷽"
     },
@@ -2832,7 +2832,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\ufdfa\"}",
-    statement:"{ `literal`: 'ﷺ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ﷺ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ﷺ"
     },
@@ -2851,7 +2851,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u0645\\u064f\\u0646\\u064e\\u0627\\u0642\\u064e\\u0634\\u064e\\u0629\\u064f \\u0633\\u064f\\u0628\\u064f\\u0644\\u0650 \\u0627\\u0650\\u0633\\u0652\\u062a\\u0650\\u062e\\u0652\\u062f\\u064e\\u0627\\u0645\\u0650 \\u0627\\u0644\\u0644\\u064f\\u0651\\u063a\\u064e\\u0629\\u0650 \\u0641\\u0650\\u064a \\u0627\\u0644\\u0646\\u064f\\u0651\\u0638\\u064f\\u0645\\u0650 \\u0627\\u0644\\u0652\\u0642\\u064e\\u0627\\u0626\\u0650\\u0645\\u064e\\u0629\\u0650 \\u0648\\u064e\\u0641\\u0650\\u064a\\u0645 \\u064a\\u064e\\u062e\\u064f\\u0635\\u064e\\u0651 \\u0627\\u0644\\u062a\\u064e\\u0651\\u0637\\u0652\\u0628\\u0650\\u064a\\u0642\\u064e\\u0627\\u062a\\u064f \\u0627\\u0644\\u0652\\u062d\\u0627\\u0633\\u064f\\u0648\\u0628\\u0650\\u064a\\u064e\\u0651\\u0629\\u064f\\u060c \"}",
-    statement:"{ `literal`: 'مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ، ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ، ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ، "
     },
@@ -2870,7 +2870,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u200b\"}",
-    statement:"{ `literal`: '​', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '​', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"​"
     },
@@ -2889,7 +2889,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u1680\"}",
-    statement:"{ `literal`: ' ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': ' ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:" "
     },
@@ -2908,7 +2908,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u180e\"}",
-    statement:"{ `literal`: '᠎', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '᠎', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"᠎"
     },
@@ -2927,7 +2927,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u3000\"}",
-    statement:"{ `literal`: '　', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '　', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"　"
     },
@@ -2946,7 +2946,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\ufeff\"}",
-    statement:"{ `literal`: '﻿', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '﻿', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"﻿"
     },
@@ -2965,7 +2965,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u2423\"}",
-    statement:"{ `literal`: '␣', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '␣', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"␣"
     },
@@ -2984,7 +2984,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u2422\"}",
-    statement:"{ `literal`: '␢', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '␢', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"␢"
     },
@@ -3003,7 +3003,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u2421\"}",
-    statement:"{ `literal`: '␡', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '␡', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"␡"
     },
@@ -3022,7 +3022,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u202a\\u202atest\\u202a\"}",
-    statement:"{ `literal`: '‪‪test‪', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '‪‪test‪', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"‪‪test‪"
     },
@@ -3041,7 +3041,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u202btest\\u202b\"}",
-    statement:"{ `literal`: '‫test‫', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '‫test‫', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"‫test‫"
     },
@@ -3060,7 +3060,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u2029test\\u2029\"}",
-    statement:"{ `literal`: ' test ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': ' test ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:" test "
     },
@@ -3079,7 +3079,7 @@
   },
   {
     name:"big list of naughty strings{str:\"test\\u2060test\\u202b\"}",
-    statement:"{ `literal`: 'test⁠test‫', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'test⁠test‫', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"test⁠test‫"
     },
@@ -3098,7 +3098,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u2066test\\u2067\"}",
-    statement:"{ `literal`: '⁦test⁧', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '⁦test⁧', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"⁦test⁧"
     },
@@ -3117,7 +3117,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u1e70\\u033a\\u033a\\u0315o\\u035e \\u0337i\\u0332\\u032c\\u0347\\u032a\\u0359n\\u031d\\u0317\\u0355v\\u031f\\u031c\\u0318\\u0326\\u035fo\\u0336\\u0319\\u0330\\u0320k\\xe8\\u035a\\u032e\\u033a\\u032a\\u0339\\u0331\\u0324 \\u0316t\\u031d\\u0355\\u0333\\u0323\\u033b\\u032a\\u035eh\\u033c\\u0353\\u0332\\u0326\\u0333\\u0318\\u0332e\\u0347\\u0323\\u0330\\u0326\\u032c\\u034e \\u0322\\u033c\\u033b\\u0331\\u0318h\\u035a\\u034e\\u0359\\u031c\\u0323\\u0332\\u0345i\\u0326\\u0332\\u0323\\u0330\\u0324v\\u033b\\u034de\\u033a\\u032d\\u0333\\u032a\\u0330-m\\u0322i\\u0345n\\u0316\\u033a\\u031e\\u0332\\u032f\\u0330d\\u0335\\u033c\\u031f\\u0359\\u0329\\u033c\\u0318\\u0333 \\u031e\\u0325\\u0331\\u0333\\u032dr\\u031b\\u0317\\u0318e\\u0359p\\u0360r\\u033c\\u031e\\u033b\\u032d\\u0317e\\u033a\\u0320\\u0323\\u035fs\\u0318\\u0347\\u0333\\u034d\\u031d\\u0349e\\u0349\\u0325\\u032f\\u031e\\u0332\\u035a\\u032c\\u035c\\u01f9\\u032c\\u034e\\u034e\\u031f\\u0316\\u0347\\u0324t\\u034d\\u032c\\u0324\\u0353\\u033c\\u032d\\u0358\\u0345i\\u032a\\u0331n\\u0360g\\u0334\\u0349 \\u034f\\u0349\\u0345c\\u032c\\u031fh\\u0361a\\u032b\\u033b\\u032f\\u0358o\\u032b\\u031f\\u0316\\u034d\\u0319\\u031d\\u0349s\\u0317\\u0326\\u0332.\\u0328\\u0339\\u0348\\u0323\"}",
-    statement:"{ `literal`: 'Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣"
     },
@@ -3136,7 +3136,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u0321\\u0353\\u031e\\u0345I\\u0317\\u0318\\u0326\\u035dn\\u0347\\u0347\\u0359v\\u032e\\u032bok\\u0332\\u032b\\u0319\\u0348i\\u0316\\u0359\\u032d\\u0339\\u0320\\u031en\\u0321\\u033b\\u032e\\u0323\\u033ag\\u0332\\u0348\\u0359\\u032d\\u0359\\u032c\\u034e \\u0330t\\u0354\\u0326h\\u031e\\u0332e\\u0322\\u0324 \\u034d\\u032c\\u0332\\u0356f\\u0334\\u0318\\u0355\\u0323\\xe8\\u0356\\u1eb9\\u0325\\u0329l\\u0356\\u0354\\u035ai\\u0353\\u035a\\u0326\\u0360n\\u0356\\u034d\\u0317\\u0353\\u0333\\u032eg\\u034d \\u0328o\\u035a\\u032a\\u0361f\\u0318\\u0323\\u032c \\u0316\\u0318\\u0356\\u031f\\u0359\\u032ec\\u0489\\u0354\\u032b\\u0356\\u0353\\u0347\\u0356\\u0345h\\u0335\\u0324\\u0323\\u035a\\u0354\\xe1\\u0317\\u033c\\u0355\\u0345o\\u033c\\u0323\\u0325s\\u0331\\u0348\\u033a\\u0316\\u0326\\u033b\\u0362.\\u031b\\u0316\\u031e\\u0320\\u032b\\u0330\"}",
-    statement:"{ `literal`: '̡͓̞ͅI̗̘̦͝n͇͇͙v̮̫ok̲̫̙͈i̖͙̭̹̠̞n̡̻̮̣̺g̲͈͙̭͙̬͎ ̰t͔̦h̞̲e̢̤ ͍̬̲͖f̴̘͕̣è͖ẹ̥̩l͖͔͚i͓͚̦͠n͖͍̗͓̳̮g͍ ̨o͚̪͡f̘̣̬ ̖̘͖̟͙̮c҉͔̫͖͓͇͖ͅh̵̤̣͚͔á̗̼͕ͅo̼̣̥s̱͈̺̖̦̻͢.̛̖̞̠̫̰', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '̡͓̞ͅI̗̘̦͝n͇͇͙v̮̫ok̲̫̙͈i̖͙̭̹̠̞n̡̻̮̣̺g̲͈͙̭͙̬͎ ̰t͔̦h̞̲e̢̤ ͍̬̲͖f̴̘͕̣è͖ẹ̥̩l͖͔͚i͓͚̦͠n͖͍̗͓̳̮g͍ ̨o͚̪͡f̘̣̬ ̖̘͖̟͙̮c҉͔̫͖͓͇͖ͅh̵̤̣͚͔á̗̼͕ͅo̼̣̥s̱͈̺̖̦̻͢.̛̖̞̠̫̰', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"̡͓̞ͅI̗̘̦͝n͇͇͙v̮̫ok̲̫̙͈i̖͙̭̹̠̞n̡̻̮̣̺g̲͈͙̭͙̬͎ ̰t͔̦h̞̲e̢̤ ͍̬̲͖f̴̘͕̣è͖ẹ̥̩l͖͔͚i͓͚̦͠n͖͍̗͓̳̮g͍ ̨o͚̪͡f̘̣̬ ̖̘͖̟͙̮c҉͔̫͖͓͇͖ͅh̵̤̣͚͔á̗̼͕ͅo̼̣̥s̱͈̺̖̦̻͢.̛̖̞̠̫̰"
     },
@@ -3155,7 +3155,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u0317\\u033a\\u0356\\u0339\\u032f\\u0353\\u1e6e\\u0324\\u034d\\u0325\\u0347\\u0348h\\u0332\\u0301e\\u034f\\u0353\\u033c\\u0317\\u0319\\u033c\\u0323\\u0354 \\u0347\\u031c\\u0331\\u0320\\u0353\\u034d\\u0345N\\u0355\\u0360e\\u0317\\u0331z\\u0318\\u031d\\u031c\\u033a\\u0359p\\u0324\\u033a\\u0339\\u034d\\u032f\\u035ae\\u0320\\u033b\\u0320\\u035cr\\u0328\\u0324\\u034d\\u033a\\u0316\\u0354\\u0316\\u0316d\\u0320\\u031f\\u032d\\u032c\\u031d\\u035fi\\u0326\\u0356\\u0329\\u0353\\u0354\\u0324a\\u0320\\u0317\\u032c\\u0349\\u0319n\\u035a\\u035c \\u033b\\u031e\\u0330\\u035a\\u0345h\\u0335\\u0349i\\u0333\\u031ev\\u0322\\u0347\\u1e19\\u034e\\u035f-\\u0489\\u032d\\u0329\\u033c\\u0354m\\u0324\\u032d\\u032bi\\u0355\\u0347\\u031d\\u0326n\\u0317\\u0359\\u1e0d\\u031f \\u032f\\u0332\\u0355\\u035e\\u01eb\\u031f\\u032f\\u0330\\u0332\\u0359\\u033b\\u031df \\u032a\\u0330\\u0330\\u0317\\u0316\\u032d\\u0318\\u0358c\\u0326\\u034d\\u0332\\u031e\\u034d\\u0329\\u0319\\u1e25\\u035aa\\u032e\\u034e\\u031f\\u0319\\u035c\\u01a1\\u0329\\u0339\\u034es\\u0324.\\u031d\\u031d \\u0489Z\\u0321\\u0316\\u031c\\u0356\\u0330\\u0323\\u0349\\u031ca\\u0356\\u0330\\u0359\\u032c\\u0361l\\u0332\\u032b\\u0333\\u034d\\u0329g\\u0321\\u031f\\u033c\\u0331\\u035a\\u031e\\u032c\\u0345o\\u0317\\u035c.\\u031f\"}",
-    statement:"{ `literal`: '̗̺͖̹̯͓Ṯ̤͍̥͇͈h̲́e͏͓̼̗̙̼̣͔ ͇̜̱̠͓͍ͅN͕͠e̗̱z̘̝̜̺͙p̤̺̹͍̯͚e̠̻̠͜r̨̤͍̺̖͔̖̖d̠̟̭̬̝͟i̦͖̩͓͔̤a̠̗̬͉̙n͚͜ ̻̞̰͚ͅh̵͉i̳̞v̢͇ḙ͎͟-҉̭̩̼͔m̤̭̫i͕͇̝̦n̗͙ḍ̟ ̯̲͕͞ǫ̟̯̰̲͙̻̝f ̪̰̰̗̖̭̘͘c̦͍̲̞͍̩̙ḥ͚a̮͎̟̙͜ơ̩̹͎s̤.̝̝ ҉Z̡̖̜͖̰̣͉̜a͖̰͙̬͡l̲̫̳͍̩g̡̟̼̱͚̞̬ͅo̗͜.̟', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '̗̺͖̹̯͓Ṯ̤͍̥͇͈h̲́e͏͓̼̗̙̼̣͔ ͇̜̱̠͓͍ͅN͕͠e̗̱z̘̝̜̺͙p̤̺̹͍̯͚e̠̻̠͜r̨̤͍̺̖͔̖̖d̠̟̭̬̝͟i̦͖̩͓͔̤a̠̗̬͉̙n͚͜ ̻̞̰͚ͅh̵͉i̳̞v̢͇ḙ͎͟-҉̭̩̼͔m̤̭̫i͕͇̝̦n̗͙ḍ̟ ̯̲͕͞ǫ̟̯̰̲͙̻̝f ̪̰̰̗̖̭̘͘c̦͍̲̞͍̩̙ḥ͚a̮͎̟̙͜ơ̩̹͎s̤.̝̝ ҉Z̡̖̜͖̰̣͉̜a͖̰͙̬͡l̲̫̳͍̩g̡̟̼̱͚̞̬ͅo̗͜.̟', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"̗̺͖̹̯͓Ṯ̤͍̥͇͈h̲́e͏͓̼̗̙̼̣͔ ͇̜̱̠͓͍ͅN͕͠e̗̱z̘̝̜̺͙p̤̺̹͍̯͚e̠̻̠͜r̨̤͍̺̖͔̖̖d̠̟̭̬̝͟i̦͖̩͓͔̤a̠̗̬͉̙n͚͜ ̻̞̰͚ͅh̵͉i̳̞v̢͇ḙ͎͟-҉̭̩̼͔m̤̭̫i͕͇̝̦n̗͙ḍ̟ ̯̲͕͞ǫ̟̯̰̲͙̻̝f ̪̰̰̗̖̭̘͘c̦͍̲̞͍̩̙ḥ͚a̮͎̟̙͜ơ̩̹͎s̤.̝̝ ҉Z̡̖̜͖̰̣͉̜a͖̰͙̬͡l̲̫̳͍̩g̡̟̼̱͚̞̬ͅo̗͜.̟"
     },
@@ -3174,7 +3174,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u0326H\\u032c\\u0324\\u0317\\u0324\\u035de\\u035c \\u031c\\u0325\\u031d\\u033b\\u034d\\u031f\\u0301w\\u0315h\\u0316\\u032f\\u0353o\\u031d\\u0359\\u0316\\u034e\\u0331\\u032e \\u0489\\u033a\\u0319\\u031e\\u031f\\u0348W\\u0337\\u033c\\u032da\\u033a\\u032a\\u034d\\u012f\\u0348\\u0355\\u032d\\u0359\\u032f\\u031ct\\u0336\\u033c\\u032es\\u0318\\u0359\\u0356\\u0315 \\u0320\\u032b\\u0320B\\u033b\\u034d\\u0359\\u0349\\u0333\\u0345e\\u0335h\\u0335\\u032c\\u0347\\u032b\\u0359i\\u0339\\u0353\\u0333\\u0333\\u032e\\u034e\\u032b\\u0315n\\u035fd\\u0334\\u032a\\u031c\\u0316 \\u0330\\u0349\\u0329\\u0347\\u0359\\u0332\\u035e\\u0345T\\u0356\\u033c\\u0353\\u032a\\u0362h\\u034f\\u0353\\u032e\\u033be\\u032c\\u031d\\u031f\\u0345 \\u0324\\u0339\\u031dW\\u0359\\u031e\\u031d\\u0354\\u0347\\u035d\\u0345a\\u034f\\u0353\\u0354\\u0339\\u033c\\u0323l\\u0334\\u0354\\u0330\\u0324\\u031f\\u0354\\u1e3d\\u032b.\\u0355\"}",
-    statement:"{ `literal`: '̦H̬̤̗̤͝e͜ ̜̥̝̻͍̟́w̕h̖̯͓o̝͙̖͎̱̮ ҉̺̙̞̟͈W̷̼̭a̺̪͍į͈͕̭͙̯̜t̶̼̮s̘͙͖̕ ̠̫̠B̻͍͙͉̳ͅe̵h̵̬͇̫͙i̹͓̳̳̮͎̫̕n͟d̴̪̜̖ ̰͉̩͇͙̲͞ͅT͖̼͓̪͢h͏͓̮̻e̬̝̟ͅ ̤̹̝W͙̞̝͔͇͝ͅa͏͓͔̹̼̣l̴͔̰̤̟͔ḽ̫.͕', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '̦H̬̤̗̤͝e͜ ̜̥̝̻͍̟́w̕h̖̯͓o̝͙̖͎̱̮ ҉̺̙̞̟͈W̷̼̭a̺̪͍į͈͕̭͙̯̜t̶̼̮s̘͙͖̕ ̠̫̠B̻͍͙͉̳ͅe̵h̵̬͇̫͙i̹͓̳̳̮͎̫̕n͟d̴̪̜̖ ̰͉̩͇͙̲͞ͅT͖̼͓̪͢h͏͓̮̻e̬̝̟ͅ ̤̹̝W͙̞̝͔͇͝ͅa͏͓͔̹̼̣l̴͔̰̤̟͔ḽ̫.͕', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"̦H̬̤̗̤͝e͜ ̜̥̝̻͍̟́w̕h̖̯͓o̝͙̖͎̱̮ ҉̺̙̞̟͈W̷̼̭a̺̪͍į͈͕̭͙̯̜t̶̼̮s̘͙͖̕ ̠̫̠B̻͍͙͉̳ͅe̵h̵̬͇̫͙i̹͓̳̳̮͎̫̕n͟d̴̪̜̖ ̰͉̩͇͙̲͞ͅT͖̼͓̪͢h͏͓̮̻e̬̝̟ͅ ̤̹̝W͙̞̝͔͇͝ͅa͏͓͔̹̼̣l̴͔̰̤̟͔ḽ̫.͕"
     },
@@ -3193,7 +3193,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Z\\u032e\\u031e\\u0320\\u0359\\u0354\\u0345\\u1e00\\u0317\\u031e\\u0348\\u033b\\u0317\\u1e36\\u0359\\u034e\\u032f\\u0339\\u031e\\u0353G\\u033bO\\u032d\\u0317\\u032e\"}",
-    statement:"{ `literal`: 'Z̮̞̠͙͔ͅḀ̗̞͈̻̗Ḷ͙͎̯̹̞͓G̻O̭̗̮', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Z̮̞̠͙͔ͅḀ̗̞͈̻̗Ḷ͙͎̯̹̞͓G̻O̭̗̮', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Z̮̞̠͙͔ͅḀ̗̞͈̻̗Ḷ͙͎̯̹̞͓G̻O̭̗̮"
     },
@@ -3212,7 +3212,7 @@
   },
   {
     name:"big list of naughty strings{str:\"00\\u02d9\\u0196-\"}",
-    statement:"{ `literal`: '00˙Ɩ$-', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '00˙Ɩ$-', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"00˙Ɩ$-"
     },
@@ -3231,7 +3231,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\uff34\\uff48\\uff45 \\uff51\\uff55\\uff49\\uff43\\uff4b \\uff42\\uff52\\uff4f\\uff57\\uff4e \\uff46\\uff4f\\uff58 \\uff4a\\uff55\\uff4d\\uff50\\uff53 \\uff4f\\uff56\\uff45\\uff52 \\uff54\\uff48\\uff45 \\uff4c\\uff41\\uff5a\\uff59 \\uff44\\uff4f\\uff47\"}",
-    statement:"{ `literal`: 'Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ"
     },
@@ -3250,7 +3250,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001d413\\U0001d421\\U0001d41e \\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b \\U0001d42d\\U0001d421\\U0001d41e \\U0001d425\\U0001d41a\\U0001d433\\U0001d432 \\U0001d41d\\U0001d428\\U0001d420\"}",
-    statement:"{ `literal`: '𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠"
     },
@@ -3269,7 +3269,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001d57f\\U0001d58d\\U0001d58a \\U0001d596\\U0001d59a\\U0001d58e\\U0001d588\\U0001d590 \\U0001d587\\U0001d597\\U0001d594\\U0001d59c\\U0001d593 \\U0001d58b\\U0001d594\\U0001d59d \\U0001d58f\\U0001d59a\\U0001d592\\U0001d595\\U0001d598 \\U0001d594\\U0001d59b\\U0001d58a\\U0001d597 \\U0001d599\\U0001d58d\\U0001d58a \\U0001d591\\U0001d586\\U0001d59f\\U0001d59e \\U0001d589\\U0001d594\\U0001d58c\"}",
-    statement:"{ `literal`: '𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌"
     },
@@ -3288,7 +3288,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001d47b\\U0001d489\\U0001d486 \\U0001d492\\U0001d496\\U0001d48a\\U0001d484\\U0001d48c \\U0001d483\\U0001d493\\U0001d490\\U0001d498\\U0001d48f \\U0001d487\\U0001d490\\U0001d499 \\U0001d48b\\U0001d496\\U0001d48e\\U0001d491\\U0001d494 \\U0001d490\\U0001d497\\U0001d486\\U0001d493 \\U0001d495\\U0001d489\\U0001d486 \\U0001d48d\\U0001d482\\U0001d49b\\U0001d49a \\U0001d485\\U0001d490\\U0001d488\"}",
-    statement:"{ `literal`: '𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈"
     },
@@ -3307,7 +3307,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001d4e3\\U0001d4f1\\U0001d4ee \\U0001d4fa\\U0001d4fe\\U0001d4f2\\U0001d4ec\\U0001d4f4 \\U0001d4eb\\U0001d4fb\\U0001d4f8\\U0001d500\\U0001d4f7 \\U0001d4ef\\U0001d4f8\\U0001d501 \\U0001d4f3\\U0001d4fe\\U0001d4f6\\U0001d4f9\\U0001d4fc \\U0001d4f8\\U0001d4ff\\U0001d4ee\\U0001d4fb \\U0001d4fd\\U0001d4f1\\U0001d4ee \\U0001d4f5\\U0001d4ea\\U0001d503\\U0001d502 \\U0001d4ed\\U0001d4f8\\U0001d4f0\"}",
-    statement:"{ `literal`: '𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰"
     },
@@ -3326,7 +3326,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001d54b\\U0001d559\\U0001d556 \\U0001d562\\U0001d566\\U0001d55a\\U0001d554\\U0001d55c \\U0001d553\\U0001d563\\U0001d560\\U0001d568\\U0001d55f \\U0001d557\\U0001d560\\U0001d569 \\U0001d55b\\U0001d566\\U0001d55e\\U0001d561\\U0001d564 \\U0001d560\\U0001d567\\U0001d556\\U0001d563 \\U0001d565\\U0001d559\\U0001d556 \\U0001d55d\\U0001d552\\U0001d56b\\U0001d56a \\U0001d555\\U0001d560\\U0001d558\"}",
-    statement:"{ `literal`: '𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘"
     },
@@ -3345,7 +3345,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\U0001d683\\U0001d691\\U0001d68e \\U0001d69a\\U0001d69e\\U0001d692\\U0001d68c\\U0001d694 \\U0001d68b\\U0001d69b\\U0001d698\\U0001d6a0\\U0001d697 \\U0001d68f\\U0001d698\\U0001d6a1 \\U0001d693\\U0001d69e\\U0001d696\\U0001d699\\U0001d69c \\U0001d698\\U0001d69f\\U0001d68e\\U0001d69b \\U0001d69d\\U0001d691\\U0001d68e \\U0001d695\\U0001d68a\\U0001d6a3\\U0001d6a2 \\U0001d68d\\U0001d698\\U0001d690\"}",
-    statement:"{ `literal`: '𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐"
     },
@@ -3364,7 +3364,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\u24af\\u24a3\\u24a0 \\u24ac\\u24b0\\u24a4\\u249e\\u24a6 \\u249d\\u24ad\\u24aa\\u24b2\\u24a9 \\u24a1\\u24aa\\u24b3 \\u24a5\\u24b0\\u24a8\\u24ab\\u24ae \\u24aa\\u24b1\\u24a0\\u24ad \\u24af\\u24a3\\u24a0 \\u24a7\\u249c\\u24b5\\u24b4 \\u249f\\u24aa\\u24a2\"}",
-    statement:"{ `literal`: '⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢"
     },
@@ -3383,7 +3383,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<script>alert(123)</script>\"}",
-    statement:"{ `literal`: '<script>alert(123)</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<script>alert(123)</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<script>alert(123)</script>"
     },
@@ -3402,7 +3402,7 @@
   },
   {
     name:"big list of naughty strings{str:\"&lt;script&gt;alert(&#39;123&#39;);&lt;/script&gt;\"}",
-    statement:"{ `literal`: '&lt;script&gt;alert(&#39;123&#39;);&lt;/script&gt;', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '&lt;script&gt;alert(&#39;123&#39;);&lt;/script&gt;', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"&lt;script&gt;alert(&#39;123&#39;);&lt;/script&gt;"
     },
@@ -3421,7 +3421,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x onerror=alert(123) />\"}",
-    statement:"{ `literal`: '<img src=x onerror=alert(123) />', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x onerror=alert(123) />', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x onerror=alert(123) />"
     },
@@ -3440,7 +3440,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<svg><script>123<1>alert(123)</script>\"}",
-    statement:"{ `literal`: '<svg><script>123<1>alert(123)</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<svg><script>123<1>alert(123)</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<svg><script>123<1>alert(123)</script>"
     },
@@ -3459,7 +3459,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\\"><script>alert(123)</script>\"}",
-    statement:"{ `literal`: '\"><script>alert(123)</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\"><script>alert(123)</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\"><script>alert(123)</script>"
     },
@@ -3478,7 +3478,7 @@
   },
   {
     name:"big list of naughty strings{str:\"><script>alert(123)</script>\"}",
-    statement:"{ `literal`: '><script>alert(123)</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '><script>alert(123)</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"><script>alert(123)</script>"
     },
@@ -3497,7 +3497,7 @@
   },
   {
     name:"big list of naughty strings{str:\"</script><script>alert(123)</script>\"}",
-    statement:"{ `literal`: '</script><script>alert(123)</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '</script><script>alert(123)</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"</script><script>alert(123)</script>"
     },
@@ -3516,7 +3516,7 @@
   },
   {
     name:"big list of naughty strings{str:\"< / script >< script >alert(123)< / script >\"}",
-    statement:"{ `literal`: '< / script >< script >alert(123)< / script >', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '< / script >< script >alert(123)< / script >', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"< / script >< script >alert(123)< / script >"
     },
@@ -3535,7 +3535,7 @@
   },
   {
     name:"big list of naughty strings{str:\" onfocus=JaVaSCript:alert(123) autofocus\"}",
-    statement:"{ `literal`: ' onfocus=JaVaSCript:alert(123) autofocus', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': ' onfocus=JaVaSCript:alert(123) autofocus', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:" onfocus=JaVaSCript:alert(123) autofocus"
     },
@@ -3554,7 +3554,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\\" onfocus=JaVaSCript:alert(123) autofocus\"}",
-    statement:"{ `literal`: '\" onfocus=JaVaSCript:alert(123) autofocus', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\" onfocus=JaVaSCript:alert(123) autofocus', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\" onfocus=JaVaSCript:alert(123) autofocus"
     },
@@ -3573,7 +3573,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\uff1cscript\\uff1ealert(123)\\uff1c/script\\uff1e\"}",
-    statement:"{ `literal`: '＜script＞alert(123)＜/script＞', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '＜script＞alert(123)＜/script＞', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"＜script＞alert(123)＜/script＞"
     },
@@ -3592,7 +3592,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<sc<script>ript>alert(123)</sc</script>ript>\"}",
-    statement:"{ `literal`: '<sc<script>ript>alert(123)</sc</script>ript>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<sc<script>ript>alert(123)</sc</script>ript>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<sc<script>ript>alert(123)</sc</script>ript>"
     },
@@ -3611,7 +3611,7 @@
   },
   {
     name:"big list of naughty strings{str:\"--><script>alert(123)</script>\"}",
-    statement:"{ `literal`: '--><script>alert(123)</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '--><script>alert(123)</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"--><script>alert(123)</script>"
     },
@@ -3630,7 +3630,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\\";alert(123);t=\\\"\"}",
-    statement:"{ `literal`: '\";alert(123);t=\"', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\";alert(123);t=\"', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\";alert(123);t=\""
     },
@@ -3649,7 +3649,7 @@
   },
   {
     name:"big list of naughty strings{str:\"JavaSCript:alert(123)\"}",
-    statement:"{ `literal`: 'JavaSCript:alert(123)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'JavaSCript:alert(123)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"JavaSCript:alert(123)"
     },
@@ -3668,7 +3668,7 @@
   },
   {
     name:"big list of naughty strings{str:\";alert(123);\"}",
-    statement:"{ `literal`: ';alert(123);', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': ';alert(123);', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:";alert(123);"
     },
@@ -3687,7 +3687,7 @@
   },
   {
     name:"big list of naughty strings{str:\"src=JaVaSCript:prompt(132)\"}",
-    statement:"{ `literal`: 'src=JaVaSCript:prompt(132)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'src=JaVaSCript:prompt(132)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"src=JaVaSCript:prompt(132)"
     },
@@ -3706,7 +3706,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\\"><script>alert(123);</script x=\\\"\"}",
-    statement:"{ `literal`: '\"><script>alert(123);</script x=\"', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\"><script>alert(123);</script x=\"', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\"><script>alert(123);</script x=\""
     },
@@ -3725,7 +3725,7 @@
   },
   {
     name:"big list of naughty strings{str:\"><script>alert(123);</script x=\"}",
-    statement:"{ `literal`: '><script>alert(123);</script x=', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '><script>alert(123);</script x=', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"><script>alert(123);</script x="
     },
@@ -3744,7 +3744,7 @@
   },
   {
     name:"big list of naughty strings{str:\"\\\" autofocus onkeyup=\\\"javascript:alert(123)\"}",
-    statement:"{ `literal`: '\" autofocus onkeyup=\"javascript:alert(123)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '\" autofocus onkeyup=\"javascript:alert(123)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"\" autofocus onkeyup=\"javascript:alert(123)"
     },
@@ -3763,7 +3763,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<script\\\\x20type=\\\"text/javascript\\\">javascript:alert(1);</script>\"}",
-    statement:"{ `literal`: '<script\\x20type=\"text/javascript\">javascript:alert(1);</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<script\\x20type=\"text/javascript\">javascript:alert(1);</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<script\\x20type=\"text/javascript\">javascript:alert(1);</script>"
     },
@@ -3782,7 +3782,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<script\\\\x3Etype=\\\"text/javascript\\\">javascript:alert(1);</script>\"}",
-    statement:"{ `literal`: '<script\\x3Etype=\"text/javascript\">javascript:alert(1);</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<script\\x3Etype=\"text/javascript\">javascript:alert(1);</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<script\\x3Etype=\"text/javascript\">javascript:alert(1);</script>"
     },
@@ -3801,7 +3801,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<script\\\\x0Dtype=\\\"text/javascript\\\">javascript:alert(1);</script>\"}",
-    statement:"{ `literal`: '<script\\x0Dtype=\"text/javascript\">javascript:alert(1);</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<script\\x0Dtype=\"text/javascript\">javascript:alert(1);</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<script\\x0Dtype=\"text/javascript\">javascript:alert(1);</script>"
     },
@@ -3820,7 +3820,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<script\\\\x09type=\\\"text/javascript\\\">javascript:alert(1);</script>\"}",
-    statement:"{ `literal`: '<script\\x09type=\"text/javascript\">javascript:alert(1);</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<script\\x09type=\"text/javascript\">javascript:alert(1);</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<script\\x09type=\"text/javascript\">javascript:alert(1);</script>"
     },
@@ -3839,7 +3839,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<script\\\\x0Ctype=\\\"text/javascript\\\">javascript:alert(1);</script>\"}",
-    statement:"{ `literal`: '<script\\x0Ctype=\"text/javascript\">javascript:alert(1);</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<script\\x0Ctype=\"text/javascript\">javascript:alert(1);</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<script\\x0Ctype=\"text/javascript\">javascript:alert(1);</script>"
     },
@@ -3858,7 +3858,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<script\\\\x2Ftype=\\\"text/javascript\\\">javascript:alert(1);</script>\"}",
-    statement:"{ `literal`: '<script\\x2Ftype=\"text/javascript\">javascript:alert(1);</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<script\\x2Ftype=\"text/javascript\">javascript:alert(1);</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<script\\x2Ftype=\"text/javascript\">javascript:alert(1);</script>"
     },
@@ -3877,7 +3877,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<script\\\\x0Atype=\\\"text/javascript\\\">javascript:alert(1);</script>\"}",
-    statement:"{ `literal`: '<script\\x0Atype=\"text/javascript\">javascript:alert(1);</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<script\\x0Atype=\"text/javascript\">javascript:alert(1);</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<script\\x0Atype=\"text/javascript\">javascript:alert(1);</script>"
     },
@@ -3896,7 +3896,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x\\\\x3Aexpression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x\\x3Aexpression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x\\x3Aexpression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x\\x3Aexpression(javascript:alert(1)\">DEF"
     },
@@ -3915,7 +3915,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:expression\\\\x5C(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:expression\\x5C(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:expression\\x5C(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:expression\\x5C(javascript:alert(1)\">DEF"
     },
@@ -3934,7 +3934,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:expression\\\\x00(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:expression\\x00(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:expression\\x00(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:expression\\x00(javascript:alert(1)\">DEF"
     },
@@ -3953,7 +3953,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:exp\\\\x00ression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:exp\\x00ression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:exp\\x00ression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:exp\\x00ression(javascript:alert(1)\">DEF"
     },
@@ -3972,7 +3972,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:exp\\\\x5Cression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:exp\\x5Cression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:exp\\x5Cression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:exp\\x5Cression(javascript:alert(1)\">DEF"
     },
@@ -3991,7 +3991,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\x0Aexpression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\x0Aexpression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\x0Aexpression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\x0Aexpression(javascript:alert(1)\">DEF"
     },
@@ -4010,7 +4010,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\x09expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\x09expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\x09expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\x09expression(javascript:alert(1)\">DEF"
     },
@@ -4029,7 +4029,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE3\\\\x80\\\\x80expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE3\\x80\\x80expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE3\\x80\\x80expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE3\\x80\\x80expression(javascript:alert(1)\">DEF"
     },
@@ -4048,7 +4048,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x84expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x84expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x84expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x84expression(javascript:alert(1)\">DEF"
     },
@@ -4067,7 +4067,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xC2\\\\xA0expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xC2\\xA0expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xC2\\xA0expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xC2\\xA0expression(javascript:alert(1)\">DEF"
     },
@@ -4086,7 +4086,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x80expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x80expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x80expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x80expression(javascript:alert(1)\">DEF"
     },
@@ -4105,7 +4105,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x8Aexpression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x8Aexpression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x8Aexpression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x8Aexpression(javascript:alert(1)\">DEF"
     },
@@ -4124,7 +4124,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\x0Dexpression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\x0Dexpression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\x0Dexpression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\x0Dexpression(javascript:alert(1)\">DEF"
     },
@@ -4143,7 +4143,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\x0Cexpression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\x0Cexpression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\x0Cexpression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\x0Cexpression(javascript:alert(1)\">DEF"
     },
@@ -4162,7 +4162,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x87expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x87expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x87expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x87expression(javascript:alert(1)\">DEF"
     },
@@ -4181,7 +4181,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xEF\\\\xBB\\\\xBFexpression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xEF\\xBB\\xBFexpression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xEF\\xBB\\xBFexpression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xEF\\xBB\\xBFexpression(javascript:alert(1)\">DEF"
     },
@@ -4200,7 +4200,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\x20expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\x20expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\x20expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\x20expression(javascript:alert(1)\">DEF"
     },
@@ -4219,7 +4219,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x88expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x88expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x88expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x88expression(javascript:alert(1)\">DEF"
     },
@@ -4238,7 +4238,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\x00expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\x00expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\x00expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\x00expression(javascript:alert(1)\">DEF"
     },
@@ -4257,7 +4257,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x8Bexpression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x8Bexpression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x8Bexpression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x8Bexpression(javascript:alert(1)\">DEF"
     },
@@ -4276,7 +4276,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x86expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x86expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x86expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x86expression(javascript:alert(1)\">DEF"
     },
@@ -4295,7 +4295,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x85expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x85expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x85expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x85expression(javascript:alert(1)\">DEF"
     },
@@ -4314,7 +4314,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x82expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x82expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x82expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x82expression(javascript:alert(1)\">DEF"
     },
@@ -4333,7 +4333,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\x0Bexpression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\x0Bexpression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\x0Bexpression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\x0Bexpression(javascript:alert(1)\">DEF"
     },
@@ -4352,7 +4352,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x81expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x81expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x81expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x81expression(javascript:alert(1)\">DEF"
     },
@@ -4371,7 +4371,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x83expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x83expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x83expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x83expression(javascript:alert(1)\">DEF"
     },
@@ -4390,7 +4390,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ABC<div style=\\\"x:\\\\xE2\\\\x80\\\\x89expression(javascript:alert(1)\\\">DEF\"}",
-    statement:"{ `literal`: 'ABC<div style=\"x:\\xE2\\x80\\x89expression(javascript:alert(1)\">DEF', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ABC<div style=\"x:\\xE2\\x80\\x89expression(javascript:alert(1)\">DEF', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ABC<div style=\"x:\\xE2\\x80\\x89expression(javascript:alert(1)\">DEF"
     },
@@ -4409,7 +4409,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x0Bjavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x0Bjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x0Bjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x0Bjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4428,7 +4428,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x0Fjavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x0Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x0Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x0Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4447,7 +4447,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xC2\\\\xA0javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xC2\\xA0javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xC2\\xA0javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xC2\\xA0javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4466,7 +4466,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x05javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x05javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x05javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x05javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4485,7 +4485,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE1\\\\xA0\\\\x8Ejavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE1\\xA0\\x8Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE1\\xA0\\x8Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE1\\xA0\\x8Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4504,7 +4504,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x18javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x18javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x18javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x18javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4523,7 +4523,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x11javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x11javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x11javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x11javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4542,7 +4542,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x88javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x88javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x88javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x88javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4561,7 +4561,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x89javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x89javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x89javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x89javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4580,7 +4580,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x80javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4599,7 +4599,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x17javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x17javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x17javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x17javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4618,7 +4618,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x03javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x03javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x03javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x03javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4637,7 +4637,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x0Ejavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x0Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x0Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x0Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4656,7 +4656,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x1Ajavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x1Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x1Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x1Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4675,7 +4675,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x00javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x00javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x00javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x00javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4694,7 +4694,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x10javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x10javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x10javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x10javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4713,7 +4713,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x82javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x82javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x82javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x82javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4732,7 +4732,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x20javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x20javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x20javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x20javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4751,7 +4751,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x13javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x13javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x13javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x13javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4770,7 +4770,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x09javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x09javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x09javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x09javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4789,7 +4789,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x8Ajavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x8Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x8Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x8Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4808,7 +4808,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x14javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x14javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x14javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x14javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4827,7 +4827,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x19javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x19javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x19javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x19javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4846,7 +4846,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\xAFjavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\xAFjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\xAFjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\xAFjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4865,7 +4865,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x1Fjavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x1Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x1Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x1Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4884,7 +4884,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x81javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x81javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x81javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x81javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4903,7 +4903,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x1Djavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x1Djavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x1Djavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x1Djavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4922,7 +4922,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x87javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x87javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x87javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x87javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4941,7 +4941,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x07javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x07javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x07javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x07javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4960,7 +4960,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE1\\\\x9A\\\\x80javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE1\\x9A\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE1\\x9A\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE1\\x9A\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4979,7 +4979,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x83javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x83javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x83javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x83javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -4998,7 +4998,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x04javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x04javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x04javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x04javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5017,7 +5017,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x01javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x01javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x01javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x01javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5036,7 +5036,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x08javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x08javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x08javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x08javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5055,7 +5055,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x84javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x84javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x84javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x84javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5074,7 +5074,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x86javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x86javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x86javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x86javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5093,7 +5093,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE3\\\\x80\\\\x80javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE3\\x80\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE3\\x80\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE3\\x80\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5112,7 +5112,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x12javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x12javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x12javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x12javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5131,7 +5131,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x0Djavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x0Djavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x0Djavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x0Djavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5150,7 +5150,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x0Ajavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x0Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x0Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x0Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5169,7 +5169,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x0Cjavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x0Cjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x0Cjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x0Cjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5188,7 +5188,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x15javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x15javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x15javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x15javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5207,7 +5207,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\xA8javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\xA8javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\xA8javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\xA8javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5226,7 +5226,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x16javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x16javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x16javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x16javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5245,7 +5245,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x02javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x02javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x02javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x02javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5264,7 +5264,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x1Bjavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x1Bjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x1Bjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x1Bjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5283,7 +5283,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x06javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x06javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x06javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x06javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5302,7 +5302,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\xA9javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\xA9javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\xA9javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\xA9javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5321,7 +5321,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x80\\\\x85javascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x80\\x85javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x80\\x85javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x80\\x85javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5340,7 +5340,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x1Ejavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x1Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x1Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x1Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5359,7 +5359,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\xE2\\\\x81\\\\x9Fjavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\xE2\\x81\\x9Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\xE2\\x81\\x9Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\xE2\\x81\\x9Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5378,7 +5378,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"\\\\x1Cjavascript:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"\\x1Cjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"\\x1Cjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"\\x1Cjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5397,7 +5397,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"javascript\\\\x00:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"javascript\\x00:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"javascript\\x00:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"javascript\\x00:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5416,7 +5416,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"javascript\\\\x3A:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"javascript\\x3A:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"javascript\\x3A:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"javascript\\x3A:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5435,7 +5435,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"javascript\\\\x09:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"javascript\\x09:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"javascript\\x09:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"javascript\\x09:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5454,7 +5454,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"javascript\\\\x0D:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"javascript\\x0D:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"javascript\\x0D:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"javascript\\x0D:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5473,7 +5473,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=\\\"javascript\\\\x0A:javascript:alert(1)\\\" id=\\\"fuzzelement1\\\">test</a>\"}",
-    statement:"{ `literal`: '<a href=\"javascript\\x0A:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=\"javascript\\x0A:javascript:alert(1)\" id=\"fuzzelement1\">test</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=\"javascript\\x0A:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
     },
@@ -5492,7 +5492,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img \\\\x47src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img \\x47src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img \\x47src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img \\x47src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5511,7 +5511,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img \\\\x11src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img \\x11src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img \\x11src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img \\x11src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5530,7 +5530,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img \\\\x12src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img \\x12src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img \\x12src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img \\x12src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5549,7 +5549,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img\\\\x47src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img\\x47src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img\\x47src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img\\x47src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5568,7 +5568,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img\\\\x10src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img\\x10src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img\\x10src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img\\x10src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5587,7 +5587,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img\\\\x13src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img\\x13src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img\\x13src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img\\x13src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5606,7 +5606,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img\\\\x32src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img\\x32src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img\\x32src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img\\x32src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5625,7 +5625,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img\\\\x11src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img\\x11src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img\\x11src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img\\x11src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5644,7 +5644,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img \\\\x34src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img \\x34src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img \\x34src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img \\x34src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5663,7 +5663,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img \\\\x39src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img \\x39src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img \\x39src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img \\x39src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5682,7 +5682,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img \\\\x00src=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img \\x00src=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img \\x00src=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img \\x00src=x onerror=\"javascript:alert(1)\">"
     },
@@ -5701,7 +5701,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src\\\\x09=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src\\x09=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src\\x09=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src\\x09=x onerror=\"javascript:alert(1)\">"
     },
@@ -5720,7 +5720,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src\\\\x10=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src\\x10=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src\\x10=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src\\x10=x onerror=\"javascript:alert(1)\">"
     },
@@ -5739,7 +5739,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src\\\\x13=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src\\x13=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src\\x13=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src\\x13=x onerror=\"javascript:alert(1)\">"
     },
@@ -5758,7 +5758,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src\\\\x32=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src\\x32=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src\\x32=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src\\x32=x onerror=\"javascript:alert(1)\">"
     },
@@ -5777,7 +5777,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src\\\\x12=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src\\x12=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src\\x12=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src\\x12=x onerror=\"javascript:alert(1)\">"
     },
@@ -5796,7 +5796,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src\\\\x11=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src\\x11=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src\\x11=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src\\x11=x onerror=\"javascript:alert(1)\">"
     },
@@ -5815,7 +5815,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src\\\\x00=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src\\x00=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src\\x00=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src\\x00=x onerror=\"javascript:alert(1)\">"
     },
@@ -5834,7 +5834,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src\\\\x47=x onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src\\x47=x onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src\\x47=x onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src\\x47=x onerror=\"javascript:alert(1)\">"
     },
@@ -5853,7 +5853,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x\\\\x09onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x\\x09onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x\\x09onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x\\x09onerror=\"javascript:alert(1)\">"
     },
@@ -5872,7 +5872,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x\\\\x10onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x\\x10onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x\\x10onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x\\x10onerror=\"javascript:alert(1)\">"
     },
@@ -5891,7 +5891,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x\\\\x11onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x\\x11onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x\\x11onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x\\x11onerror=\"javascript:alert(1)\">"
     },
@@ -5910,7 +5910,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x\\\\x12onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x\\x12onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x\\x12onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x\\x12onerror=\"javascript:alert(1)\">"
     },
@@ -5929,7 +5929,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x\\\\x13onerror=\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x\\x13onerror=\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x\\x13onerror=\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x\\x13onerror=\"javascript:alert(1)\">"
     },
@@ -5948,7 +5948,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img[a][b][c]src[d]=x[e]onerror=[f]\\\"alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img[a][b][c]src[d]=x[e]onerror=[f]\"alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img[a][b][c]src[d]=x[e]onerror=[f]\"alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img[a][b][c]src[d]=x[e]onerror=[f]\"alert(1)\">"
     },
@@ -5967,7 +5967,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x onerror=\\\\x09\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x onerror=\\x09\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x onerror=\\x09\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x onerror=\\x09\"javascript:alert(1)\">"
     },
@@ -5986,7 +5986,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x onerror=\\\\x10\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x onerror=\\x10\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x onerror=\\x10\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x onerror=\\x10\"javascript:alert(1)\">"
     },
@@ -6005,7 +6005,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x onerror=\\\\x11\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x onerror=\\x11\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x onerror=\\x11\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x onerror=\\x11\"javascript:alert(1)\">"
     },
@@ -6024,7 +6024,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x onerror=\\\\x12\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x onerror=\\x12\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x onerror=\\x12\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x onerror=\\x12\"javascript:alert(1)\">"
     },
@@ -6043,7 +6043,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x onerror=\\\\x32\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x onerror=\\x32\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x onerror=\\x32\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x onerror=\\x32\"javascript:alert(1)\">"
     },
@@ -6062,7 +6062,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=x onerror=\\\\x00\\\"javascript:alert(1)\\\">\"}",
-    statement:"{ `literal`: '<img src=x onerror=\\x00\"javascript:alert(1)\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=x onerror=\\x00\"javascript:alert(1)\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=x onerror=\\x00\"javascript:alert(1)\">"
     },
@@ -6081,7 +6081,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=java&#1&#2&#3&#4&#5&#6&#7&#8&#11&#12script:javascript:alert(1)>XXX</a>\"}",
-    statement:"{ `literal`: '<a href=java&#1&#2&#3&#4&#5&#6&#7&#8&#11&#12script:javascript:alert(1)>XXX</a>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=java&#1&#2&#3&#4&#5&#6&#7&#8&#11&#12script:javascript:alert(1)>XXX</a>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=java&#1&#2&#3&#4&#5&#6&#7&#8&#11&#12script:javascript:alert(1)>XXX</a>"
     },
@@ -6100,7 +6100,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<img src=\\\"x` `<script>javascript:alert(1)</script>\\\"` `>\"}",
-    statement:"{ `literal`: '<img src=\"x` `<script>javascript:alert(1)</script>\"` `>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<img src=\"x` `<script>javascript:alert(1)</script>\"` `>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<img src=\"x` `<script>javascript:alert(1)</script>\"` `>"
     },
@@ -6119,7 +6119,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<title onpropertychange=javascript:alert(1)></title><title title=>\"}",
-    statement:"{ `literal`: '<title onpropertychange=javascript:alert(1)></title><title title=>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<title onpropertychange=javascript:alert(1)></title><title title=>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<title onpropertychange=javascript:alert(1)></title><title title=>"
     },
@@ -6138,7 +6138,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<a href=http://foo.bar/#x=`y></a><img alt=\\\"`><img src=x:x onerror=javascript:alert(1)></a>\\\">\"}",
-    statement:"{ `literal`: '<a href=http://foo.bar/#x=`y></a><img alt=\"`><img src=x:x onerror=javascript:alert(1)></a>\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<a href=http://foo.bar/#x=`y></a><img alt=\"`><img src=x:x onerror=javascript:alert(1)></a>\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<a href=http://foo.bar/#x=`y></a><img alt=\"`><img src=x:x onerror=javascript:alert(1)></a>\">"
     },
@@ -6157,7 +6157,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<!--[if]><script>javascript:alert(1)</script -->\"}",
-    statement:"{ `literal`: '<!--[if]><script>javascript:alert(1)</script -->', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<!--[if]><script>javascript:alert(1)</script -->', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<!--[if]><script>javascript:alert(1)</script -->"
     },
@@ -6176,7 +6176,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<!--[if<img src=x onerror=javascript:alert(1)//]> -->\"}",
-    statement:"{ `literal`: '<!--[if<img src=x onerror=javascript:alert(1)//]> -->', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<!--[if<img src=x onerror=javascript:alert(1)//]> -->', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<!--[if<img src=x onerror=javascript:alert(1)//]> -->"
     },
@@ -6195,7 +6195,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<script src=\\\"/\\\\%(jscript)s\\\"></script>\"}",
-    statement:"{ `literal`: '<script src=\"/\\%(jscript)s\"></script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<script src=\"/\\%(jscript)s\"></script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<script src=\"/\\%(jscript)s\"></script>"
     },
@@ -6214,7 +6214,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<script src=\\\"\\\\\\\\%(jscript)s\\\"></script>\"}",
-    statement:"{ `literal`: '<script src=\"\\\\%(jscript)s\"></script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<script src=\"\\\\%(jscript)s\"></script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<script src=\"\\\\%(jscript)s\"></script>"
     },
@@ -6233,7 +6233,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<IMG \\\"\\\"\\\"><SCRIPT>alert(\\\"XSS\\\")</SCRIPT>\\\">\"}",
-    statement:"{ `literal`: '<IMG \"\"\"><SCRIPT>alert(\"XSS\")</SCRIPT>\">', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<IMG \"\"\"><SCRIPT>alert(\"XSS\")</SCRIPT>\">', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<IMG \"\"\"><SCRIPT>alert(\"XSS\")</SCRIPT>\">"
     },
@@ -6252,7 +6252,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<IMG SRC=javascript:alert(String.fromCharCode(88,83,83))>\"}",
-    statement:"{ `literal`: '<IMG SRC=javascript:alert(String.fromCharCode(88,83,83))>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<IMG SRC=javascript:alert(String.fromCharCode(88,83,83))>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<IMG SRC=javascript:alert(String.fromCharCode(88,83,83))>"
     },
@@ -6271,7 +6271,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;>\"}",
-    statement:"{ `literal`: '<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;>"
     },
@@ -6290,7 +6290,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<IMG SRC=&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041>\"}",
-    statement:"{ `literal`: '<IMG SRC=&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<IMG SRC=&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<IMG SRC=&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041>"
     },
@@ -6309,7 +6309,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<IMG SRC=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29>\"}",
-    statement:"{ `literal`: '<IMG SRC=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<IMG SRC=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<IMG SRC=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29>"
     },
@@ -6328,7 +6328,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<SCRIPT/XSS SRC=\\\"http://ha.ckers.org/xss.js\\\"></SCRIPT>\"}",
-    statement:"{ `literal`: '<SCRIPT/XSS SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<SCRIPT/XSS SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<SCRIPT/XSS SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>"
     },
@@ -6347,7 +6347,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<BODY onload!#%&()*~+-_.,:;?@[/|\\\\]^`=alert(\\\"XSS\\\")>\"}",
-    statement:"{ `literal`: '<BODY onload!#$%&()*~+-_.,:;?@[/|\\]^`=alert(\"XSS\")>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<BODY onload!#$%&()*~+-_.,:;?@[/|\\]^`=alert(\"XSS\")>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<BODY onload!#$%&()*~+-_.,:;?@[/|\\]^`=alert(\"XSS\")>"
     },
@@ -6366,7 +6366,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<SCRIPT/SRC=\\\"http://ha.ckers.org/xss.js\\\"></SCRIPT>\"}",
-    statement:"{ `literal`: '<SCRIPT/SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<SCRIPT/SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<SCRIPT/SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>"
     },
@@ -6385,7 +6385,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<<SCRIPT>alert(\\\"XSS\\\");//<</SCRIPT>\"}",
-    statement:"{ `literal`: '<<SCRIPT>alert(\"XSS\");//<</SCRIPT>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<<SCRIPT>alert(\"XSS\");//<</SCRIPT>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<<SCRIPT>alert(\"XSS\");//<</SCRIPT>"
     },
@@ -6404,7 +6404,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<SCRIPT SRC=http://ha.ckers.org/xss.js?< B >\"}",
-    statement:"{ `literal`: '<SCRIPT SRC=http://ha.ckers.org/xss.js?< B >', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<SCRIPT SRC=http://ha.ckers.org/xss.js?< B >', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<SCRIPT SRC=http://ha.ckers.org/xss.js?< B >"
     },
@@ -6423,7 +6423,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<SCRIPT SRC=//ha.ckers.org/.j>\"}",
-    statement:"{ `literal`: '<SCRIPT SRC=//ha.ckers.org/.j>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<SCRIPT SRC=//ha.ckers.org/.j>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<SCRIPT SRC=//ha.ckers.org/.j>"
     },
@@ -6442,7 +6442,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<iframe src=http://ha.ckers.org/scriptlet.html <\"}",
-    statement:"{ `literal`: '<iframe src=http://ha.ckers.org/scriptlet.html <', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<iframe src=http://ha.ckers.org/scriptlet.html <', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<iframe src=http://ha.ckers.org/scriptlet.html <"
     },
@@ -6461,7 +6461,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<u oncopy=alert()> Copy me</u>\"}",
-    statement:"{ `literal`: '<u oncopy=alert()> Copy me</u>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<u oncopy=alert()> Copy me</u>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<u oncopy=alert()> Copy me</u>"
     },
@@ -6480,7 +6480,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<i onwheel=alert(1)> Scroll over me </i>\"}",
-    statement:"{ `literal`: '<i onwheel=alert(1)> Scroll over me </i>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<i onwheel=alert(1)> Scroll over me </i>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<i onwheel=alert(1)> Scroll over me </i>"
     },
@@ -6499,7 +6499,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<plaintext>\"}",
-    statement:"{ `literal`: '<plaintext>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<plaintext>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<plaintext>"
     },
@@ -6518,7 +6518,7 @@
   },
   {
     name:"big list of naughty strings{str:\"http://a/%%30%30\"}",
-    statement:"{ `literal`: 'http://a/%%30%30', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'http://a/%%30%30', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"http://a/%%30%30"
     },
@@ -6537,7 +6537,7 @@
   },
   {
     name:"big list of naughty strings{str:\"</textarea><script>alert(123)</script>\"}",
-    statement:"{ `literal`: '</textarea><script>alert(123)</script>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '</textarea><script>alert(123)</script>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"</textarea><script>alert(123)</script>"
     },
@@ -6556,7 +6556,7 @@
   },
   {
     name:"big list of naughty strings{str:\"1;DROP TABLE users\"}",
-    statement:"{ `literal`: '1;DROP TABLE users', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '1;DROP TABLE users', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"1;DROP TABLE users"
     },
@@ -6575,7 +6575,7 @@
   },
   {
     name:"big list of naughty strings{str:\" \"}",
-    statement:"{ `literal`: ' ', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': ' ', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:" "
     },
@@ -6594,7 +6594,7 @@
   },
   {
     name:"big list of naughty strings{str:\"%\"}",
-    statement:"{ `literal`: '%', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '%', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"%"
     },
@@ -6613,7 +6613,7 @@
   },
   {
     name:"big list of naughty strings{str:\"_\"}",
-    statement:"{ `literal`: '_', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '_', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"_"
     },
@@ -6632,7 +6632,7 @@
   },
   {
     name:"big list of naughty strings{str:\"-\"}",
-    statement:"{ `literal`: '-', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '-', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"-"
     },
@@ -6651,7 +6651,7 @@
   },
   {
     name:"big list of naughty strings{str:\"--\"}",
-    statement:"{ `literal`: '--', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '--', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"--"
     },
@@ -6670,7 +6670,7 @@
   },
   {
     name:"big list of naughty strings{str:\"--version\"}",
-    statement:"{ `literal`: '--version', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '--version', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"--version"
     },
@@ -6689,7 +6689,7 @@
   },
   {
     name:"big list of naughty strings{str:\"--help\"}",
-    statement:"{ `literal`: '--help', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '--help', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"--help"
     },
@@ -6708,7 +6708,7 @@
   },
   {
     name:"big list of naughty strings{str:\"USER\"}",
-    statement:"{ `literal`: '$USER', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '$USER', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"$USER"
     },
@@ -6727,7 +6727,7 @@
   },
   {
     name:"big list of naughty strings{str:\"/dev/null; touch /tmp/blns.fail ; echo\"}",
-    statement:"{ `literal`: '/dev/null; touch /tmp/blns.fail ; echo', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '/dev/null; touch /tmp/blns.fail ; echo', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"/dev/null; touch /tmp/blns.fail ; echo"
     },
@@ -6746,7 +6746,7 @@
   },
   {
     name:"big list of naughty strings{str:\"`touch /tmp/blns.fail`\"}",
-    statement:"{ `literal`: '`touch /tmp/blns.fail`', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '`touch /tmp/blns.fail`', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"`touch /tmp/blns.fail`"
     },
@@ -6765,7 +6765,7 @@
   },
   {
     name:"big list of naughty strings{str:\"(touch /tmp/blns.fail)\"}",
-    statement:"{ `literal`: '$(touch /tmp/blns.fail)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '$(touch /tmp/blns.fail)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"$(touch /tmp/blns.fail)"
     },
@@ -6784,7 +6784,7 @@
   },
   {
     name:"big list of naughty strings{str:\"@{[system \\\"touch /tmp/blns.fail\\\"]}\"}",
-    statement:"{ `literal`: '@{[system \"touch /tmp/blns.fail\"]}', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '@{[system \"touch /tmp/blns.fail\"]}', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"@{[system \"touch /tmp/blns.fail\"]}"
     },
@@ -6803,7 +6803,7 @@
   },
   {
     name:"big list of naughty strings{str:\"System(\\\"ls -al /\\\")\"}",
-    statement:"{ `literal`: 'System(\"ls -al /\")', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'System(\"ls -al /\")', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"System(\"ls -al /\")"
     },
@@ -6822,7 +6822,7 @@
   },
   {
     name:"big list of naughty strings{str:\"`ls -al /`\"}",
-    statement:"{ `literal`: '`ls -al /`', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '`ls -al /`', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"`ls -al /`"
     },
@@ -6841,7 +6841,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Kernel.exec(\\\"ls -al /\\\")\"}",
-    statement:"{ `literal`: 'Kernel.exec(\"ls -al /\")', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Kernel.exec(\"ls -al /\")', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Kernel.exec(\"ls -al /\")"
     },
@@ -6860,7 +6860,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Kernel.exit(1)\"}",
-    statement:"{ `literal`: 'Kernel.exit(1)', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Kernel.exit(1)', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Kernel.exit(1)"
     },
@@ -6879,7 +6879,7 @@
   },
   {
     name:"big list of naughty strings{str:\"<?xml version=\\\"1.0\\\" encoding=\\\"ISO-8859-1\\\"?><!DOCTYPE foo [ <!ELEMENT foo ANY ><!ENTITY xxe SYSTEM \\\"file:///etc/passwd\\\" >]><foo>&xxe;</foo>\"}",
-    statement:"{ `literal`: '<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><!DOCTYPE foo [ <!ELEMENT foo ANY ><!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]><foo>&xxe;</foo>', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><!DOCTYPE foo [ <!ELEMENT foo ANY ><!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]><foo>&xxe;</foo>', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><!DOCTYPE foo [ <!ELEMENT foo ANY ><!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]><foo>&xxe;</foo>"
     },
@@ -6898,7 +6898,7 @@
   },
   {
     name:"big list of naughty strings{str:\"HOME\"}",
-    statement:"{ `literal`: '$HOME', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '$HOME', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"$HOME"
     },
@@ -6917,7 +6917,7 @@
   },
   {
     name:"big list of naughty strings{str:\"%d\"}",
-    statement:"{ `literal`: '%d', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '%d', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"%d"
     },
@@ -6936,7 +6936,7 @@
   },
   {
     name:"big list of naughty strings{str:\"%s\"}",
-    statement:"{ `literal`: '%s', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '%s', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"%s"
     },
@@ -6955,7 +6955,7 @@
   },
   {
     name:"big list of naughty strings{str:\"{0}\"}",
-    statement:"{ `literal`: '{0}', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '{0}', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"{0}"
     },
@@ -6974,7 +6974,7 @@
   },
   {
     name:"big list of naughty strings{str:\"%*.*s\"}",
-    statement:"{ `literal`: '%*.*s', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '%*.*s', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"%*.*s"
     },
@@ -6993,7 +6993,7 @@
   },
   {
     name:"big list of naughty strings{str:\"File:///\"}",
-    statement:"{ `literal`: 'File:///', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'File:///', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"File:///"
     },
@@ -7012,7 +7012,7 @@
   },
   {
     name:"big list of naughty strings{str:\"../../../../../../../../../../../etc/passwd%00\"}",
-    statement:"{ `literal`: '../../../../../../../../../../../etc/passwd%00', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '../../../../../../../../../../../etc/passwd%00', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"../../../../../../../../../../../etc/passwd%00"
     },
@@ -7031,7 +7031,7 @@
   },
   {
     name:"big list of naughty strings{str:\"../../../../../../../../../../../etc/hosts\"}",
-    statement:"{ `literal`: '../../../../../../../../../../../etc/hosts', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '../../../../../../../../../../../etc/hosts', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"../../../../../../../../../../../etc/hosts"
     },
@@ -7050,7 +7050,7 @@
   },
   {
     name:"big list of naughty strings{str:\"() { 0; }; touch /tmp/blns.shellshock1.fail;\"}",
-    statement:"{ `literal`: '() { 0; }; touch /tmp/blns.shellshock1.fail;', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '() { 0; }; touch /tmp/blns.shellshock1.fail;', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"() { 0; }; touch /tmp/blns.shellshock1.fail;"
     },
@@ -7069,7 +7069,7 @@
   },
   {
     name:"big list of naughty strings{str:\"() { _; } >_[(())] { touch /tmp/blns.shellshock2.fail; }\"}",
-    statement:"{ `literal`: '() { _; } >_[$($())] { touch /tmp/blns.shellshock2.fail; }', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '() { _; } >_[$($())] { touch /tmp/blns.shellshock2.fail; }', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"() { _; } >_[$($())] { touch /tmp/blns.shellshock2.fail; }"
     },
@@ -7088,7 +7088,7 @@
   },
   {
     name:"big list of naughty strings{str:\"+++ATH0\"}",
-    statement:"{ `literal`: '+++ATH0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': '+++ATH0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"+++ATH0"
     },
@@ -7107,7 +7107,7 @@
   },
   {
     name:"big list of naughty strings{str:\"CON\"}",
-    statement:"{ `literal`: 'CON', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'CON', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"CON"
     },
@@ -7126,7 +7126,7 @@
   },
   {
     name:"big list of naughty strings{str:\"PRN\"}",
-    statement:"{ `literal`: 'PRN', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'PRN', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"PRN"
     },
@@ -7145,7 +7145,7 @@
   },
   {
     name:"big list of naughty strings{str:\"AUX\"}",
-    statement:"{ `literal`: 'AUX', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'AUX', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"AUX"
     },
@@ -7164,7 +7164,7 @@
   },
   {
     name:"big list of naughty strings{str:\"CLOCK\"}",
-    statement:"{ `literal`: 'CLOCK$', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'CLOCK$', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"CLOCK$"
     },
@@ -7183,7 +7183,7 @@
   },
   {
     name:"big list of naughty strings{str:\"NUL\"}",
-    statement:"{ `literal`: 'NUL', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'NUL', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"NUL"
     },
@@ -7202,7 +7202,7 @@
   },
   {
     name:"big list of naughty strings{str:\"A:\"}",
-    statement:"{ `literal`: 'A:', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'A:', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"A:"
     },
@@ -7221,7 +7221,7 @@
   },
   {
     name:"big list of naughty strings{str:\"ZZ:\"}",
-    statement:"{ `literal`: 'ZZ:', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'ZZ:', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"ZZ:"
     },
@@ -7240,7 +7240,7 @@
   },
   {
     name:"big list of naughty strings{str:\"COM1\"}",
-    statement:"{ `literal`: 'COM1', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'COM1', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"COM1"
     },
@@ -7259,7 +7259,7 @@
   },
   {
     name:"big list of naughty strings{str:\"LPT1\"}",
-    statement:"{ `literal`: 'LPT1', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'LPT1', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"LPT1"
     },
@@ -7278,7 +7278,7 @@
   },
   {
     name:"big list of naughty strings{str:\"LPT2\"}",
-    statement:"{ `literal`: 'LPT2', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'LPT2', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"LPT2"
     },
@@ -7297,7 +7297,7 @@
   },
   {
     name:"big list of naughty strings{str:\"LPT3\"}",
-    statement:"{ `literal`: 'LPT3', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'LPT3', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"LPT3"
     },
@@ -7316,7 +7316,7 @@
   },
   {
     name:"big list of naughty strings{str:\"COM2\"}",
-    statement:"{ `literal`: 'COM2', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'COM2', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"COM2"
     },
@@ -7335,7 +7335,7 @@
   },
   {
     name:"big list of naughty strings{str:\"COM3\"}",
-    statement:"{ `literal`: 'COM3', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'COM3', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"COM3"
     },
@@ -7354,7 +7354,7 @@
   },
   {
     name:"big list of naughty strings{str:\"COM4\"}",
-    statement:"{ `literal`: 'COM4', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'COM4', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"COM4"
     },
@@ -7373,7 +7373,7 @@
   },
   {
     name:"big list of naughty strings{str:\"DCC SEND STARTKEYLOGGER 0 0 0\"}",
-    statement:"{ `literal`: 'DCC SEND STARTKEYLOGGER 0 0 0', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'DCC SEND STARTKEYLOGGER 0 0 0', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"DCC SEND STARTKEYLOGGER 0 0 0"
     },
@@ -7392,7 +7392,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Scunthorpe General Hospital\"}",
-    statement:"{ `literal`: 'Scunthorpe General Hospital', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Scunthorpe General Hospital', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Scunthorpe General Hospital"
     },
@@ -7411,7 +7411,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Penistone Community Church\"}",
-    statement:"{ `literal`: 'Penistone Community Church', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Penistone Community Church', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Penistone Community Church"
     },
@@ -7430,7 +7430,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Lightwater Country Park\"}",
-    statement:"{ `literal`: 'Lightwater Country Park', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Lightwater Country Park', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Lightwater Country Park"
     },
@@ -7449,7 +7449,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Jimmy Clitheroe\"}",
-    statement:"{ `literal`: 'Jimmy Clitheroe', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Jimmy Clitheroe', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Jimmy Clitheroe"
     },
@@ -7468,7 +7468,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Horniman Museum\"}",
-    statement:"{ `literal`: 'Horniman Museum', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Horniman Museum', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Horniman Museum"
     },
@@ -7487,7 +7487,7 @@
   },
   {
     name:"big list of naughty strings{str:\"shitake mushrooms\"}",
-    statement:"{ `literal`: 'shitake mushrooms', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'shitake mushrooms', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"shitake mushrooms"
     },
@@ -7506,7 +7506,7 @@
   },
   {
     name:"big list of naughty strings{str:\"RomansInSussex.co.uk\"}",
-    statement:"{ `literal`: 'RomansInSussex.co.uk', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'RomansInSussex.co.uk', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"RomansInSussex.co.uk"
     },
@@ -7525,7 +7525,7 @@
   },
   {
     name:"big list of naughty strings{str:\"http://www.cum.qc.ca/\"}",
-    statement:"{ `literal`: 'http://www.cum.qc.ca/', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'http://www.cum.qc.ca/', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"http://www.cum.qc.ca/"
     },
@@ -7544,7 +7544,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Craig Cockburn, Software Specialist\"}",
-    statement:"{ `literal`: 'Craig Cockburn, Software Specialist', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Craig Cockburn, Software Specialist', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Craig Cockburn, Software Specialist"
     },
@@ -7563,7 +7563,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Linda Callahan\"}",
-    statement:"{ `literal`: 'Linda Callahan', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Linda Callahan', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Linda Callahan"
     },
@@ -7582,7 +7582,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Dr. Herman I. Libshitz\"}",
-    statement:"{ `literal`: 'Dr. Herman I. Libshitz', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Dr. Herman I. Libshitz', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Dr. Herman I. Libshitz"
     },
@@ -7601,7 +7601,7 @@
   },
   {
     name:"big list of naughty strings{str:\"magna cum laude\"}",
-    statement:"{ `literal`: 'magna cum laude', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'magna cum laude', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"magna cum laude"
     },
@@ -7620,7 +7620,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Super Bowl XXX\"}",
-    statement:"{ `literal`: 'Super Bowl XXX', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Super Bowl XXX', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Super Bowl XXX"
     },
@@ -7639,7 +7639,7 @@
   },
   {
     name:"big list of naughty strings{str:\"medieval erection of parapets\"}",
-    statement:"{ `literal`: 'medieval erection of parapets', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'medieval erection of parapets', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"medieval erection of parapets"
     },
@@ -7658,7 +7658,7 @@
   },
   {
     name:"big list of naughty strings{str:\"evaluate\"}",
-    statement:"{ `literal`: 'evaluate', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'evaluate', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"evaluate"
     },
@@ -7677,7 +7677,7 @@
   },
   {
     name:"big list of naughty strings{str:\"mocha\"}",
-    statement:"{ `literal`: 'mocha', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'mocha', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"mocha"
     },
@@ -7696,7 +7696,7 @@
   },
   {
     name:"big list of naughty strings{str:\"expression\"}",
-    statement:"{ `literal`: 'expression', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'expression', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"expression"
     },
@@ -7715,7 +7715,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Arsenal canal\"}",
-    statement:"{ `literal`: 'Arsenal canal', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Arsenal canal', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Arsenal canal"
     },
@@ -7734,7 +7734,7 @@
   },
   {
     name:"big list of naughty strings{str:\"classic\"}",
-    statement:"{ `literal`: 'classic', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'classic', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"classic"
     },
@@ -7753,7 +7753,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Tyson Gay\"}",
-    statement:"{ `literal`: 'Tyson Gay', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Tyson Gay', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Tyson Gay"
     },
@@ -7772,7 +7772,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Dick Van Dyke\"}",
-    statement:"{ `literal`: 'Dick Van Dyke', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Dick Van Dyke', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Dick Van Dyke"
     },
@@ -7791,7 +7791,7 @@
   },
   {
     name:"big list of naughty strings{str:\"basement\"}",
-    statement:"{ `literal`: 'basement', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'basement', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"basement"
     },
@@ -7810,7 +7810,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Roses are \\x1b[0;31mred\\x1b[0m, violets are \\x1b[0;34mblue. Hope you enjoy terminal hue\"}",
-    statement:"{ `literal`: 'Roses are \x1b[0;31mred\x1b[0m, violets are \x1b[0;34mblue. Hope you enjoy terminal hue', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Roses are \x1b[0;31mred\x1b[0m, violets are \x1b[0;34mblue. Hope you enjoy terminal hue', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Roses are \x1b[0;31mred\x1b[0m, violets are \x1b[0;34mblue. Hope you enjoy terminal hue"
     },
@@ -7829,7 +7829,7 @@
   },
   {
     name:"big list of naughty strings{str:\"But now...\\x1b[20Cfor my greatest trick...\\x1b[8m\"}",
-    statement:"{ `literal`: 'But now...\x1b[20Cfor my greatest trick...\x1b[8m', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'But now...\x1b[20Cfor my greatest trick...\x1b[8m', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"But now...\x1b[20Cfor my greatest trick...\x1b[8m"
     },
@@ -7848,7 +7848,7 @@
   },
   {
     name:"big list of naughty strings{str:\"The quic\\b\\b\\b\\b\\b\\bk brown fo\\a\\a\\a\\a\\a\\a\\a\\a\\a\\a\\ax... [Beeeep]\"}",
-    statement:"{ `literal`: 'The quic\b\b\b\b\b\bk brown fo\a\a\a\a\a\a\a\a\a\a\ax... [Beeeep]', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'The quic\b\b\b\b\b\bk brown fo\a\a\a\a\a\a\a\a\a\a\ax... [Beeeep]', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"The quic\b\b\b\b\b\bk brown fo\a\a\a\a\a\a\a\a\a\a\ax... [Beeeep]"
     },
@@ -7867,7 +7867,7 @@
   },
   {
     name:"big list of naughty strings{str:\"Power\\u0644\\u064f\\u0644\\u064f\\u0635\\u0651\\u0628\\u064f\\u0644\\u064f\\u0644\\u0635\\u0651\\u0628\\u064f\\u0631\\u0631\\u064b \\u0963 \\u0963h \\u0963 \\u0963\\u5197\"}",
-    statement:"{ `literal`: 'Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗', `variable`: env_str, `concatenated`: env_str || env_str }",
+    statement:"{ 'literal': 'Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗', 'variable': env_str, 'concatenated': env_str || env_str }",
     env:{
       env_str:"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"
     },

--- a/partiql-tests-data/eval/primitives/string.ion
+++ b/partiql-tests-data/eval/primitives/string.ion
@@ -1,7 +1,7 @@
 string::[
   {
     name:"concatenation with non-nulls{left:\"\",right:\"\",result:\"\"}",
-    statement:"{ `concatenated_literals`: '' || '', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': '' || '', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"",
       env_right:""
@@ -20,7 +20,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"left\",right:\"\",result:\"left\"}",
-    statement:"{ `concatenated_literals`: 'left' || '', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': 'left' || '', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"left",
       env_right:""
@@ -39,7 +39,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"\",right:\"right\",result:\"right\"}",
-    statement:"{ `concatenated_literals`: '' || 'right', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': '' || 'right', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"",
       env_right:"right"
@@ -58,7 +58,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"a\",right:\"b\",result:\"ab\"}",
-    statement:"{ `concatenated_literals`: 'a' || 'b', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': 'a' || 'b', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"a",
       env_right:"b"
@@ -77,7 +77,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"hello\",right:\"world\",result:\"helloworld\"}",
-    statement:"{ `concatenated_literals`: 'hello' || 'world', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': 'hello' || 'world', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"hello",
       env_right:"world"
@@ -96,7 +96,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"o\",right:\"\\u0300\",result:\"o\\u0300\"}",
-    statement:"{ `concatenated_literals`: 'o' || '̀', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': 'o' || '̀', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"o",
       env_right:"̀"
@@ -115,7 +115,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\",right:\"\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\",result:\"\\u8a71\\u5bb6\\u8eab\\u5727\\u8cbb\\u8c37\\u6599\\u6751\\u80fd\\u8a08\\u7a0e\\u91d1\"}",
-    statement:"{ `concatenated_literals`: '話家身圧費谷' || '料村能計税金', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': '話家身圧費谷' || '料村能計税金', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"話家身圧費谷",
       env_right:"料村能計税金"
@@ -134,7 +134,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\",right:\"\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\",result:\"\\u0401\\u0402\\u0403\\u0404\\u0405\\u0406\\u0407\\u0408\\u0409\\u040a\\u040b\\u040c\\u040d\\u040e\\u040f\\u0410\\u0411\\u0412\\u0413\\u0414\\u0415\\u0416\\u0417\\u0418\\u0419\\u041a\\u041b\\u041c\\u041d\\u041e\\u041f\\u0420\\u0421\\u0422\\u0423\\u0424\\u0425\\u0426\\u0427\\u0428\\u0429\\u042a\\u042b\\u042c\\u042d\\u042e\\u042f\\u0430\\u0431\\u0432\\u0433\\u0434\\u0435\\u0436\\u0437\\u0438\\u0439\\u043a\\u043b\\u043c\\u043d\\u043e\\u043f\\u0440\\u0441\\u0442\\u0443\\u0444\\u0445\\u0446\\u0447\\u0448\\u0449\\u044a\\u044b\\u044c\\u044d\\u044e\\u044f\"}",
-    statement:"{ `concatenated_literals`: 'ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРС' || 'ТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': 'ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРС' || 'ТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРС",
       env_right:"ТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
@@ -153,7 +153,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \",right:\"\\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\",result:\"\\U0001d42a\\U0001d42e\\U0001d422\\U0001d41c\\U0001d424 \\U0001d41b\\U0001d42b\\U0001d428\\U0001d430\\U0001d427 \\U0001d41f\\U0001d428\\U0001d431 \\U0001d423\\U0001d42e\\U0001d426\\U0001d429\\U0001d42c \\U0001d428\\U0001d42f\\U0001d41e\\U0001d42b\"}",
-    statement:"{ `concatenated_literals`: '𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 ' || '𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': '𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 ' || '𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 ",
       env_right:"𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫"
@@ -172,7 +172,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce\",right:\"( \\xba _ \\xba\\u30ce)\",result:\"( \\u0361\\xb0 \\u035c\\u0296 \\u0361\\xb0)\\u252c\\u2500\\u252c\\u30ce( \\xba _ \\xba\\u30ce)\"}",
-    statement:"{ `concatenated_literals`: '( ͡° ͜ʖ ͡°)┬─┬ノ' || '( º _ ºノ)', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': '( ͡° ͜ʖ ͡°)┬─┬ノ' || '( º _ ºノ)', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"( ͡° ͜ʖ ͡°)┬─┬ノ",
       env_right:"( º _ ºノ)"
@@ -191,7 +191,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"\\U0001f60d\",right:\"\\U0001f60d\",result:\"\\U0001f60d\\U0001f60d\"}",
-    statement:"{ `concatenated_literals`: '😍' || '😍', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': '😍' || '😍', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"😍",
       env_right:"😍"
@@ -210,7 +210,7 @@ string::[
   },
   {
     name:"concatenation with non-nulls{left:\"\\U0001f4a9\\U0001f4a9\",right:\"\\U0001f4a9\\U0001f4a9\",result:\"\\U0001f4a9\\U0001f4a9\\U0001f4a9\\U0001f4a9\"}",
-    statement:"{ `concatenated_literals`: '💩💩' || '💩💩', `concatenated_variables`: env_left || env_right }",
+    statement:"{ 'concatenated_literals': '💩💩' || '💩💩', 'concatenated_variables': env_left || env_right }",
     env:{
       env_left:"💩💩",
       env_right:"💩💩"


### PR DESCRIPTION
A handful of tests used quoted ion symbols as keys in structs, rather than strings. This seems to be a typo that happens to work as the ion is coerced into text.

These were originally ported from an old version of the PartiQL-Lang-Kotlin test scripts: https://github.com/partiql/partiql-lang-kotlin/blob/v0.7.0-alpha/testscript/pts/test-scripts/primitive-types/naughty-strings.sqlts#L20

This PR changes the keys to strings.

E.g., 

```{ `key`:  'value' }``` -> ```{ 'key': 'value'}```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.