### PR TITLE
add SIZE function tests with SELECT subqueries

### DIFF
--- a/partiql-tests-data-extended/eval/primitives/functions/size.ion
+++ b/partiql-tests-data-extended/eval/primitives/functions/size.ion
@@ -227,4 +227,52 @@ size::[
       output:$missing::null
     }
   },
+  {
+    name:"size with SELECT subquery{param:\"SELECT a FROM <<{'a': 1}>>\",result:1}",
+    statement:"size(SELECT a FROM <<{'a': 1}>>)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:1
+    }
+  },
+  {
+    name:"size with SELECT subquery{param:\"SELECT a FROM <<{'a': 1}, {'a': 2}>>\",result:2}",
+    statement:"size(SELECT a FROM <<{'a': 1}, {'a': 2}>>)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:2
+    }
+  },
+  {
+    name:"size with SELECT subquery and WHERE{param:\"SELECT a FROM <<{'a': 1}, {'a': 2}>> WHERE a = 1\",result:1}",
+    statement:"size(SELECT a FROM <<{'a': 1}, {'a': 2}>> WHERE a = 1)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:1
+    }
+  },
+  {
+    name:"size with SELECT subquery empty result{param:\"SELECT a FROM <<{'a': 1}>> WHERE a = 2\",result:0}",
+    statement:"size(SELECT a FROM <<{'a': 1}>> WHERE a = 2)",
+    assert:{
+      result:EvaluationSuccess,
+      evalMode:[
+        EvalModeCoerce,
+        EvalModeError
+      ],
+      output:0
+    }
+  },
 ]


### PR DESCRIPTION
## Description
This PR adds test cases for the SIZE function when used with SELECT subqueries to ensure proper functionality after fixing the compilation bug where SELECT expressions were being incorrectly coerced to scalars.

Tests added for PR - https://github.com/partiql/partiql-lang-kotlin/pull/1869

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.