### PR TITLE
fix: null tests including missing

### DIFF
--- a/partiql-tests-data/eval/ion/primitives/null.ion
+++ b/partiql-tests-data/eval/ion/primitives/null.ion
@@ -396,7 +396,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.null` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.null` = MISSING\",result:null}",
     statement:"`null.null` = MISSING",
     assert:{
       result:EvaluationSuccess,
@@ -408,7 +408,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.bool` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.bool` = MISSING\",result:null}",
     statement:"`null.bool` = MISSING",
     assert:{
       result:EvaluationSuccess,
@@ -420,7 +420,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.int` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.int` = MISSING\",result:null}",
     statement:"`null.int` = MISSING",
     assert:{
       result:EvaluationSuccess,
@@ -432,7 +432,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.decimal` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.decimal` = MISSING\",result:null}",
     statement:"`null.decimal` = MISSING",
     assert:{
       result:EvaluationSuccess,
@@ -444,7 +444,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.string` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.string` = MISSING\",result:null}",
     statement:"`null.string` = MISSING",
     assert:{
       result:EvaluationSuccess,
@@ -456,7 +456,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.symbol` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.symbol` = MISSING\",result:null}",
     statement:"`null.symbol` = MISSING",
     assert:{
       result:EvaluationSuccess,
@@ -468,7 +468,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.clob` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.clob` = MISSING\",result:null}",
     statement:"`null.clob` = MISSING",
     assert:{
       result:EvaluationSuccess,
@@ -480,7 +480,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.blob` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.blob` = MISSING\",result:null}",
     statement:"`null.blob` = MISSING",
     assert:{
       result:EvaluationSuccess,
@@ -492,7 +492,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.list` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.list` = MISSING\",result:null}",
     statement:"`null.list` = MISSING",
     assert:{
       result:EvaluationSuccess,
@@ -504,7 +504,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.struct` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.struct` = MISSING\",result:null}",
     statement:"`null.struct` = MISSING",
     assert:{
       result:EvaluationSuccess,
@@ -516,7 +516,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"`null.sexp` = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"`null.sexp` = MISSING\",result:null}",
     statement:"`null.sexp` = MISSING",
     assert:{
       result:EvaluationSuccess,

--- a/partiql-tests-data/eval/ion/primitives/null.ion
+++ b/partiql-tests-data/eval/ion/primitives/null.ion
@@ -404,7 +404,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -416,7 +416,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -428,7 +428,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -440,7 +440,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -452,7 +452,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -464,7 +464,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -476,7 +476,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -488,7 +488,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -500,7 +500,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -512,7 +512,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -524,7 +524,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   }
 ]

--- a/partiql-tests-data/eval/primitives/null.ion
+++ b/partiql-tests-data/eval/primitives/null.ion
@@ -84,7 +84,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"MISSING = NULL\",result:missing::null}",
+    name:"null comparison{sql:\"MISSING = NULL\",result:null}",
     statement:"MISSING = NULL",
     assert:{
       result:EvaluationSuccess,
@@ -96,7 +96,7 @@
     }
   },
   {
-    name:"null comparison{sql:\"NULL = MISSING\",result:missing::null}",
+    name:"null comparison{sql:\"NULL = MISSING\",result:null}",
     statement:"NULL = MISSING",
     assert:{
       result:EvaluationSuccess,

--- a/partiql-tests-data/eval/primitives/null.ion
+++ b/partiql-tests-data/eval/primitives/null.ion
@@ -92,7 +92,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
   {
@@ -104,7 +104,7 @@
         EvalModeCoerce,
         EvalModeError
       ],
-      output:$missing::null
+      output:null
     }
   },
 ]


### PR DESCRIPTION
Issue #, if available:

Description of changes:
In prior tests including `missing` as an operand on `=` operator, `missing` was returned mistakenly. Fix these tests in this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.