### PR TITLE
fix: NOT MISSING test

### DIFF
--- a/partiql-tests-data/eval/primitives/logical.ion
+++ b/partiql-tests-data/eval/primitives/logical.ion
@@ -40,7 +40,7 @@ logical::[
     assert:{
       evalMode:[EvalModeCoerce, EvalModeError],
       result:EvaluationSuccess,
-      output:$missing::null
+      output:null
     }
   },
   // AND


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Prior PR that added more logical operator tests included a test with the wrong behavior for `NOT MISSING`. It should return `NOT NULL`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.