### PR TITLE
Revert "Corrects case-when conformance tests"

### DIFF
--- a/partiql-tests-data/eval/primitives/operators/case-operator.ion
+++ b/partiql-tests-data/eval/primitives/operators/case-operator.ion
@@ -8,89 +8,65 @@ case::[
   {
     name:"simpleCase",
     statement:"SELECT VALUE CASE x + 1 WHEN NULL THEN 'shouldnt be null' WHEN MISSING THEN 'shouldnt be missing' WHEN i THEN 'ONE' WHEN f THEN 'TWO' WHEN d THEN 'THREE' ELSE '?' END FROM << i, f, d, null, missing >> AS x",
-    assert:[
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
-          "TWO",
-          "THREE",
-          "?",
-          "?",
-          "?"
-        ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail
-      }
-    ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        "TWO",
+        "THREE",
+        "?",
+        "?",
+        "?"
+      ]
+    }
   },
   {
     name:"simpleCaseNoElse",
     statement:"SELECT VALUE CASE x + 1 WHEN NULL THEN 'shouldnt be null' WHEN MISSING THEN 'shouldnt be missing' WHEN i THEN 'ONE' WHEN f THEN 'TWO' WHEN d THEN 'THREE' END FROM << i, f, d, null, missing >> AS x",
-    assert:[
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
-          "TWO",
-          "THREE",
-          null,
-          null,
-          null
-        ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail
-      }
-    ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        "TWO",
+        "THREE",
+        null,
+        null,
+        null
+      ]
+    }
   },
   {
     name:"searchedCase",
     statement:"SELECT VALUE CASE WHEN x + 1 < i THEN '< ONE' WHEN x + 1 = f THEN 'TWO' WHEN (x + 1 > d) AND (x + 1 < 100) THEN '>= THREE < 100' ELSE '?' END FROM << -1.0000, i, f, d, 100e0, null, missing >> AS x",
-    assert:[
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
-          "< ONE",
-          "TWO",
-          "?",
-          ">= THREE < 100",
-          "?",
-          "?",
-          "?"
-        ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail
-      }
-    ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        "< ONE",
+        "TWO",
+        "?",
+        ">= THREE < 100",
+        "?",
+        "?",
+        "?"
+      ]
+    }
   },
   {
     name:"searchedCaseNoElse",
     statement:"SELECT VALUE CASE WHEN x + 1 < i THEN '< ONE' WHEN x + 1 = f THEN 'TWO' WHEN (x + 1 > d) AND (x + 1 < 100) THEN '>= THREE < 100' END FROM << -1.0000, i, f, d, 100e0, null, missing >> AS x",
-    assert:[
-      {
-        evalMode:EvalModeCoerce,
-        result:EvaluationSuccess,
-        output:$bag::[
-          "< ONE",
-          "TWO",
-          null,
-          ">= THREE < 100",
-          null,
-          null,
-          null
-        ]
-      },
-      {
-        evalMode: EvalModeError,
-        result: EvaluationFail
-      }
-    ]
+    assert:{
+      evalMode:[EvalModeCoerce, EvalModeError],
+      result:EvaluationSuccess,
+      output:$bag::[
+        "< ONE",
+        "TWO",
+        null,
+        ">= THREE < 100",
+        null,
+        null,
+        null
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Issue #, if available:
None.

Description of changes:
This reverts commit 5aca10abe04039d70d69e94db233e848884d5656 from #115. Behavior is missing literals should behave as null literals and not error in strict mode. See this summary of discussion from a prior PR -- https://github.com/partiql/partiql-tests/pull/118#issuecomment-2248990609.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.