### PR TITLE
add: interval conformance tests

### DIFF
--- a/docs/partiql-tests-schema-proposal.md
+++ b/docs/partiql-tests-schema-proposal.md
@@ -196,11 +196,24 @@ $bag::[1, 2, 3]
 // missing -- null value annotated with $missing
 $missing::null
 
-// date -- string annotated with $date
-$date::'2022-02-22'
+// date -- struct annotated with $date
+$date::{ year: 2022, month: 2, day: 22 } // All fields are required
 
-// time -- string annotated with $time
-$time::'02:30:59'
+// time -- struct annotated with $time
+$time::{ hour: 2, minute: 30, second: 59.0, offset: 0 } // All fields are required, offset can be null
+
+// interval year-month -- struct annotated with $interval_ym
+// All fields are optional
+// Default value -- sign: "+", years(int): 0, months(int): 0
+// Normalization rules -- sign = "+"/"-"; 0 <= years <= 999999999; 0 <= months <= 11
+$interval_ym::{ sign: "+", years: 1, months: 6 }
+
+// interval day-time -- struct annotated with $interval_dt
+// All fields are optional
+// Default value -- sign: "+", days(int): 0, hours(int): 0, minutes(int): 0, seconds(int): 0, nanos(int): 0
+// Normalization rules -- sign = "+"/"-"; 0 <= days <= 999999999; 0 <= hours <= 23; 0 <= minutes <=  59;
+// 0 <= seconds <= 59; 0 <= nanos <= 999999999
+$interval_dt::{ sign: "+", days: 5, hours: 4, minutes: 30, seconds: 15, nanos: 500000000 }
 ```
 
 Similarly, graphs defined with the Ion-based format for "external" graphs 

--- a/partiql-tests-data/eval/primitives/cast.ion
+++ b/partiql-tests-data/eval/primitives/cast.ion
@@ -681,5 +681,52 @@ cast_invalid::[
         output:$missing::null
       }
     ],
+  },
+  // Year-Month interval same-family casts (precision adjustments)
+  {
+    name: "CAST INTERVAL YEAR to INTERVAL YEAR with precision",
+    statement: "CAST(INTERVAL '1' YEAR AS INTERVAL YEAR(3))",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 1, months: 0 }
+    }
+  },
+  {
+    name: "CAST INTERVAL MONTH to INTERVAL YEAR TO MONTH",
+    statement: "CAST(INTERVAL '13' MONTH AS INTERVAL YEAR TO MONTH)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 1, months: 1 }
+    }
+  },
+  // Day-Time interval same-family casts (precision adjustments)
+  {
+    name: "CAST INTERVAL DAY to INTERVAL DAY with precision",
+    statement: "CAST(INTERVAL '1' DAY AS INTERVAL DAY(5))",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 1, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "CAST INTERVAL HOUR to INTERVAL DAY TO HOUR",
+    statement: "CAST(INTERVAL '25' HOUR AS INTERVAL DAY TO HOUR)",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 1, hours: 1, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "CAST INTERVAL SECOND with fractional precision",
+    statement: "CAST(INTERVAL '1.123456789' SECOND AS INTERVAL SECOND(3, 3))",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 1, nanos: 123000000 }
+    }
   }
 ]

--- a/partiql-tests-data/eval/primitives/functions/abs.ion
+++ b/partiql-tests-data/eval/primitives/functions/abs.ion
@@ -109,5 +109,474 @@ abs::[
         output:$missing::null
       }
     ]
+  },
+  // Tests for INTERVAL
+  {
+    name:"ABS(INTERVAL '1-6' YEAR TO MONTH)",
+    statement:"ABS(INTERVAL '1-6' YEAR TO MONTH)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_ym::{ sign: "+", years: 1, months: 6 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '+1-6' YEAR TO MONTH)",
+    statement:"ABS(INTERVAL '+1-6' YEAR TO MONTH)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_ym::{ sign: "+", years: 1, months: 6 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-1-6' YEAR TO MONTH)",
+    statement:"ABS(INTERVAL '-1-6' YEAR TO MONTH)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_ym::{ sign: "+", years: 1, months: 6 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '100-6' YEAR(3) TO MONTH)",
+    statement:"ABS(INTERVAL '100-6' YEAR(3) TO MONTH)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_ym::{ sign: "+", years: 100, months: 6 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-100-6' YEAR(3) TO MONTH)",
+    statement:"ABS(INTERVAL '-100-6' YEAR(3) TO MONTH)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_ym::{ sign: "+", years: 100, months: 6 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '5' YEAR)",
+    statement:"ABS(INTERVAL '5' YEAR)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_ym::{ sign: "+", years: 5 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-5' YEAR)",
+    statement:"ABS(INTERVAL '-5' YEAR)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_ym::{ sign: "+", years: 5 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '100' MONTH(3))",
+    statement:"ABS(INTERVAL '100' MONTH(3))",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_ym::{ sign: "+", years: 8, months: 4 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-100' MONTH(3))",
+    statement:"ABS(INTERVAL '-100' MONTH(3))",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_ym::{ sign: "+", years: 8, months: 4 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '0-0' YEAR TO MONTH)",
+    statement:"ABS(INTERVAL '0-0' YEAR TO MONTH)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_ym::{ sign: "+", years: 0, months: 0 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '5' DAY)",
+    statement:"ABS(INTERVAL '5' DAY)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 5 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-5' DAY)",
+    statement:"ABS(INTERVAL '-5' DAY)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 5 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '100' DAY(3))",
+    statement:"ABS(INTERVAL '100' DAY(3))",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 100 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-100' DAY(3))",
+    statement:"ABS(INTERVAL '-100' DAY(3))",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 100 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '3' HOUR)",
+    statement:"ABS(INTERVAL '3' HOUR)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", hours: 3 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-3' HOUR)",
+    statement:"ABS(INTERVAL '-3' HOUR)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", hours: 3 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '30' MINUTE)",
+    statement:"ABS(INTERVAL '30' MINUTE)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", minutes: 30 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-30' MINUTE)",
+    statement:"ABS(INTERVAL '-30' MINUTE)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", minutes: 30 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '45.123' SECOND)",
+    statement:"ABS(INTERVAL '45.123' SECOND)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", seconds: 45, nanos: 123000000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-45.123' SECOND)",
+    statement:"ABS(INTERVAL '-45.123' SECOND)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", seconds: 45, nanos: 123000000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '123.456789' SECOND(3,6))",
+    statement:"ABS(INTERVAL '123.456789' SECOND(3,6))",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", minutes: 2, seconds: 3, nanos: 456789000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-123.456789' SECOND(3,6))",
+    statement:"ABS(INTERVAL '-123.456789' SECOND(3,6))",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", minutes: 2, seconds: 3, nanos: 456789000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '1 2' DAY TO HOUR)",
+    statement:"ABS(INTERVAL '1 2' DAY TO HOUR)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 1, hours: 2 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-1 2' DAY TO HOUR)",
+    statement:"ABS(INTERVAL '-1 2' DAY TO HOUR)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 1, hours: 2 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '1 2:30' DAY TO MINUTE)",
+    statement:"ABS(INTERVAL '1 2:30' DAY TO MINUTE)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 1, hours: 2, minutes: 30 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-1 2:30' DAY TO MINUTE)",
+    statement:"ABS(INTERVAL '-1 2:30' DAY TO MINUTE)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 1, hours: 2, minutes: 30 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '100 10:30' DAY(3) TO MINUTE)",
+    statement:"ABS(INTERVAL '100 10:30' DAY(3) TO MINUTE)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 100, hours: 10, minutes: 30 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-100 10:30' DAY(3) TO MINUTE)",
+    statement:"ABS(INTERVAL '-100 10:30' DAY(3) TO MINUTE)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 100, hours: 10, minutes: 30 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '1 2:30:45.567' DAY TO SECOND)",
+    statement:"ABS(INTERVAL '1 2:30:45.567' DAY TO SECOND)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 1, hours: 2, minutes: 30, seconds: 45, nanos: 567000000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-1 2:30:45.567' DAY TO SECOND)",
+    statement:"ABS(INTERVAL '-1 2:30:45.567' DAY TO SECOND)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 1, hours: 2, minutes: 30, seconds: 45, nanos: 567000000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '100 10:30:45.123456' DAY(3) TO SECOND(6))",
+    statement:"ABS(INTERVAL '100 10:30:45.123456' DAY(3) TO SECOND(6))",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 100, hours: 10, minutes: 30, seconds: 45, nanos: 123456000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-100 10:30:45.123456' DAY(3) TO SECOND(6))",
+    statement:"ABS(INTERVAL '-100 10:30:45.123456' DAY(3) TO SECOND(6))",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 100, hours: 10, minutes: 30, seconds: 45, nanos: 123456000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '2:30' HOUR TO MINUTE)",
+    statement:"ABS(INTERVAL '2:30' HOUR TO MINUTE)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", hours: 2, minutes: 30 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-2:30' HOUR TO MINUTE)",
+    statement:"ABS(INTERVAL '-2:30' HOUR TO MINUTE)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", hours: 2, minutes: 30 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '2:30:45.789' HOUR TO SECOND)",
+    statement:"ABS(INTERVAL '2:30:45.789' HOUR TO SECOND)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", hours: 2, minutes: 30, seconds: 45, nanos: 789000000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-2:30:45.789' HOUR TO SECOND)",
+    statement:"ABS(INTERVAL '-2:30:45.789' HOUR TO SECOND)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", hours: 2, minutes: 30, seconds: 45, nanos: 789000000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '30:45.123' MINUTE TO SECOND)",
+    statement:"ABS(INTERVAL '30:45.123' MINUTE TO SECOND)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", minutes: 30, seconds: 45, nanos: 123000000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '-30:45.123' MINUTE TO SECOND)",
+    statement:"ABS(INTERVAL '-30:45.123' MINUTE TO SECOND)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", minutes: 30, seconds: 45, nanos: 123000000 }
+    }
+  },
+  {
+    name:"ABS(INTERVAL '0 0:0:0' DAY TO SECOND)",
+    statement:"ABS(INTERVAL '0 0:0:0' DAY TO SECOND)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:$interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 0 }
+    }
   }
 ]

--- a/partiql-tests-data/eval/primitives/interval.ion
+++ b/partiql-tests-data/eval/primitives/interval.ion
@@ -276,6 +276,9 @@ interval::[
     }
   },
   // Out of default precision - failure
+  // WARNING: There exists some ambiguity in SQL-spec and these tests currently conform with PLK implementation
+  // The behavior may change after formalizeing INTERVAL further
+  // See issue: https://github.com/partiql/partiql-lang/issues/100
   {
     name: "interval year-month - out of range",
     statement: "INTERVAL '100-11' YEAR TO MONTH",
@@ -458,6 +461,9 @@ interval::[
     }
   },
   // Precision specification tests with truncation
+  // WARNING: There exists some ambiguity in SQL-spec and these tests currently conform with PLK implementation
+  // which means rounding/truncation is an implementation-defined behavior
+  // See issue: https://github.com/partiql/partiql-lang/issues/100
   {
     name: "interval second fractional precision - truncate",
     statement: "INTERVAL '1.123456789' SECOND(2,3)",

--- a/partiql-tests-data/eval/primitives/interval.ion
+++ b/partiql-tests-data/eval/primitives/interval.ion
@@ -145,4 +145,344 @@ interval::[
       output: $interval_dt::{ sign: "-", nanos: 250000000 }
     }
   },
+  // Decimal precision tests
+  {
+    name: "interval second decimal microseconds",
+    statement: "INTERVAL '1.123456' SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", seconds: 1, nanos: 123456000 }
+    }
+  },
+  {
+    name: "interval second decimal nanoseconds - truncate",
+    statement: "INTERVAL '2.123456789' SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", seconds: 2, nanos: 123456000 }
+    }
+  },
+  {
+    name: "interval second negative decimal",
+    statement: "INTERVAL '-3.750' SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", seconds: 3, nanos: 750000000 }
+    }
+  },
+  // Mixed field tests - Year-Month
+  {
+    name: "interval year month mixed positive",
+    statement: "INTERVAL '+2-6' YEAR TO MONTH",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_ym::{ sign: "+", years: 2, months: 6 }
+    }
+  },
+  {
+    name: "interval year month mixed negative",
+    statement: "INTERVAL '-1-11' YEAR TO MONTH",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_ym::{ sign: "-", years: 1, months: 11 }
+    }
+  },
+  // Mixed field tests - Day-Time
+  {
+    name: "interval day hour mixed",
+    statement: "INTERVAL '5 12' DAY TO HOUR",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", days: 5, hours: 12 }
+    }
+  },
+  {
+    name: "interval day minute mixed",
+    statement: "INTERVAL '3 8:45' DAY TO MINUTE",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", days: 3, hours: 8, minutes: 45 }
+    }
+  },
+  {
+    name: "interval day second mixed",
+    statement: "INTERVAL '2 4:30:15' DAY TO SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", days: 2, hours: 4, minutes: 30, seconds: 15 }
+    }
+  },
+  {
+    name: "interval hour minute mixed",
+    statement: "INTERVAL '14:25' HOUR TO MINUTE",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", hours: 14, minutes: 25 }
+    }
+  },
+  {
+    name: "interval hour second mixed",
+    statement: "INTERVAL '6:30:45' HOUR TO SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", hours: 6, minutes: 30, seconds: 45 }
+    }
+  },
+  {
+    name: "interval minute second mixed",
+    statement: "INTERVAL '42:18' MINUTE TO SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", minutes: 42, seconds: 18 }
+    }
+  },
+  // Mixed with decimals
+  {
+    name: "interval day second with decimal",
+    statement: "INTERVAL '1 2:30:45.123' DAY TO SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", days: 1, hours: 2, minutes: 30, seconds: 45, nanos: 123000000 }
+    }
+  },
+  {
+    name: "interval hour second with decimal negative",
+    statement: "INTERVAL '-10:15:30.456789' HOUR TO SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", hours: 10, minutes: 15, seconds: 30, nanos: 456789000 }
+    }
+  },
+  {
+    name: "interval minute second with decimal",
+    statement: "INTERVAL '59:59.999999' MINUTE TO SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", minutes: 59, seconds: 59, nanos: 999999000 }
+    }
+  },
+  // Out of default precision - failure
+  {
+    name: "interval year-month - out of range",
+    statement: "INTERVAL '100-11' YEAR TO MONTH",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result:EvaluationFail
+    }
+  },
+  {
+    name: "interval month - out of range",
+    statement: "INTERVAL '100' MONTH",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result:EvaluationFail
+    }
+  },
+  {
+    name: "interval day - out of range",
+    statement: "INTERVAL '100' DAY",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result:EvaluationFail
+    }
+  },
+  {
+    name: "interval minute - out of range",
+    statement: "INTERVAL '100' MINUTE",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result:EvaluationFail
+    }
+  },
+  {
+    name: "interval second - out of range",
+    statement: "INTERVAL '100.123' SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result:EvaluationFail
+    }
+  },
+  {
+    name: "interval nano - out of range",
+    statement: "INTERVAL '1.1234567899' SECOND;",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result:EvaluationFail
+    }
+  },
+  {
+    name: "interval day-hour - out of range",
+    statement: "INTERVAL '1 24' DAY TO HOUR",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result:EvaluationFail
+    }
+  },
+  {
+    name: "interval day-minute - out of range",
+    statement: "INTERVAL '1 23:60' DAY TO MINUTE",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result:EvaluationFail
+    }
+  },
+  {
+    name: "interval hour-minute - out of range",
+    statement: "INTERVAL '100:59' HOUR TO MINUTE",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result:EvaluationFail
+    }
+  },
+  {
+    name: "interval day-second - out of range",
+    statement: "INTERVAL '100 2:30:45.123' DAY TO SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result:EvaluationFail
+    }
+  },
+  // Precision specification tests
+  {
+    name: "interval year to month with precision",
+    statement: "INTERVAL '999-11' YEAR(3) TO MONTH",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_ym::{ sign: "+", years: 999, months: 11 }
+    }
+  },
+  {
+    name: "interval day to hour with precision",
+    statement: "INTERVAL '999 23' DAY(3) TO HOUR",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", days: 999, hours: 23 }
+    }
+  },
+  {
+    name: "interval day to minute negative with precision",
+    statement: "INTERVAL '-999 23:59' DAY(3) TO MINUTE",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", days: 999, hours: 23, minutes: 59 }
+    }
+  },
+  {
+    name: "interval day to second with precision",
+    statement: "INTERVAL '999 23:59:59.123456789' DAY(3) TO SECOND(9)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", days: 999, hours: 23, minutes: 59, seconds: 59, nanos: 123456789 }
+    }
+  },
+  // Precision specification tests with flowing over
+  {
+    name: "interval month with precision - flow over",
+    statement: "INTERVAL '999' MONTH(3)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_ym::{ sign: "+", years: 83, months: 3 }
+    }
+  },
+  {
+    name: "interval month negative with precision - flow over",
+    statement: "INTERVAL '-1203' MONTH(4)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_ym::{ sign: "-", years: 100, months: 3 }
+    }
+  },
+  {
+    name: "interval hour with precision - flow over",
+    statement: "INTERVAL '999' HOUR(3)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", days: 41, hours: 15 }
+    }
+  },
+  {
+    name: "interval second with precision and fractional precision - flow over",
+    statement: "INTERVAL '999.123456' SECOND(3,6)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", minutes: 16, seconds: 39, nanos: 123456000 }
+    }
+  },
+  {
+    name: "interval second with precision and fractional precision - flow over",
+    statement: "INTERVAL '999999.123456' SECOND(6,6)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", days: 11, hours: 13, minutes: 46, seconds: 39, nanos: 123456000 }
+    }
+  },
+  {
+    name: "interval minute to second negative with precision - flow over",
+    statement: "INTERVAL '-999:59.123456789' MINUTE(3) TO SECOND(9)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", hours: 16, minutes: 39, seconds: 59, nanos: 123456789 }
+    }
+  },
+  {
+    name: "interval hour to second negative with precision - flow over",
+    statement: "INTERVAL '-999:59:59.123456789' HOUR(3) TO SECOND(9)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", days: 41, hours: 15, minutes: 59, seconds: 59, nanos: 123456789 }
+    }
+  },
+  // Precision specification tests with truncation
+  {
+    name: "interval second fractional precision - truncate",
+    statement: "INTERVAL '1.123456789' SECOND(2,3)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", seconds: 1, nanos: 123000000 }
+    }
+  },
+  {
+    name: "interval second fractional precision - truncate mixed flow over",
+    statement: "INTERVAL '123.123456789' SECOND(3,3)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", minutes: 2, seconds: 3, nanos: 123000000 }
+    }
+  },
+  {
+    name: "interval hour to second negative with precision - truncate mixed flow over",
+    statement: "INTERVAL '-999:59:59.123456789' HOUR(3) TO SECOND(5)",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", days: 41, hours: 15, minutes: 59, seconds: 59, nanos: 123450000 }
+    }
+  },
 ]

--- a/partiql-tests-data/eval/primitives/interval.ion
+++ b/partiql-tests-data/eval/primitives/interval.ion
@@ -1,0 +1,148 @@
+interval::[
+  // Single Interval - Year-Month
+  {
+    name: "interval year",
+    statement: "INTERVAL '10' YEAR",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_ym::{ years: 10 }
+    }
+  },
+  {
+    name: "interval year positive",
+    statement: "INTERVAL '+5' YEAR",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_ym::{ sign: "+", years: 5 }
+    }
+  },
+  {
+    name: "interval year negative",
+    statement: "INTERVAL '-3' YEAR",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_ym::{ sign: "-", years: 3 }
+    }
+  },
+  {
+    name: "interval month positive",
+    statement: "INTERVAL '+8' MONTH",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_ym::{ sign: "+", months: 8 }
+    }
+  },
+  {
+    name: "interval month negative",
+    statement: "INTERVAL '-11' MONTH",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_ym::{ sign: "-", months: 11 }
+    }
+  },
+  // Single Interval - Day-Time
+  {
+    name: "interval day positive",
+    statement: "INTERVAL '+7' DAY",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", days: 7 }
+    }
+  },
+  {
+    name: "interval day negative",
+    statement: "INTERVAL '-4' DAY",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", days: 4 }
+    }
+  },
+  {
+    name: "interval hour positive",
+    statement: "INTERVAL '+12' HOUR",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", hours: 12 }
+    }
+  },
+  {
+    name: "interval hour negative",
+    statement: "INTERVAL '-6' HOUR",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", hours: 6 }
+    }
+  },
+  {
+    name: "interval minute positive",
+    statement: "INTERVAL '+30' MINUTE",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", minutes: 30 }
+    }
+  },
+  {
+    name: "interval minute negative",
+    statement: "INTERVAL '-45' MINUTE",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", minutes: 45 }
+    }
+  },
+  {
+    name: "interval second positive",
+    statement: "INTERVAL '+25' SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", seconds: 25 }
+    }
+  },
+  {
+    name: "interval second negative",
+    statement: "INTERVAL '-15' SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", seconds: 15 }
+    }
+  },
+  {
+    name: "interval nano",
+    statement: "INTERVAL '0.5' SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", nanos: 500000000 }
+    }
+  },
+  {
+    name: "interval nano positive",
+    statement: "INTERVAL '+0.5000000' SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "+", nanos: 500000000 }
+    }
+  },
+  {
+    name: "interval nano negative",
+    statement: "INTERVAL '-0.2500' SECOND",
+    assert: {
+      evalMode: [EvalModeCoerce, EvalModeError],
+      result: EvaluationSuccess,
+      output: $interval_dt::{ sign: "-", nanos: 250000000 }
+    }
+  },
+]

--- a/partiql-tests-data/eval/primitives/operators/divide.ion
+++ b/partiql-tests-data/eval/primitives/operators/divide.ion
@@ -1,0 +1,529 @@
+divide::[
+  // Interval / Number tests
+  {
+    name: "INTERVAL '3' YEAR / 3",
+    statement: "INTERVAL '3' YEAR / 3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 1, months: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '7' MONTH / 3",
+    statement: "INTERVAL '7' MONTH / 3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 2 }
+    }
+  },
+  {
+    name: "INTERVAL '1-5' YEAR TO MONTH / 3",
+    statement: "INTERVAL '1-5' YEAR TO MONTH / 3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 5 }
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY / 3",
+    statement: "INTERVAL '2' DAY / 3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 16, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '4' HOUR / 3",
+    statement: "INTERVAL '4' HOUR / 3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 1, minutes: 20, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '5' MINUTE / 3",
+    statement: "INTERVAL '5' MINUTE / 3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 1, seconds: 40, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '10.5' SECOND / 3",
+    statement: "INTERVAL '10.5' SECOND / 3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 3, nanos: 500000000 }
+    }
+  },
+  {
+    name: "INTERVAL '2 4:5:10.5' DAY TO SECOND / 3",
+    statement: "INTERVAL '2 4:5:10.5' DAY TO SECOND / 3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 17, minutes: 21, seconds: 43, nanos: 500000000 }
+    }
+  },
+
+  // Interval / Negative tests
+  {
+    name: "INTERVAL '3' YEAR / -3",
+    statement: "INTERVAL '3' YEAR / -3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "-", years: 1, months: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '7' MONTH / -3",
+    statement: "INTERVAL '7' MONTH / -3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "-", years: 0, months: 2 }
+    }
+  },
+  {
+    name: "INTERVAL '1-5' YEAR TO MONTH / -3",
+    statement: "INTERVAL '1-5' YEAR TO MONTH / -3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "-", years: 0, months: 5 }
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY / -3",
+    statement: "INTERVAL '2' DAY / -3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "-", days: 0, hours: 16, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '4' HOUR / -3",
+    statement: "INTERVAL '4' HOUR / -3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "-", days: 0, hours: 1, minutes: 20, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '5' MINUTE / -3",
+    statement: "INTERVAL '5' MINUTE / -3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "-", days: 0, hours: 0, minutes: 1, seconds: 40, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '10.5' SECOND / -3",
+    statement: "INTERVAL '10.5' SECOND / -3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "-", days: 0, hours: 0, minutes: 0, seconds: 3, nanos: 500000000 }
+    }
+  },
+  {
+    name: "INTERVAL '2 4:5:10.5' DAY TO SECOND / -3",
+    statement: "INTERVAL '2 4:5:10.5' DAY TO SECOND / -3",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "-", days: 0, hours: 17, minutes: 21, seconds: 43, nanos: 500000000 }
+    }
+  },
+
+  // Interval / Decimal tests
+  {
+    name: "INTERVAL '3' YEAR / 2.5",
+    statement: "INTERVAL '3' YEAR / 2.5",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 1, months: 2 }
+    }
+  },
+  {
+    name: "INTERVAL '7' MONTH / 2.5",
+    statement: "INTERVAL '7' MONTH / 2.5",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 2 }
+    }
+  },
+  {
+    name: "INTERVAL '1-5' YEAR TO MONTH / 2.5",
+    statement: "INTERVAL '1-5' YEAR TO MONTH / 2.5",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 6 }
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY / 2.5",
+    statement: "INTERVAL '2' DAY / 2.5",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 19, minutes: 12, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '4' HOUR / 2.5",
+    statement: "INTERVAL '4' HOUR / 2.5",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 1, minutes: 36, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '5' MINUTE / 2.5",
+    statement: "INTERVAL '5' MINUTE / 2.5",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 2, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '10.5' SECOND / 2.5",
+    statement: "INTERVAL '10.5' SECOND / 2.5",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 4, nanos: 200000000 }
+    }
+  },
+  {
+    name: "INTERVAL '2 4:5:10.5' DAY TO SECOND / 2.5",
+    statement: "INTERVAL '2 4:5:10.5' DAY TO SECOND / 2.5",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 20, minutes: 50, seconds: 4, nanos: 200000000 }
+    }
+  },
+
+  // Interval / Double tests
+  {
+    name: "INTERVAL '3' YEAR / 2.25e-1",
+    statement: "INTERVAL '3' YEAR / 2.25e-1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 13, months: 4 }
+    }
+  },
+  {
+    name: "INTERVAL '7' MONTH / 2.25e-1",
+    statement: "INTERVAL '7' MONTH / 2.25e-1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 2, months: 7 }
+    }
+  },
+  {
+    name: "INTERVAL '1-5' YEAR TO MONTH / 2.25e-1",
+    statement: "INTERVAL '1-5' YEAR TO MONTH / 2.25e-1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 6, months: 3 }
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY / 2.25e-1",
+    statement: "INTERVAL '2' DAY / 2.25e-1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 8, hours: 21, minutes: 19, seconds: 59, nanos: 999999000 }
+    }
+  },
+  {
+    name: "INTERVAL '4' HOUR / 2.25e-1",
+    statement: "INTERVAL '4' HOUR / 2.25e-1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 17, minutes: 46, seconds: 39, nanos: 999999000 }
+    }
+  },
+  {
+    name: "INTERVAL '5' MINUTE / 2.25e-1",
+    statement: "INTERVAL '5' MINUTE / 2.25e-1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 22, seconds: 13, nanos: 333333000 }
+    }
+  },
+  {
+    name: "INTERVAL '10.5' SECOND / 2.25e-1",
+    statement: "INTERVAL '10.5' SECOND / 2.25e-1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 46, nanos: 666666000 }
+    }
+  },
+  {
+    name: "INTERVAL '2 4:5:10.5' DAY TO SECOND / 2.25e-1",
+    statement: "INTERVAL '2 4:5:10.5' DAY TO SECOND / 2.25e-1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 9, hours: 15, minutes: 29, seconds: 39, nanos: 999999000 }
+    }
+  },
+
+  // Interval / Zero tests (should fail)
+  {
+    name: "INTERVAL '3' YEAR / 0",
+    statement: "INTERVAL '3' YEAR / 0",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+  {
+    name: "INTERVAL '7' MONTH / 0",
+    statement: "INTERVAL '7' MONTH / 0",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+  {
+    name: "INTERVAL '1-5' YEAR TO MONTH / 0",
+    statement: "INTERVAL '1-5' YEAR TO MONTH / 0",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY / 0",
+    statement: "INTERVAL '2' DAY / 0",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+  {
+    name: "INTERVAL '4' HOUR / 0",
+    statement: "INTERVAL '4' HOUR / 0",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+  {
+    name: "INTERVAL '5' MINUTE / 0",
+    statement: "INTERVAL '5' MINUTE / 0",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+  {
+    name: "INTERVAL '10.5' SECOND / 0",
+    statement: "INTERVAL '10.5' SECOND / 0",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+  {
+    name: "INTERVAL '2 4:5:10.5' DAY TO SECOND / 0",
+    statement: "INTERVAL '2 4:5:10.5' DAY TO SECOND / 0",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+
+  // Interval / Null tests
+  {
+    name: "INTERVAL '3' YEAR / NULL",
+    statement: "INTERVAL '3' YEAR / NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+  {
+    name: "INTERVAL '7' MONTH / NULL",
+    statement: "INTERVAL '7' MONTH / NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+  {
+    name: "INTERVAL '1-5' YEAR TO MONTH / NULL",
+    statement: "INTERVAL '1-5' YEAR TO MONTH / NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY / NULL",
+    statement: "INTERVAL '2' DAY / NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+  {
+    name: "INTERVAL '4' HOUR / NULL",
+    statement: "INTERVAL '4' HOUR / NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+  {
+    name: "INTERVAL '5' MINUTE / NULL",
+    statement: "INTERVAL '5' MINUTE / NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+  {
+    name: "INTERVAL '10.5' SECOND / NULL",
+    statement: "INTERVAL '10.5' SECOND / NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+  {
+    name: "INTERVAL '2 4:5:10.5' DAY TO SECOND / NULL",
+    statement: "INTERVAL '2 4:5:10.5' DAY TO SECOND / NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+
+  // Interval / Missing tests
+  {
+    name: "INTERVAL '3' YEAR / MISSING",
+    statement: "INTERVAL '3' YEAR / MISSING",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+  {
+    name: "INTERVAL '7' MONTH / MISSING",
+    statement: "INTERVAL '7' MONTH / MISSING",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+  {
+    name: "INTERVAL '1-5' YEAR TO MONTH / MISSING",
+    statement: "INTERVAL '1-5' YEAR TO MONTH / MISSING",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY / MISSING",
+    statement: "INTERVAL '2' DAY / MISSING",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+  {
+    name: "INTERVAL '4' HOUR / MISSING",
+    statement: "INTERVAL '4' HOUR / MISSING",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+  {
+    name: "INTERVAL '5' MINUTE / MISSING",
+    statement: "INTERVAL '5' MINUTE / MISSING",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+  {
+    name: "INTERVAL '10.5' SECOND / MISSING",
+    statement: "INTERVAL '10.5' SECOND / MISSING",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+  {
+    name: "INTERVAL '2 4:5:10.5' DAY TO SECOND / MISSING",
+    statement: "INTERVAL '2 4:5:10.5' DAY TO SECOND / MISSING",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+
+  // Precision overflow tests (should fail)
+  {
+    name: "INTERVAL '3' YEAR / 0.03",
+    statement: "INTERVAL '3' YEAR / 0.03",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY / 0.02",
+    statement: "INTERVAL '2' DAY / 0.02",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  }
+]

--- a/partiql-tests-data/eval/primitives/operators/divide.ion
+++ b/partiql-tests-data/eval/primitives/operators/divide.ion
@@ -222,6 +222,9 @@ divide::[
   },
 
   // Interval / Double tests
+  // WARNING: There exists some ambiguity in SQL-spec and these tests currently conform with PLK implementation
+  // which means rounding/truncation is an implementation-defined behavior
+  // See issue: https://github.com/partiql/partiql-lang/issues/100
   {
     name: "INTERVAL '3' YEAR / 2.25e-1",
     statement: "INTERVAL '3' YEAR / 2.25e-1",
@@ -510,6 +513,9 @@ divide::[
   },
 
   // Precision overflow tests (should fail)
+  // WARNING: There exists some ambiguity in SQL-spec and these tests currently conform with PLK implementation
+  // The behavior may change after formalizeing INTERVAL further
+  // See issue: https://github.com/partiql/partiql-lang/issues/100
   {
     name: "INTERVAL '3' YEAR / 0.03",
     statement: "INTERVAL '3' YEAR / 0.03",

--- a/partiql-tests-data/eval/primitives/operators/minus.ion
+++ b/partiql-tests-data/eval/primitives/operators/minus.ion
@@ -85,6 +85,9 @@ minus::[
   },
   
   // Time - Year-Month interval failure cases
+  // WARNING: These tests conform with SQL-spec and current PLK implementation
+  // However, the behavior may change after formalizeing INTERVAL further
+  // See issue: https://github.com/partiql/partiql-lang/issues/100
   {
     name: "TIME '01:01:01.1' - INTERVAL '1' YEAR",
     statement: "TIME '01:01:01.1' - INTERVAL '1' YEAR",

--- a/partiql-tests-data/eval/primitives/operators/minus.ion
+++ b/partiql-tests-data/eval/primitives/operators/minus.ion
@@ -1,0 +1,310 @@
+minus::[
+  // Date - Interval tests
+  {
+    name: "DATE '2025-01-01' - INTERVAL '1' YEAR",
+    statement: "DATE '2025-01-01' - INTERVAL '1' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2024, month: 1, day: 1 }
+    }
+  },
+  {
+    name: "DATE '2025-01-01' - INTERVAL '1' MONTH",
+    statement: "DATE '2025-01-01' - INTERVAL '1' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2024, month: 12, day: 1 }
+    }
+  },
+  {
+    name: "DATE '2025-01-01' - INTERVAL '1-1' YEAR TO MONTH",
+    statement: "DATE '2025-01-01' - INTERVAL '1-1' YEAR TO MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2023, month: 12, day: 1 }
+    }
+  },
+  {
+    name: "DATE '2025-01-01' - INTERVAL '1' DAY",
+    statement: "DATE '2025-01-01' - INTERVAL '1' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2024, month: 12, day: 31 }
+    }
+  },
+  
+  // Time - Interval tests
+  {
+    name: "TIME '01:01:01.1' - INTERVAL '1' DAY",
+    statement: "TIME '01:01:01.1' - INTERVAL '1' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIME '01:01:01.1' - INTERVAL '1' HOUR",
+    statement: "TIME '01:01:01.1' - INTERVAL '1' HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 0, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIME '01:01:01.1' - INTERVAL '1' MINUTE",
+    statement: "TIME '01:01:01.1' - INTERVAL '1' MINUTE",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 1, minute: 0, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIME '01:01:01.1' - INTERVAL '1.1' SECOND",
+    statement: "TIME '01:01:01.1' - INTERVAL '1.1' SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 1, minute: 1, second: 0.0, offset: null }
+    }
+  },
+  {
+    name: "TIME '01:01:01.1' - INTERVAL '25:25:14.2' HOUR TO SECOND",
+    statement: "TIME '01:01:01.1' - INTERVAL '25:25:14.2' HOUR TO SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 23, minute: 35, second: 46.9, offset: null }
+    }
+  },
+  
+  // Time - Year-Month interval failure cases
+  {
+    name: "TIME '01:01:01.1' - INTERVAL '1' YEAR",
+    statement: "TIME '01:01:01.1' - INTERVAL '1' YEAR",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "TIME '01:01:01.1' - INTERVAL '1' MONTH",
+    statement: "TIME '01:01:01.1' - INTERVAL '1' MONTH",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "TIME '01:01:01.1' - INTERVAL '1-1' YEAR TO MONTH",
+    statement: "TIME '01:01:01.1' - INTERVAL '1-1' YEAR TO MONTH",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  
+  // Timestamp - Interval tests
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '1' YEAR",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '1' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2024, month: 1, day: 1, hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '1' MONTH",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '1' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2024, month: 12, day: 1, hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '1' DAY",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '1' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2024, month: 12, day: 31, hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '1' HOUR",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '1' HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2025, month: 1, day: 1, hour: 0, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '1.1' SECOND",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '1.1' SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2025, month: 1, day: 1, hour: 1, minute: 1, second: 0.0, offset: null }
+    }
+  },
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '25:25:14.2' HOUR TO SECOND",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' - INTERVAL '25:25:14.2' HOUR TO SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2024, month: 12, day: 30, hour: 23, minute: 35, second: 46.9, offset: null }
+    }
+  },
+  
+  // Interval - Interval Year-Month tests
+  {
+    name: "INTERVAL '1' YEAR - INTERVAL '1' YEAR",
+    statement: "INTERVAL '1' YEAR - INTERVAL '1' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1' YEAR - INTERVAL '1' MONTH",
+    statement: "INTERVAL '1' YEAR - INTERVAL '1' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 11 }
+    }
+  },
+  {
+    name: "INTERVAL '1' YEAR - INTERVAL '1-1' YEAR TO MONTH",
+    statement: "INTERVAL '1' YEAR - INTERVAL '1-1' YEAR TO MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "-", years: 0, months: 1 }
+    }
+  },
+  {
+    name: "INTERVAL '1' MONTH - INTERVAL '1' MONTH",
+    statement: "INTERVAL '1' MONTH - INTERVAL '1' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1' MONTH - INTERVAL '1-1' YEAR TO MONTH",
+    statement: "INTERVAL '1' MONTH - INTERVAL '1-1' YEAR TO MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "-", years: 1, months: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1-1' YEAR TO MONTH - INTERVAL '1-1' YEAR TO MONTH",
+    statement: "INTERVAL '1-1' YEAR TO MONTH - INTERVAL '1-1' YEAR TO MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 0 }
+    }
+  },
+  
+  // Interval - Interval Day-Time tests
+  {
+    name: "INTERVAL '1' DAY - INTERVAL '1' DAY",
+    statement: "INTERVAL '1' DAY - INTERVAL '1' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1' DAY - INTERVAL '1' HOUR",
+    statement: "INTERVAL '1' DAY - INTERVAL '1' HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 23, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1' DAY - INTERVAL '1.1' SECOND",
+    statement: "INTERVAL '1' DAY - INTERVAL '1.1' SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 23, minutes: 59, seconds: 58, nanos: 900000000 }
+    }
+  },
+  {
+    name: "INTERVAL '1' HOUR - INTERVAL '1' HOUR",
+    statement: "INTERVAL '1' HOUR - INTERVAL '1' HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1.1' SECOND - INTERVAL '1.1' SECOND",
+    statement: "INTERVAL '1.1' SECOND - INTERVAL '1.1' SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1 1' DAY TO HOUR - INTERVAL '1 1' DAY TO HOUR",
+    statement: "INTERVAL '1 1' DAY TO HOUR - INTERVAL '1 1' DAY TO HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1 1:1:1.1' DAY TO SECOND - INTERVAL '1 1:1:1.1' DAY TO SECOND",
+    statement: "INTERVAL '1 1:1:1.1' DAY TO SECOND - INTERVAL '1 1:1:1.1' DAY TO SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  }
+]

--- a/partiql-tests-data/eval/primitives/operators/plus.ion
+++ b/partiql-tests-data/eval/primitives/operators/plus.ion
@@ -1,0 +1,499 @@
+plus::[
+  // Interval + Date tests
+  {
+    name: "INTERVAL '1' YEAR + DATE '2025-01-01'",
+    statement: "INTERVAL '1' YEAR + DATE '2025-01-01'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2026, month: 1, day: 1 }
+    }
+  },
+  {
+    name: "DATE '2025-01-01' + INTERVAL '1' YEAR",
+    statement: "DATE '2025-01-01' + INTERVAL '1' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2026, month: 1, day: 1 }
+    }
+  },
+  {
+    name: "INTERVAL '1' MONTH + DATE '2025-01-01'",
+    statement: "INTERVAL '1' MONTH + DATE '2025-01-01'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2025, month: 2, day: 1 }
+    }
+  },
+  {
+    name: "DATE '2025-01-01' + INTERVAL '1' MONTH",
+    statement: "DATE '2025-01-01' + INTERVAL '1' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2025, month: 2, day: 1 }
+    }
+  },
+  {
+    name: "INTERVAL '1-1' YEAR TO MONTH + DATE '2025-01-01'",
+    statement: "INTERVAL '1-1' YEAR TO MONTH + DATE '2025-01-01'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2026, month: 2, day: 1 }
+    }
+  },
+  {
+    name: "DATE '2025-01-01' + INTERVAL '1-1' YEAR TO MONTH",
+    statement: "DATE '2025-01-01' + INTERVAL '1-1' YEAR TO MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2026, month: 2, day: 1 }
+    }
+  },
+  {
+    name: "INTERVAL '1' DAY + DATE '2025-01-01'",
+    statement: "INTERVAL '1' DAY + DATE '2025-01-01'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2025, month: 1, day: 2 }
+    }
+  },
+  {
+    name: "DATE '2025-01-01' + INTERVAL '1' DAY",
+    statement: "DATE '2025-01-01' + INTERVAL '1' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $date::{ year: 2025, month: 1, day: 2 }
+    }
+  },
+  
+  // Interval + Time tests
+  {
+    name: "INTERVAL '1' DAY + TIME '01:01:01.1'",
+    statement: "INTERVAL '1' DAY + TIME '01:01:01.1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIME '01:01:01.1' + INTERVAL '1' DAY",
+    statement: "TIME '01:01:01.1' + INTERVAL '1' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "INTERVAL '1' HOUR + TIME '01:01:01.1'",
+    statement: "INTERVAL '1' HOUR + TIME '01:01:01.1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 2, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIME '01:01:01.1' + INTERVAL '1' HOUR",
+    statement: "TIME '01:01:01.1' + INTERVAL '1' HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 2, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "INTERVAL '1' MINUTE + TIME '01:01:01.1'",
+    statement: "INTERVAL '1' MINUTE + TIME '01:01:01.1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 1, minute: 2, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIME '01:01:01.1' + INTERVAL '1' MINUTE",
+    statement: "TIME '01:01:01.1' + INTERVAL '1' MINUTE",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 1, minute: 2, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "INTERVAL '1.1' SECOND + TIME '01:01:01.1'",
+    statement: "INTERVAL '1.1' SECOND + TIME '01:01:01.1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 1, minute: 1, second: 2.2, offset: null }
+    }
+  },
+  {
+    name: "TIME '01:01:01.1' + INTERVAL '1.1' SECOND",
+    statement: "TIME '01:01:01.1' + INTERVAL '1.1' SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $time::{ hour: 1, minute: 1, second: 2.2, offset: null }
+    }
+  },
+  
+  // Time + Year-Month interval failure cases
+  {
+    name: "TIME '01:01:01.1' + INTERVAL '1' YEAR",
+    statement: "TIME '01:01:01.1' + INTERVAL '1' YEAR",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "TIME '01:01:01.1' + INTERVAL '1' MONTH",
+    statement: "TIME '01:01:01.1' + INTERVAL '1' MONTH",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "TIME '01:01:01.1' + INTERVAL '1-1' YEAR TO MONTH",
+    statement: "TIME '01:01:01.1' + INTERVAL '1-1' YEAR TO MONTH",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "INTERVAL '1' YEAR + TIME '01:01:01.1'",
+    statement: "INTERVAL '1' YEAR + TIME '01:01:01.1'",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "INTERVAL '1' MONTH + TIME '01:01:01.1'",
+    statement: "INTERVAL '1' MONTH + TIME '01:01:01.1'",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  {
+    name: "INTERVAL '1-1' YEAR TO MONTH + TIME '01:01:01.1'",
+    statement: "INTERVAL '1-1' YEAR TO MONTH + TIME '01:01:01.1'",
+    assert: [
+      {
+        evalMode: EvalModeError,
+        result: EvaluationFail
+      },
+      {
+        evalMode: EvalModeCoerce,
+        result: EvaluationSuccess,
+        output: $missing::null
+      }
+    ]
+  },
+  
+  // Interval + Timestamp tests
+  {
+    name: "INTERVAL '1' YEAR + TIMESTAMP '2025-01-01 01:01:01.1'",
+    statement: "INTERVAL '1' YEAR + TIMESTAMP '2025-01-01 01:01:01.1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2026, month: 1, day: 1, hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' + INTERVAL '1' YEAR",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' + INTERVAL '1' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2026, month: 1, day: 1, hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "INTERVAL '1' MONTH + TIMESTAMP '2025-01-01 01:01:01.1'",
+    statement: "INTERVAL '1' MONTH + TIMESTAMP '2025-01-01 01:01:01.1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2025, month: 2, day: 1, hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' + INTERVAL '1' MONTH",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' + INTERVAL '1' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2025, month: 2, day: 1, hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "INTERVAL '1' DAY + TIMESTAMP '2025-01-01 01:01:01.1'",
+    statement: "INTERVAL '1' DAY + TIMESTAMP '2025-01-01 01:01:01.1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2025, month: 1, day: 2, hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' + INTERVAL '1' DAY",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' + INTERVAL '1' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2025, month: 1, day: 2, hour: 1, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "INTERVAL '1' HOUR + TIMESTAMP '2025-01-01 01:01:01.1'",
+    statement: "INTERVAL '1' HOUR + TIMESTAMP '2025-01-01 01:01:01.1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2025, month: 1, day: 1, hour: 2, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' + INTERVAL '1' HOUR",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' + INTERVAL '1' HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2025, month: 1, day: 1, hour: 2, minute: 1, second: 1.1, offset: null }
+    }
+  },
+  {
+    name: "INTERVAL '1.1' SECOND + TIMESTAMP '2025-01-01 01:01:01.1'",
+    statement: "INTERVAL '1.1' SECOND + TIMESTAMP '2025-01-01 01:01:01.1'",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2025, month: 1, day: 1, hour: 1, minute: 1, second: 2.2, offset: null }
+    }
+  },
+  {
+    name: "TIMESTAMP '2025-01-01 01:01:01.1' + INTERVAL '1.1' SECOND",
+    statement: "TIMESTAMP '2025-01-01 01:01:01.1' + INTERVAL '1.1' SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $timestamp::{ year: 2025, month: 1, day: 1, hour: 1, minute: 1, second: 2.2, offset: null }
+    }
+  },
+  
+  // Interval + Interval Year-Month tests
+  {
+    name: "INTERVAL '1' YEAR + INTERVAL '1' YEAR",
+    statement: "INTERVAL '1' YEAR + INTERVAL '1' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 2, months: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1' YEAR + INTERVAL '1' MONTH",
+    statement: "INTERVAL '1' YEAR + INTERVAL '1' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 1, months: 1 }
+    }
+  },
+  {
+    name: "INTERVAL '1' MONTH + INTERVAL '1' YEAR",
+    statement: "INTERVAL '1' MONTH + INTERVAL '1' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 1, months: 1 }
+    }
+  },
+  {
+    name: "INTERVAL '1' YEAR + INTERVAL '1-1' YEAR TO MONTH",
+    statement: "INTERVAL '1' YEAR + INTERVAL '1-1' YEAR TO MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 2, months: 1 }
+    }
+  },
+  {
+    name: "INTERVAL '1-1' YEAR TO MONTH + INTERVAL '1' YEAR",
+    statement: "INTERVAL '1-1' YEAR TO MONTH + INTERVAL '1' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 2, months: 1 }
+    }
+  },
+  {
+    name: "INTERVAL '1' MONTH + INTERVAL '1' MONTH",
+    statement: "INTERVAL '1' MONTH + INTERVAL '1' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 2 }
+    }
+  },
+  {
+    name: "INTERVAL '1' MONTH + INTERVAL '1-1' YEAR TO MONTH",
+    statement: "INTERVAL '1' MONTH + INTERVAL '1-1' YEAR TO MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 1, months: 2 }
+    }
+  },
+  {
+    name: "INTERVAL '1-1' YEAR TO MONTH + INTERVAL '1' MONTH",
+    statement: "INTERVAL '1-1' YEAR TO MONTH + INTERVAL '1' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 1, months: 2 }
+    }
+  },
+  {
+    name: "INTERVAL '1-1' YEAR TO MONTH + INTERVAL '1-1' YEAR TO MONTH",
+    statement: "INTERVAL '1-1' YEAR TO MONTH + INTERVAL '1-1' YEAR TO MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 2, months: 2 }
+    }
+  },
+  
+  // Interval + Interval Day-Time tests
+  {
+    name: "INTERVAL '1' DAY + INTERVAL '1' DAY",
+    statement: "INTERVAL '1' DAY + INTERVAL '1' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 2, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1' DAY + INTERVAL '1' HOUR",
+    statement: "INTERVAL '1' DAY + INTERVAL '1' HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 1, hours: 1, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1' HOUR + INTERVAL '1' DAY",
+    statement: "INTERVAL '1' HOUR + INTERVAL '1' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 1, hours: 1, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1' DAY + INTERVAL '1.1' SECOND",
+    statement: "INTERVAL '1' DAY + INTERVAL '1.1' SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 1, hours: 0, minutes: 0, seconds: 1, nanos: 100000000 }
+    }
+  },
+  {
+    name: "INTERVAL '1.1' SECOND + INTERVAL '1' DAY",
+    statement: "INTERVAL '1.1' SECOND + INTERVAL '1' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 1, hours: 0, minutes: 0, seconds: 1, nanos: 100000000 }
+    }
+  },
+  {
+    name: "INTERVAL '1' HOUR + INTERVAL '1' HOUR",
+    statement: "INTERVAL '1' HOUR + INTERVAL '1' HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 2, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1.1' SECOND + INTERVAL '1.1' SECOND",
+    statement: "INTERVAL '1.1' SECOND + INTERVAL '1.1' SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 2, nanos: 200000000 }
+    }
+  },
+  {
+    name: "INTERVAL '1 1' DAY TO HOUR + INTERVAL '1 1' DAY TO HOUR",
+    statement: "INTERVAL '1 1' DAY TO HOUR + INTERVAL '1 1' DAY TO HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 2, hours: 2, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '1 1:1:1.1' DAY TO SECOND + INTERVAL '1 1:1:1.1' DAY TO SECOND",
+    statement: "INTERVAL '1 1:1:1.1' DAY TO SECOND + INTERVAL '1 1:1:1.1' DAY TO SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 2, hours: 2, minutes: 2, seconds: 2, nanos: 200000000 }
+    }
+  }
+]

--- a/partiql-tests-data/eval/primitives/operators/times.ion
+++ b/partiql-tests-data/eval/primitives/operators/times.ion
@@ -1,0 +1,429 @@
+times::[
+  // Interval * Number tests
+  {
+    name: "INTERVAL '3' YEAR * 2",
+    statement: "INTERVAL '3' YEAR * 2",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 6, months: 0 }
+    }
+  },
+  {
+    name: "2 * INTERVAL '3' YEAR",
+    statement: "2 * INTERVAL '3' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 6, months: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '7' MONTH * 2",
+    statement: "INTERVAL '7' MONTH * 2",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 1, months: 2 }
+    }
+  },
+  {
+    name: "2 * INTERVAL '7' MONTH",
+    statement: "2 * INTERVAL '7' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 1, months: 2 }
+    }
+  },
+  {
+    name: "INTERVAL '1-5' YEAR TO MONTH * 2",
+    statement: "INTERVAL '1-5' YEAR TO MONTH * 2",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 2, months: 10 }
+    }
+  },
+  {
+    name: "2 * INTERVAL '1-5' YEAR TO MONTH",
+    statement: "2 * INTERVAL '1-5' YEAR TO MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 2, months: 10 }
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY * 20",
+    statement: "INTERVAL '2' DAY * 20",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 40, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "20 * INTERVAL '2' DAY",
+    statement: "20 * INTERVAL '2' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 40, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '4' HOUR * 20",
+    statement: "INTERVAL '4' HOUR * 20",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 3, hours: 8, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "20 * INTERVAL '4' HOUR",
+    statement: "20 * INTERVAL '4' HOUR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 3, hours: 8, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '5' MINUTE * 20",
+    statement: "INTERVAL '5' MINUTE * 20",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 1, minutes: 40, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "20 * INTERVAL '5' MINUTE",
+    statement: "20 * INTERVAL '5' MINUTE",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 1, minutes: 40, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '10.5' SECOND * 20",
+    statement: "INTERVAL '10.5' SECOND * 20",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 3, seconds: 30, nanos: 0 }
+    }
+  },
+  {
+    name: "20 * INTERVAL '10.5' SECOND",
+    statement: "20 * INTERVAL '10.5' SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 3, seconds: 30, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '2 4:5:10.5' DAY TO SECOND * 20",
+    statement: "INTERVAL '2 4:5:10.5' DAY TO SECOND * 20",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 43, hours: 9, minutes: 43, seconds: 30, nanos: 0 }
+    }
+  },
+  {
+    name: "20 * INTERVAL '2 4:5:10.5' DAY TO SECOND",
+    statement: "20 * INTERVAL '2 4:5:10.5' DAY TO SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 43, hours: 9, minutes: 43, seconds: 30, nanos: 0 }
+    }
+  },
+
+  // Interval * Zero tests
+  {
+    name: "INTERVAL '3' YEAR * 0",
+    statement: "INTERVAL '3' YEAR * 0",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 0 }
+    }
+  },
+  {
+    name: "0 * INTERVAL '3' YEAR",
+    statement: "0 * INTERVAL '3' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY * 0",
+    statement: "INTERVAL '2' DAY * 0",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "0 * INTERVAL '2' DAY",
+    statement: "0 * INTERVAL '2' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+
+  // Interval * Negative tests
+  {
+    name: "INTERVAL '3' YEAR * -2",
+    statement: "INTERVAL '3' YEAR * -2",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "-", years: 6, months: 0 }
+    }
+  },
+  {
+    name: "-2 * INTERVAL '3' YEAR",
+    statement: "-2 * INTERVAL '3' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "-", years: 6, months: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '7' MONTH * -2",
+    statement: "INTERVAL '7' MONTH * -2",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "-", years: 1, months: 2 }
+    }
+  },
+  {
+    name: "-2 * INTERVAL '7' MONTH",
+    statement: "-2 * INTERVAL '7' MONTH",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "-", years: 1, months: 2 }
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY * -20",
+    statement: "INTERVAL '2' DAY * -20",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "-", days: 40, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "-20 * INTERVAL '2' DAY",
+    statement: "-20 * INTERVAL '2' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "-", days: 40, hours: 0, minutes: 0, seconds: 0, nanos: 0 }
+    }
+  },
+
+  // Interval * Decimal tests
+  {
+    name: "INTERVAL '3' YEAR * 2.1",
+    statement: "INTERVAL '3' YEAR * 2.1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 6, months: 3 }
+    }
+  },
+  {
+    name: "2.1 * INTERVAL '3' YEAR",
+    statement: "2.1 * INTERVAL '3' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 6, months: 3 }
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY * 2.1",
+    statement: "INTERVAL '2' DAY * 2.1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 4, hours: 4, minutes: 48, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "2.1 * INTERVAL '2' DAY",
+    statement: "2.1 * INTERVAL '2' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 4, hours: 4, minutes: 48, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "INTERVAL '10.5' SECOND * 2.1",
+    statement: "INTERVAL '10.5' SECOND * 2.1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 22, nanos: 50000000 }
+    }
+  },
+  {
+    name: "2.1 * INTERVAL '10.5' SECOND",
+    statement: "2.1 * INTERVAL '10.5' SECOND",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 0, minutes: 0, seconds: 22, nanos: 50000000 }
+    }
+  },
+
+  // Interval * Double tests
+  {
+    name: "INTERVAL '3' YEAR * 2.25e-1",
+    statement: "INTERVAL '3' YEAR * 2.25e-1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 8 }
+    }
+  },
+  {
+    name: "2.25e-1 * INTERVAL '3' YEAR",
+    statement: "2.25e-1 * INTERVAL '3' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_ym::{ sign: "+", years: 0, months: 8 }
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY * 2.25e-1",
+    statement: "INTERVAL '2' DAY * 2.25e-1",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 10, minutes: 48, seconds: 0, nanos: 0 }
+    }
+  },
+  {
+    name: "2.25e-1 * INTERVAL '2' DAY",
+    statement: "2.25e-1 * INTERVAL '2' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $interval_dt::{ sign: "+", days: 0, hours: 10, minutes: 48, seconds: 0, nanos: 0 }
+    }
+  },
+
+  // Precision overflow failure cases
+  {
+    name: "INTERVAL '3' YEAR * 50",
+    statement: "INTERVAL '3' YEAR * 50",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY * 50",
+    statement: "INTERVAL '2' DAY * 50",
+    assert: {
+      result: EvaluationFail,
+      evalMode: [EvalModeCoerce, EvalModeError]
+    }
+  },
+
+  // Null cases - should return null in both strict and permissive modes
+  {
+    name: "INTERVAL '3' YEAR * NULL",
+    statement: "INTERVAL '3' YEAR * NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+  {
+    name: "NULL * INTERVAL '3' YEAR",
+    statement: "NULL * INTERVAL '3' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY * NULL",
+    statement: "INTERVAL '2' DAY * NULL",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+  {
+    name: "NULL * INTERVAL '2' DAY",
+    statement: "NULL * INTERVAL '2' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: null
+    }
+  },
+
+  // Missing cases - should return missing in both strict and permissive modes
+  {
+    name: "INTERVAL '3' YEAR * MISSING",
+    statement: "INTERVAL '3' YEAR * MISSING",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+  {
+    name: "MISSING * INTERVAL '3' YEAR",
+    statement: "MISSING * INTERVAL '3' YEAR",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+  {
+    name: "INTERVAL '2' DAY * MISSING",
+    statement: "INTERVAL '2' DAY * MISSING",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  },
+  {
+    name: "MISSING * INTERVAL '2' DAY",
+    statement: "MISSING * INTERVAL '2' DAY",
+    assert: {
+      result: EvaluationSuccess,
+      evalMode: [EvalModeCoerce, EvalModeError],
+      output: $missing::null
+    }
+  }
+]


### PR DESCRIPTION
Issue #, if available:
Close #144 #143 #145 

Description of changes:
Port current PLK evaluation unit tests on `INTERVAL` to the conformance tests, including:

- arithmetic operation tests (plus, minus, times, divide)
- abs function tests

Also add some tests on:

- literal tests
- sign parsing tests
- casting tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.